### PR TITLE
adjust models, factories, specs, and seeds to align with updated schema

### DIFF
--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -2,23 +2,23 @@ class Interaction < ApplicationRecord
   belongs_to :customer
   belongs_to :user
 
-  belongs_to :parent, class_name: "Interaction", foreign_key: "parent_interaction_id", optional: true
-  has_many :children, class_name: "Interaction", foreign_key: "parent_interaction_id"
+  belongs_to :parent, class_name: "Interaction", optional: true
+  has_many :children, class_name: "Interaction", foreign_key: "parent_id"
 
   # add associations after other models are created
   # has_many :notices
   # has_many :tasks
 
-  enum :interaction_type, {
-  phone: "phone",
-  email: "email",
-  web: "web",
-  sns: "sns",
-  in_person: "in_person"
-}
+  enum :channel, {
+    phone: "phone",
+    email: "email",
+    web: "web",
+    sns: "sns",
+    in_person: "in_person"
+  }
 
   validates :occurred_at, presence: true
-  validates :interaction_type, presence: true
+  validates :channel, presence: true
   validates :request_content, presence: true
   validates :response_result, presence: true
   validates :completed, inclusion: { in: [ true, false ] }

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,14 +1,14 @@
 class Notice < ApplicationRecord
-  belongs_to :posted_by_user, class_name: "User"
+  belongs_to :user
 
-  belongs_to :parent, class_name: "Notice", foreign_key: "parent_notice_id", optional: true
-  has_many :children, class_name: "Notice", foreign_key: "parent_notice_id"
+  belongs_to :parent, class_name: "Notice", optional: true
+  has_many :children, class_name: "Notice", foreign_key: "parent_id"
 
   # add associations after other models are created
   # has_many :interactions
   # has_many :tasks
 
-  enum :notice_type, {
+  enum :level, {
     important: "important",
     normal: "normal",
     confidential: "confidential"
@@ -16,8 +16,8 @@ class Notice < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :content, presence: true,  length: { maximum: 2000 }
-  validates :notice_type, presence: true
-  validates :admin_only, inclusion: { in: [ true, false ] }
+  validates :level, presence: true
+  validates :restricted, inclusion: { in: [ true, false ] }
   validates :start_at, presence: true
   validates :end_at, presence: true, comparison: { greater_than: :start_at }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,14 +1,14 @@
 class Task < ApplicationRecord
-  belongs_to :created_by_user, class_name: "User"
+  belongs_to :user
 
-  belongs_to :parent, class_name: "Task", foreign_key: "parent_task_id", optional: true
-  has_many :children, class_name: "Task", foreign_key: "parent_task_id"
+  belongs_to :parent, class_name: "Task", optional: true
+  has_many :children, class_name: "Task", foreign_key: "parent_id"
 
   # add associations after other models are created
   has_many :task_assignments
-  has_many :users, through: :task_assignments
+  has_many :assigned_users, through: :task_assignments, source: :user
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :description, presence: true, length: { maximum: 2000 }
-  validates :admin_only, inclusion: { in: [ true, false ] }
+  validates :restricted, inclusion: { in: [ true, false ] }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,16 +2,16 @@ class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
 
+  has_many :interactions
+  has_many :notices
+  has_many :tasks
+
+  has_many :task_assignments
+  has_many :assigned_tasks, through: :task_assignments, source: :task
+
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
   validates :email_address, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :name, presence: true, length: { maximum: 50 }
   validates :password, length: { minimum: 8 }, if: -> { new_record? || !password.nil? }
-
-  has_many :interactions
-  has_many :notices
-  has_many :created_tasks, class_name: "Task", foreign_key: "created_by_user_id"
-
-  has_many :task_assignments
-  has_many :assigned_tasks, through: :task_assignments, source: :task
 end

--- a/db/migrate/20260210145148_rename_columns_for_consistency.rb
+++ b/db/migrate/20260210145148_rename_columns_for_consistency.rb
@@ -1,0 +1,32 @@
+class RenameColumnsForConsistency < ActiveRecord::Migration[8.1]
+  def change
+    # remove foreign_key
+    remove_foreign_key :interactions, column: :parent_interaction_id
+    remove_foreign_key :notices, column: :parent_notice_id
+    remove_foreign_key :notices, column: :posted_by_user_id
+    remove_foreign_key :tasks, column: :parent_task_id
+    remove_foreign_key :tasks, column: :created_by_user_id
+
+    # interactions
+    rename_column :interactions, :interaction_type, :channel
+    rename_column :interactions, :parent_interaction_id, :parent_id
+
+    # notices
+    rename_column :notices, :admin_only, :restricted
+    rename_column :notices, :notice_type, :level
+    rename_column :notices, :parent_notice_id, :parent_id
+    rename_column :notices, :posted_by_user_id, :user_id
+
+    # tasks
+    rename_column :tasks, :admin_only, :restricted
+    rename_column :tasks, :parent_task_id, :parent_id
+    rename_column :tasks, :created_by_user_id, :user_id
+
+    # add foreign_key
+    add_foreign_key :interactions, :interactions, column: :parent_id
+    add_foreign_key :notices, :notices, column: :parent_id
+    add_foreign_key :notices, :users, column: :user_id
+    add_foreign_key :tasks, :tasks, column: :parent_id
+    add_foreign_key :tasks, :users, column: :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_06_100900) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_10_145148) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,35 +26,35 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_06_100900) do
   end
 
   create_table "interactions", force: :cascade do |t|
+    t.string "channel", null: false
     t.boolean "completed", default: false, null: false
     t.datetime "created_at", null: false
     t.bigint "customer_id", null: false
-    t.string "interaction_type", null: false
     t.datetime "occurred_at", null: false
-    t.bigint "parent_interaction_id"
+    t.bigint "parent_id"
     t.text "request_content", null: false
     t.text "response_result", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["channel"], name: "index_interactions_on_channel"
     t.index ["customer_id", "occurred_at"], name: "index_interactions_on_customer_id_and_occurred_at"
-    t.index ["interaction_type"], name: "index_interactions_on_interaction_type"
-    t.index ["parent_interaction_id"], name: "index_interactions_on_parent_interaction_id"
+    t.index ["parent_id"], name: "index_interactions_on_parent_id"
     t.index ["user_id", "occurred_at"], name: "index_interactions_on_user_id_and_occurred_at"
   end
 
   create_table "notices", force: :cascade do |t|
-    t.boolean "admin_only", default: false, null: false
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "end_at", null: false
-    t.string "notice_type", null: false
-    t.bigint "parent_notice_id"
-    t.bigint "posted_by_user_id", null: false
+    t.string "level", null: false
+    t.bigint "parent_id"
+    t.boolean "restricted", default: false, null: false
     t.datetime "start_at", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
-    t.index ["notice_type"], name: "index_notices_on_notice_type"
-    t.index ["parent_notice_id"], name: "index_notices_on_parent_notice_id"
+    t.bigint "user_id", null: false
+    t.index ["level"], name: "index_notices_on_level"
+    t.index ["parent_id"], name: "index_notices_on_parent_id"
     t.index ["start_at", "end_at"], name: "index_notices_on_start_at_and_end_at"
   end
 
@@ -79,16 +79,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_06_100900) do
   end
 
   create_table "tasks", force: :cascade do |t|
-    t.boolean "admin_only", default: false, null: false
     t.datetime "created_at", null: false
-    t.bigint "created_by_user_id", null: false
     t.text "description", null: false
     t.datetime "due_at"
-    t.bigint "parent_task_id"
+    t.bigint "parent_id"
+    t.boolean "restricted", default: false, null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["due_at"], name: "index_tasks_on_due_at"
-    t.index ["parent_task_id"], name: "index_tasks_on_parent_task_id"
+    t.index ["parent_id"], name: "index_tasks_on_parent_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -102,13 +102,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_06_100900) do
   end
 
   add_foreign_key "interactions", "customers"
-  add_foreign_key "interactions", "interactions", column: "parent_interaction_id"
+  add_foreign_key "interactions", "interactions", column: "parent_id"
   add_foreign_key "interactions", "users"
-  add_foreign_key "notices", "notices", column: "parent_notice_id"
-  add_foreign_key "notices", "users", column: "posted_by_user_id"
+  add_foreign_key "notices", "notices", column: "parent_id"
+  add_foreign_key "notices", "users"
   add_foreign_key "sessions", "users"
   add_foreign_key "task_assignments", "tasks"
   add_foreign_key "task_assignments", "users"
-  add_foreign_key "tasks", "tasks", column: "parent_task_id"
-  add_foreign_key "tasks", "users", column: "created_by_user_id"
+  add_foreign_key "tasks", "tasks", column: "parent_id"
+  add_foreign_key "tasks", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -95,19 +95,19 @@ customers.each do |attrs|
 end
 
 # 応対履歴のステータスを日本語に変換する
-def status_label(completed)
+def interaction_status_label(completed)
   completed ? "完了" : "対応中"
 end
 
 # 応対履歴の問合せ方法を日本語に変換する
-def interaction_type_label(interaction_type)
+def interaction_channel_label(channel)
   {
     phone: "電話",
     email: "メール",
     web: "WEB",
     sns: "SNS",
     in_person: "対面"
-  }[interaction_type.to_sym]
+  }[channel.to_sym]
 end
 
 # 初期応対履歴の作成
@@ -116,8 +116,8 @@ interactions = [
     customer_id: 1,
     user_id: 2,
     occurred_at: Time.new(2026, 1, 26, 3, 3, 0, "+09:00"),
-    interaction_type: :phone,
-    parent_interaction_id: nil,
+    channel: :phone,
+    parent_id: nil,
     request_content: "商品Aの在庫問い合わせ。入荷したら連絡してほしいとのこと。",
     response_result: "在庫確認後、明日入荷予定と回答。 入荷次第連絡する旨を伝えた。",
     completed: false
@@ -126,8 +126,8 @@ interactions = [
     customer_id: 1,
     user_id: 2,
     occurred_at: Time.new(2026, 1, 30, 11, 0, 0, "+09:00"),
-    interaction_type: :phone,
-    parent_interaction_id: 1,
+    channel: :phone,
+    parent_id: 1,
     request_content: "入荷連絡の電話するも、不在。",
     response_result: "留守電にメッセージを入れて終話。",
     completed: false
@@ -136,8 +136,8 @@ interactions = [
     customer_id: 2,
     user_id: 2,
     occurred_at: Time.new(2026, 1, 25, 2, 0, 0, "+09:00"),
-    interaction_type: :phone,
-    parent_interaction_id: nil,
+    channel: :phone,
+    parent_id: nil,
     request_content: "商品Xの不具合報告。一度店頭にて状況を確認してほしいとのこと。",
     response_result: "明日13時に来店予定。2階承りカウンターにお越しいただくように伝えてます。",
     completed: false
@@ -146,8 +146,8 @@ interactions = [
     customer_id: 3,
     user_id: 3,
     occurred_at: Time.new(2026, 1, 31, 8, 0, 0, "+09:00"),
-    interaction_type: :in_person,
-    parent_interaction_id: nil,
+    channel: :in_person,
+    parent_id: nil,
     request_content: "商品Bの取り寄せ依頼。",
     response_result: "センターにも在庫無。入荷まで2~3週間かかる旨伝える。入荷次第連絡希望。",
     completed: false
@@ -167,20 +167,20 @@ interactions.each do |attrs|
     puts "顧客: #{interaction.customer.name}"
     puts "従業員: #{interaction.user.name}"
     puts "応対日時: #{interaction.occurred_at}"
-    puts "問合せ方法: #{interaction_type_label(interaction.interaction_type)}"
+    puts "問合せ方法: #{interaction_channel_label(interaction.channel)}"
     puts "応対内容: #{interaction.request_content}"
     puts "対応結果: #{interaction.response_result}"
-    puts "対応状況: #{status_label(interaction.completed)}"
+    puts "対応状況: #{interaction_status_label(interaction.completed)}"
   end
 end
 
 # 周知事項の種別を日本語に変換する
-def notice_type_label(notice_type)
+def notice_level_label(level)
   {
     important: "重要",
     normal: "通常",
     confidential: "管理者"
-  }[notice_type.to_sym]
+  }[level.to_sym]
 end
 
 # 初期の周知事項の作成
@@ -188,52 +188,52 @@ notices = [
   {
     title: "商品Xのクレーム多発について",
     content: "商品Xに関するクレームが増加しています。 対応時は必ずマニュアルを確認し、丁寧な説明を心がけてください。 不明点があれば必ず店長に確認してください。 【対応のポイント】 ・まずお客様の話をしっかり聞く ・マニュアルP.15の手順に従う ・必要に応じて代替品を提案 ・対応後は必ず記録を残す ご協力よろしくお願いいたします。",
-    notice_type: :important,
-    admin_only: false,
+    level: :important,
+    restricted: false,
     start_at: Time.new(2026, 2, 1, 11, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 1, 11, 0, 0, "+09:00"),
-    posted_by_user_id: 2,
-    parent_notice_id: nil
+    user_id: 2,
+    parent_id: nil
   },
   {
     title: "お釣りのお渡し漏れについて",
     content: "最近レジでのお釣りを渡し忘れる事案が多発しています。お客様をお見送りするのも大事ですが、それよりも前にレジのトレーにお釣りやレシートが残っていないか、確認を徹底しましょう。",
-    notice_type: :normal,
-    admin_only: false,
+    level: :normal,
+    restricted: false,
     start_at: Time.new(2026, 2, 1, 13, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 1, 13, 0, 0, "+09:00"),
-    posted_by_user_id: 1,
-    parent_notice_id: nil
+    user_id: 1,
+    parent_id: nil
   },
   {
     title: "カードの返し忘れについて",
     content: "先日、レジでのお釣りの返し忘れが多い件について周知しましたが、今度はクレジットカードの返却忘れが発生しました。お釣りやレシートと同様ですが、お客様がクレジットカードをお取りいただいているか、カード決済端末も逐一確認するようお願いいたします。",
-    notice_type: :normal,
-    admin_only: false,
+    level: :normal,
+    restricted: false,
     start_at: Time.new(2026, 2, 2, 13, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 2, 13, 0, 0, "+09:00"),
-    posted_by_user_id: 1,
-    parent_notice_id: 3
+    user_id: 1,
+    parent_id: 3
   },
   {
     title: "従業員の退職申出について",
     content: "Uターンするため、退職したいと佐藤さんから申し入れがありました。少し掘り下げると、直近の業務でしんどい部分があったことも影響しているようです。ひとまず慰留しましたが、元気がなさそうであれば声がけするなど、管理者各位もフォローお願いします。",
-    notice_type: :confidential,
-    admin_only: true,
+    level: :confidential,
+    restricted: true,
     start_at: Time.new(2026, 2, 1, 12, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 1, 12, 0, 0, "+09:00"),
-    posted_by_user_id: 1,
-    parent_notice_id: nil
+    user_id: 1,
+    parent_id: nil
   },
   {
     title: "退職申出の保留について",
     content: "佐藤さんとフォロー面談を実施した結果、もう少し将来についてゆっくり考えたいので、退職の話は一旦取り下げしたい都申出がありました。Uターンしてカフェを開業するという夢があるようです。全力で応援する気持ちと、現職で辛いことがあれば、管理者に気兼ねなく相談しても大丈夫と伝えてます。佐藤さんから何か相談があれば、快く相談にのってあげてください。",
-    notice_type: :confidential,
-    admin_only: true,
+    level: :confidential,
+    restricted: true,
     start_at: Time.new(2026, 2, 3, 11, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 3, 11, 0, 0, "+09:00"),
-    posted_by_user_id: 1,
-    parent_notice_id: 4
+    user_id: 1,
+    parent_id: 4
   }
 ]
 
@@ -241,7 +241,7 @@ notices.each do |attrs|
   notice = Notice.find_or_create_by!(
     title: attrs[:title],
     start_at: attrs[:start_at],
-    posted_by_user_id: attrs[:posted_by_user_id]
+    user_id: attrs[:user_id]
   ) do |u|
     u.assign_attributes(attrs)
   end
@@ -250,10 +250,10 @@ notices.each do |attrs|
     puts "初期周知事項を作成しました！"
     puts "#{notice.title}"
     puts "内容: #{notice.content}"
-    puts "種別: #{notice_type_label(notice.notice_type)}"
+    puts "種別: #{notice_level_label(notice.level)}"
     puts "作成日時: #{notice.start_at}"
     puts "終了日時: #{notice.end_at}"
-    puts "作成者: #{notice.posted_by_user.name}"
+    puts "作成者: #{notice.user.name}"
   end
 end
 
@@ -262,49 +262,49 @@ tasks = [
   {
     title: "商品X再発防止策の検討",
     description: "クレーム多発のため、メーカーとの協議と対応マニュアル改訂が必要。 再発防止のための体制整備を行う。 各店舗での対応事例を収集し、ベストプラクティスをまとめておいてください。",
-    admin_only: false,
-    created_by_user_id: 1,
-    parent_task_id: nil,
+    restricted: false,
+    user_id: 1,
+    parent_id: nil,
     due_at: Time.new(2026, 2, 12, 11, 0, 0, "+09:00")
   },
   {
     title: "メーカーへの問い合わせ",
     description: "商品Xについてクレームが多発しているため、製造・設計段階で何か不具合があったのではないかメーカーへ確認要。佐藤さんが、各店舗での事例をExcelファイルにまとめてくれているので、そちらを添付の上、メーカーへメールにて問い合わせお願いします。不具合がないということであれば、今後の対応方法について助言を求めてください。",
-    admin_only: false,
-    created_by_user_id: 1,
-    parent_task_id: 1,
+    restricted: false,
+    user_id: 1,
+    parent_id: 1,
     due_at: Time.new(2026, 2, 9, 11, 0, 0, "+09:00")
   },
   {
     title: "販売マニュアルの改訂",
     description: "メーカーから製造・設計段階による具体的な不具合は確認されなかったと返答。しかしながら、今後リコールへ発展する可能性も考え、同様の申出があった場合は、故意の破損等を除いて、原則交換対応とする。商品Xのクレーム申出があった場合は、メーカーが用意した特設フォームへ情報の入力が必要なため、手順について、期間用途限定のマニュアルを、既存の販売マニュアルへ追加要。改訂作業お願いします。",
-    admin_only: true,
-    created_by_user_id: 1,
-    parent_task_id: 2,
+    restricted: true,
+    user_id: 1,
+    parent_id: 2,
     due_at: Time.new(2026, 2, 9, 11, 0, 0, "+09:00")
   },
   {
     title: "商品Yの品出し",
     description: "昨日の閉店作業時間内に商品Yの品出しが終わりませんでした。。すみませんが、朝番の方、商品Yの棚がスカスカになっているので、開店作業中に優先して品出しをお願いします。",
-    admin_only: false,
-    created_by_user_id: 3,
-    parent_task_id: nil,
+    restricted: false,
+    user_id: 3,
+    parent_id: nil,
     due_at: nil
   },
   {
     title: "扶養控除申告書の提出について",
     description: "今年も年末調整の時期がやってきました!つきましては、扶養控除申告書の提出が必要となります。書面は2Fの事務室に置いてあります。各自1部お取りいただき、期日までに提出をお願いいたします。何か不明点があれば管理者まで。",
-    admin_only: false,
-    created_by_user_id: 1,
-    parent_task_id: nil,
+    restricted: false,
+    user_id: 1,
+    parent_id: nil,
     due_at: Time.new(2026, 2, 14, 11, 0, 0, "+09:00")
   },
   {
     title: "管理者各位 期末評価について",
     description: "社長との1on1面談が実施されます。面談にあたり、今年度の自己評価表の提出が必要となります。業務システムの管理者項目、期末評価から、期日までに提出をお願いいたします。",
-    admin_only: true,
-    created_by_user_id: 1,
-    parent_task_id: nil,
+    restricted: true,
+    user_id: 1,
+    parent_id: nil,
     due_at: Time.new(2026, 2, 14, 11, 0, 0, "+09:00")
   }
 ]
@@ -312,8 +312,8 @@ tasks = [
 tasks.each do |attrs|
   task = Task.find_or_create_by!(
     title: attrs[:title],
-    created_by_user_id: attrs[:created_by_user_id],
-    parent_task_id: attrs[:parent_task_id]
+    user_id: attrs[:user_id],
+    parent_id: attrs[:parent_id]
   ) do |u|
     u.assign_attributes(attrs)
   end
@@ -322,7 +322,7 @@ tasks.each do |attrs|
     puts "初期タスクを作成しました！"
     puts "#{task.title}"
     puts "説明: #{task.description}"
-    puts "作成者: #{task.created_by_user.name}"
+    puts "作成者: #{task.user.name}"
     puts "期限: #{task.due_at}"
   end
 end

--- a/spec/factories/interactions.rb
+++ b/spec/factories/interactions.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
 
     occurred_at { Time.current }
     channel { "phone" }
-    parent { nil }
     request_content { "問い合わせ内容" }
     response_result { "対応結果" }
     completed { false }

--- a/spec/factories/interactions.rb
+++ b/spec/factories/interactions.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     association :user
 
     occurred_at { Time.current }
-    interaction_type { "phone" }
+    channel { "phone" }
     parent { nil }
     request_content { "問い合わせ内容" }
     response_result { "対応結果" }

--- a/spec/factories/notices.rb
+++ b/spec/factories/notices.rb
@@ -2,10 +2,13 @@ FactoryBot.define do
   factory :notice do
     association :user
 
+    trait :with_parent do
+      association :parent, factory: :notice
+    end
+
     title { "タイトル" }
     content { "内容" }
     level { "important" }
-    parent { nil }
     restricted { false }
     start_at { 1.hour.ago  }
     end_at { 1.week.from_now }

--- a/spec/factories/notices.rb
+++ b/spec/factories/notices.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :notice do
-    association :posted_by_user, factory: :user
+    association :user
 
     title { "タイトル" }
     content { "内容" }
-    notice_type { "important" }
+    level { "important" }
     parent { nil }
-    admin_only { false }
+    restricted { false }
     start_at { 1.hour.ago  }
     end_at { 1.week.from_now }
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -2,9 +2,12 @@ FactoryBot.define do
   factory :task do
     association :user
 
+    trait :with_parent do
+      association :parent, factory: :task
+    end
+
     title { "タイトル" }
     description { "説明" }
     restricted { false }
-    parent { nil }
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,11 +1,10 @@
 FactoryBot.define do
   factory :task do
-    association :created_by_user, factory: :user
+    association :user
 
     title { "タイトル" }
     description { "説明" }
-    admin_only { false }
+    restricted { false }
     parent { nil }
-    due_at { 1.week.from_now }
   end
 end

--- a/spec/models/interaction_spec.rb
+++ b/spec/models/interaction_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Interaction, type: :model do
       association = described_class.reflect_on_association(:parent)
       expect(association.macro).to eq(:belongs_to)
       expect(association.options[:class_name]).to eq("Interaction")
-      expect(association.options[:foreign_key]).to eq("parent_interaction_id")
       expect(association.options[:optional]).to be(true)
     end
 
@@ -37,13 +36,13 @@ RSpec.describe Interaction, type: :model do
       association = described_class.reflect_on_association(:children)
       expect(association.macro).to eq(:has_many)
       expect(association.options[:class_name]).to eq("Interaction")
-      expect(association.options[:foreign_key]).to eq("parent_interaction_id")
+      expect(association.options[:foreign_key]).to eq("parent_id")
     end
   end
 
   describe 'enum' do
-    it 'defines correct interaction_type values' do
-      expect(described_class.interaction_types).to eq(
+    it 'defines correct channel values' do
+      expect(described_class.channels).to eq(
         "phone" => "phone",
         "email" => "email",
         "web" => "web",
@@ -61,9 +60,9 @@ RSpec.describe Interaction, type: :model do
       end
     end
 
-    describe 'interaction_type' do
+    describe 'channel' do
       it 'is required' do
-        interaction = build(:interaction, interaction_type: "")
+        interaction = build(:interaction, channel: "")
         expect(interaction).to be_invalid
       end
     end

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -7,25 +7,22 @@ RSpec.describe Notice, type: :model do
     end
 
     it 'has a valid notice with parent' do
-      parent = create(:notice)
-      expect(parent).to be_valid
-      child = create(:notice, parent: parent)
-      expect(child.parent).to be_present
+      notice = create(:notice, :with_parent)
+      expect(notice).to be_valid
+      expect(notice.parent).to be_present
     end
   end
 
   describe 'associations' do
     it 'belongs to user' do
-      association = described_class.reflect_on_association(:posted_by_user)
+      association = described_class.reflect_on_association(:user)
       expect(association.macro).to eq(:belongs_to)
-      expect(association.options[:class_name]).to eq("User")
     end
 
     it 'belongs to parent notice (optional)' do
       association = described_class.reflect_on_association(:parent)
       expect(association.macro).to eq(:belongs_to)
       expect(association.options[:class_name]).to eq("Notice")
-      expect(association.options[:foreign_key]).to eq("parent_notice_id")
       expect(association.options[:optional]).to be(true)
     end
 
@@ -33,13 +30,13 @@ RSpec.describe Notice, type: :model do
       association = described_class.reflect_on_association(:children)
       expect(association.macro).to eq(:has_many)
       expect(association.options[:class_name]).to eq("Notice")
-      expect(association.options[:foreign_key]).to eq("parent_notice_id")
+      expect(association.options[:foreign_key]).to eq("parent_id")
     end
   end
 
   describe 'enum' do
-    it 'defines correct notice_type values' do
-      expect(described_class.notice_types.keys).to match_array(
+    it 'defines correct level values' do
+      expect(described_class.levels.keys).to match_array(
         %w[important normal confidential]
       )
     end
@@ -80,26 +77,26 @@ RSpec.describe Notice, type: :model do
       end
     end
 
-    describe 'notice_type' do
+    describe 'level' do
       it 'is required' do
-        notice = build(:notice, notice_type: "")
+        notice = build(:notice, level: "")
         expect(notice).to be_invalid
       end
     end
 
-    describe 'admin_only' do
-      it 'is valid when admin_only is true' do
-        notice = build(:notice, admin_only: true)
+    describe 'restricted' do
+      it 'is valid when restricted is true' do
+        notice = build(:notice, restricted: true)
         expect(notice).to be_valid
       end
 
-      it 'is valid when admin_only is false' do
-        notice = build(:notice, admin_only: false)
+      it 'is valid when restricted is false' do
+        notice = build(:notice, restricted: false)
         expect(notice).to be_valid
       end
 
-      it 'is invalid when admin_only is nil' do
-        notice = build(:notice, admin_only: nil)
+      it 'is invalid when restricted is nil' do
+        notice = build(:notice, restricted: nil)
         expect(notice).to be_invalid
       end
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -7,25 +7,22 @@ RSpec.describe Task, type: :model do
     end
 
     it 'has a valid task with parent' do
-      parent = create(:task)
-      expect(parent).to be_valid
-      child = create(:task, parent: parent)
-      expect(child.parent).to be_present
+      task = create(:task, :with_parent)
+      expect(task).to be_valid
+      expect(task.parent).to be_present
     end
   end
 
   describe 'associations' do
-    it 'belongs to created_by_user (User)' do
-      association = described_class.reflect_on_association(:created_by_user)
+    it 'belongs to user)' do
+      association = described_class.reflect_on_association(:user)
       expect(association.macro).to eq(:belongs_to)
-      expect(association.options[:class_name]).to eq("User")
     end
 
     it 'belongs to parent task (optional)' do
       association = described_class.reflect_on_association(:parent)
       expect(association.macro).to eq(:belongs_to)
       expect(association.options[:class_name]).to eq("Task")
-      expect(association.options[:foreign_key]).to eq("parent_task_id")
       expect(association.options[:optional]).to be(true)
     end
 
@@ -33,7 +30,7 @@ RSpec.describe Task, type: :model do
       association = described_class.reflect_on_association(:children)
       expect(association.macro).to eq(:has_many)
       expect(association.options[:class_name]).to eq("Task")
-      expect(association.options[:foreign_key]).to eq("parent_task_id")
+      expect(association.options[:foreign_key]).to eq("parent_id")
     end
 
     it 'has many task_assignments' do
@@ -42,9 +39,10 @@ RSpec.describe Task, type: :model do
     end
 
     it 'has_many users through task_assignments' do
-      association = described_class.reflect_on_association(:users)
+      association = described_class.reflect_on_association(:assigned_users)
       expect(association.macro).to eq(:has_many)
       expect(association.options[:through]).to eq(:task_assignments)
+      expect(association.options[:source]).to eq (:user)
     end
   end
 
@@ -83,19 +81,19 @@ RSpec.describe Task, type: :model do
       end
     end
 
-    describe 'admin_only' do
-      it 'is valid when admin_only is true' do
-        task = build(:task, admin_only: true)
+    describe 'restricted' do
+      it 'is valid when restricted is true' do
+        task = build(:task, restricted: true)
         expect(task).to be_valid
       end
 
-      it 'is valid when admin_only is false' do
-        task = build(:task, admin_only: false)
+      it 'is valid when restricted is false' do
+        task = build(:task, restricted: false)
         expect(task).to be_valid
       end
 
-      it 'is invalid when admin_only is nil' do
-        task = build(:task, admin_only: nil)
+      it 'is invalid when restricted is nil' do
+        task = build(:task, restricted: nil)
         expect(task).to be_invalid
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,17 +6,9 @@ RSpec.describe User, type: :model do
   end
 
   describe 'associations' do
-    it 'destroys associated sessions when the user is deleted' do
-      user = create(:user)
-      user.sessions.create!
-      expect { user.destroy }.to change(Session, :count).by(-1)
-    end
-
     it 'has many created_tasks' do
-      association = described_class.reflect_on_association(:created_tasks)
+      association = described_class.reflect_on_association(:tasks)
       expect(association.macro).to eq(:has_many)
-      expect(association.options[:class_name]).to eq("Task")
-      expect(association.options[:foreign_key]).to eq("created_by_user_id")
     end
 
     it 'has many task_assignments' do


### PR DESCRIPTION
## 変更内容
- カラム名変更に伴い、各モデル（Interaction / Notice / Task / TaskAssignment）の関連・バリデーションを調整
- Factory を新しい関連構造に合わせて調整
- 既存の Model Spec を新スキーマに追従する形で調整
- seed データを新しい関連・バリデーションに合わせて調整

## 確認済み
- [x] `bin/rails db:reset` が正常に完了し、`bin/rails console` で各モデルの初期データが正しく作成されていることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

## 補足
- このPRではビューやコントローラーの実装は含まない
-  Interaction / Notice / Task 同士の残りのアソシエーションは今後のPRで追加予定

Closes #27