### PR TITLE
Implement Interaction CRUD 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+gem "rails-i18n"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -440,6 +443,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.2)
+  rails-i18n
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase
   rubocop-rspec
@@ -563,6 +567,7 @@ CHECKSUMS
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-i18n (8.1.0) sha256=52d5fd6c0abef28d84223cc05647f6ae0fd552637a1ede92deee9545755b6cf3
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,5 +1,6 @@
 class InteractionsController < ApplicationController
   before_action :set_interaction, only: [ :show, :edit, :update ]
+  before_action :require_creator, only: [ :edit, :update ]
 
   def index
     @interactions = Interaction
@@ -32,8 +33,16 @@ class InteractionsController < ApplicationController
     @timeline = [ root, *root.children ].sort_by(&:occurred_at)
   end
 
-  def edit; end
-  def update; end
+  def edit
+  end
+
+  def update
+    if @interaction.update(interaction_params)
+      redirect_to @interaction, notice: "応対履歴を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   private
 
@@ -50,5 +59,11 @@ class InteractionsController < ApplicationController
       :request_content, :response_result, :completed, :parent_id,
       images: []
     )
+  end
+
+  def require_creator
+    unless @interaction.user == Current.user
+      redirect_to @interaction, alert: "編集権限がありません"
+    end
   end
 end

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,0 +1,24 @@
+class InteractionsController < ApplicationController
+  before_action :set_interaction, only: [ :show, :edit, :update ]
+
+  def index; end
+  def new; end
+  def create; end
+  def show; end
+  def edit; end
+  def update; end
+
+  private
+
+  def set_interaction
+    @interaction = Interaction.find(params[:id])
+  end
+
+  def interaction_params
+    params.require(:interaction).permit(
+      :customer_id, :channel, :occurred_at,
+      :request_content, :response_result, :completed, :parent_id,
+      images: []
+    )
+  end
+end

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -7,8 +7,25 @@ class InteractionsController < ApplicationController
                       .order(occurred_at: :desc)
   end
 
-  def new; end
-  def create; end
+  def new
+    @interaction = Interaction.new
+    @parent_interaction = Interaction.find_by(id: params[:parent_id])
+
+    if @parent_interaction
+      @interaction.parent = @parent_interaction
+      @interaction.customer = @parent_interaction.customer
+    end
+  end
+
+  def create
+    @interaction = Current.user.interactions.new(interaction_params)
+
+    if @interaction.save
+      redirect_to @interaction, notice: "応対履歴を登録しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
 
   def show
     root = @interaction.parent || @interaction

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,7 +1,12 @@
 class InteractionsController < ApplicationController
   before_action :set_interaction, only: [ :show, :edit, :update ]
 
-  def index; end
+  def index
+    @interactions = Interaction
+                      .preload(:customer, :user)
+                      .order(occurred_at: :desc)
+  end
+
   def new; end
   def create; end
   def show; end

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -9,14 +9,22 @@ class InteractionsController < ApplicationController
 
   def new; end
   def create; end
-  def show; end
+
+  def show
+    root = @interaction.parent || @interaction
+    @timeline = [ root, *root.children ].sort_by(&:occurred_at)
+  end
+
   def edit; end
   def update; end
 
   private
 
   def set_interaction
-    @interaction = Interaction.find(params[:id])
+    @interaction = Interaction.preload(
+      :customer,
+      :user
+    ).find(params[:id])
   end
 
   def interaction_params

--- a/app/helpers/interactions_helper.rb
+++ b/app/helpers/interactions_helper.rb
@@ -1,0 +1,2 @@
+module InteractionsHelper
+end

--- a/app/helpers/interactions_helper.rb
+++ b/app/helpers/interactions_helper.rb
@@ -1,2 +1,5 @@
 module InteractionsHelper
+  def interaction_channel_label(interaction)
+    I18n.t("enums.interaction.channel.#{interaction.channel}", default: interaction.channel)
+  end
 end

--- a/app/views/interactions/_form.html.erb
+++ b/app/views/interactions/_form.html.erb
@@ -1,0 +1,60 @@
+<%= form_with model: interaction, class: "space-y-4" do |f| %>
+  <% if interaction.errors.any? %>
+    <div class="bg-red-50 border border-red-300 rounded p-4">
+      <p class="text-red-700 font-semibold text-sm mb-2">
+        <%= interaction.errors.count %>件のエラーがあります
+      </p>
+      <ul class="list-disc list-inside text-red-600 text-sm space-y-1">
+        <% interaction.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= f.hidden_field :parent_id %>
+
+  <div>
+    <%= f.label :customer_id, "顧客", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <% if @parent_interaction %>
+      <%= f.hidden_field :customer_id %>
+      <div class="w-full border border-gray-200 rounded px-3 py-2 text-sm bg-gray-100 text-gray-600">
+        <%= @parent_interaction.customer.name %>
+      </div>
+    <% else %>
+      <%= f.collection_select :customer_id, Customer.order(:name), :id, :name,
+            { prompt: "選択してください" },
+            { class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" } %>
+    <% end %>
+  </div>
+  <div>
+    <%= f.label :channel, "種別", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.select :channel,
+          [["電話", "phone"], ["メール", "email"], ["来店", "visit"], ["その他", "other"]],
+          { prompt: "選択してください" },
+          { class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" } %>
+  </div>
+  <div>
+    <%= f.label :occurred_at, "対応日時", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.datetime_local_field :occurred_at,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div class="flex items-center gap-2">
+    <%= f.check_box :completed, class: "rounded" %>
+    <%= f.label :completed, "対応完了", class: "text-sm text-gray-700" %>
+  </div>
+  <div>
+    <%= f.label :request_content, "要望内容", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :request_content, rows: 4,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div>
+    <%= f.label :response_result, "対応結果", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :response_result, rows: 4,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div class="flex justify-end pt-2">
+    <%= f.submit interaction.new_record? ? "登録する" : "更新する",
+          class: "px-6 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/interactions/_form.html.erb
+++ b/app/views/interactions/_form.html.erb
@@ -16,15 +16,17 @@
 
   <div>
     <%= f.label :customer_id, "顧客", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <% if @parent_interaction %>
-      <%= f.hidden_field :customer_id %>
-      <div class="w-full border border-gray-200 rounded px-3 py-2 text-sm bg-gray-100 text-gray-600">
-        <%= @parent_interaction.customer.name %>
-      </div>
-    <% else %>
+    <% if interaction.new_record? && @parent_interaction.nil? %>
+      <%# 全くの新規登録のみセレクトボックス %>
       <%= f.collection_select :customer_id, Customer.order(:name), :id, :name,
             { prompt: "選択してください" },
             { class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" } %>
+    <% else %>
+      <%# 子として新規登録 or 編集時は顧客固定 %>
+      <%= f.hidden_field :customer_id %>
+      <div class="w-full border border-gray-200 rounded px-3 py-2 text-sm bg-gray-100 text-gray-600">
+        <%= interaction.customer.name %>
+      </div>
     <% end %>
   </div>
   <div>

--- a/app/views/interactions/_timeline.html.erb
+++ b/app/views/interactions/_timeline.html.erb
@@ -1,0 +1,28 @@
+<div class="mb-6 border-t-4 border-blue-500 pt-6">
+  <h2 class="text-lg font-semibold mb-3">この案件の流れ</h2>
+  <div class="space-y-2 text-sm">
+    <% timeline.each do |item| %>
+      <div class="pl-4 border-l-2 <%= item == current_item ? 'border-blue-500' : 'border-gray-300' %>">
+        <% if item == current_item %>
+          <span class="font-medium">
+            <%= l item.occurred_at %>
+            <%= truncate(item.request_content, length: 30) %>
+            <span class="text-blue-600">★ 現在</span>
+          </span>
+        <% else %>
+          <%= link_to interaction_path(item), class: "text-gray-700 hover:text-blue-600" do %>
+            <%= l item.occurred_at %> <%= truncate(item.request_content, length: 40) %>
+          <% end %>
+          <span class="ml-2 text-xs <%= item.completed? ? 'text-gray-600' : 'text-blue-600' %>">
+            <%= item.completed? ? "完了" : "対応中" %>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  <div class="mt-4">
+    <%= link_to "続きの応対履歴を作成",
+          new_interaction_path(parent_id: current_item.id),
+          class: "text-sm px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+  </div>
+</div>

--- a/app/views/interactions/edit.html.erb
+++ b/app/views/interactions/edit.html.erb
@@ -1,0 +1,17 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-2xl mx-auto px-4">
+
+    <div class="mb-4">
+      <%= link_to "← 詳細に戻る", interaction_path(@interaction),
+            class: "text-blue-600 hover:underline text-sm" %>
+    </div>
+
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-blue-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">応対履歴を編集</h1>
+      </div>
+
+      <%= render "form", interaction: @interaction %>
+    </div>
+  </div>
+</div>

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -21,7 +21,7 @@
             <% @interactions.each do |interaction| %>
               <tr class="hover:bg-gray-50">
                 <td class="p-3 whitespace-nowrap">
-                  <%= l interaction.occurred_at, format: :short %>
+                  <%= l interaction.occurred_at %>
                 </td>
                 <td class="p-3"><%= interaction.customer.name %></td>
                 <td class="p-3"><%= interaction.user.name %></td>

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -1,0 +1,51 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-4xl mx-auto px-4">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">応対履歴一覧</h1>
+      <%= link_to "新規登録", new_interaction_path,
+            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow">
+      <% if @interactions.any? %>
+        <table class="w-full text-sm">
+          <thead class="bg-gray-50 border-b">
+            <tr>
+              <th class="text-left p-3 text-gray-600">日時</th>
+              <th class="text-left p-3 text-gray-600">顧客</th>
+              <th class="text-left p-3 text-gray-600">担当</th>
+              <th class="text-left p-3 text-gray-600">要望内容</th>
+              <th class="text-left p-3 text-gray-600">状態</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">
+            <% @interactions.each do |interaction| %>
+              <tr class="hover:bg-gray-50">
+                <td class="p-3 whitespace-nowrap">
+                  <%= l interaction.occurred_at, format: :short %>
+                </td>
+                <td class="p-3"><%= interaction.customer.name %></td>
+                <td class="p-3"><%= interaction.user.name %></td>
+                <td class="p-3">
+                  <%= link_to truncate(interaction.request_content, length: 40),
+                        interaction_path(interaction),
+                        class: "text-blue-600 hover:underline" %>
+                </td>
+                <td class="p-3">
+                  <% if interaction.completed? %>
+                    <span class="px-2 py-1 bg-gray-100 text-gray-600 rounded text-xs">完了</span>
+                  <% else %>
+                    <span class="px-2 py-1 bg-blue-100 text-blue-600 rounded text-xs">対応中</span>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="p-8 text-center text-gray-500 text-sm">
+          まだ応対履歴はありません。
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/interactions/new.html.erb
+++ b/app/views/interactions/new.html.erb
@@ -1,0 +1,25 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-2xl mx-auto px-4">
+    <div class="mb-4">
+      <% if @parent_interaction %>
+        <%= link_to "← 親の応対履歴に戻る", interaction_path(@parent_interaction),
+              class: "text-blue-600 hover:underline text-sm" %>
+      <% else %>
+        <%= link_to "← 一覧に戻る", interactions_path,
+              class: "text-blue-600 hover:underline text-sm" %>
+      <% end %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-blue-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">
+          <% if @parent_interaction %>
+            続きの応対履歴を登録
+          <% else %>
+            応対履歴を新規登録
+          <% end %>
+        </h1>
+      </div>
+      <%= render "form", interaction: @interaction %>
+    </div>
+  </div>
+</div>

--- a/app/views/interactions/show.html.erb
+++ b/app/views/interactions/show.html.erb
@@ -1,0 +1,70 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-4xl mx-auto px-4">
+    <div class="mb-4">
+      <% if @interaction.parent %>
+        <%= link_to "← 親の応対履歴に戻る", interaction_path(@interaction.parent),
+              class: "text-blue-600 hover:underline text-sm" %>
+      <% else %>
+        <%= link_to "← 一覧に戻る", interactions_path,
+              class: "text-blue-600 hover:underline text-sm" %>
+      <% end %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-blue-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">応対履歴詳細</h1>
+      </div>
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
+        <div class="bg-gray-50 p-4 rounded text-sm">
+          <div class="grid grid-cols-2 gap-3">
+            <div>
+              <span class="text-gray-600">日時:</span>
+              <span class="ml-2"><%= l @interaction.occurred_at %></span>
+            </div>
+            <div>
+              <span class="text-gray-600">顧客:</span>
+              <span class="ml-2"><%= @interaction.customer.name %></span>
+            </div>
+            <div>
+              <span class="text-gray-600">担当:</span>
+              <span class="ml-2"><%= @interaction.user.name %></span>
+            </div>
+            <div>
+              <span class="text-gray-600">種別:</span>
+              <span class="ml-2">
+                <%= interaction_channel_label(@interaction) %>
+              </span>
+            </div>
+            <div>
+              <span class="text-gray-600">状態:</span>
+              <span class="ml-2">
+                <%= @interaction.completed? ? "対応完了" : "対応中" %>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">要望内容</h2>
+        <div class="bg-gray-50 p-4 rounded text-sm whitespace-pre-wrap">
+          <%= @interaction.request_content %>
+        </div>
+      </div>
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">対応結果</h2>
+        <div class="bg-gray-50 p-4 rounded text-sm whitespace-pre-wrap">
+          <%= @interaction.response_result %>
+        </div>
+      </div>
+
+      <%= render "timeline", timeline: @timeline, current_item: @interaction %>
+
+      <% if @interaction.user == Current.user %>
+        <div class="mt-6 flex justify-end border-t pt-4">
+          <%= link_to "編集", edit_interaction_path(@interaction),
+                class: "px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 text-sm" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,11 @@
   </head>
 
   <body>
+    <% if notice %>
+      <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+        <%= notice %>
+      </div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,7 @@ module WfmSingle
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.default_locale = :ja
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,12 @@
 ja:
+  activerecord:
+    attributes:
+      interaction:
+        customer: "顧客"
+        occurred_at: "対応日時"
+        channel: "種別"
+        request_content: "要望内容"
+        response_result: "対応結果"
   time:
     formats:
       default: "%Y/%m/%d %H:%M"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,12 @@
+ja:
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M"
+  enums:
+    interaction:
+      channel:
+        phone: "電話"
+        email: "メール"
+        web: "Web"
+        sns: "SNS"
+        in_person: "対面"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resource :session
   resources :passwords, param: :token
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  resources :interactions, except: :destroy
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/spec/helpers/interactions_helper_spec.rb
+++ b/spec/helpers/interactions_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the InteractionsHelper. For example:
+#
+# describe InteractionsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe InteractionsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Interactions", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -180,4 +180,82 @@ RSpec.describe "Interactions", type: :request do
       end
     end
   end
+
+  describe "GET /interactions/:id/edit" do
+    context "when the user is the creator" do
+      before { sign_in(user) }
+
+      it "returns 200" do
+        interaction = create(:interaction, user: user)
+        get edit_interaction_path(interaction)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when the user is not the creator" do
+      it "redirects to the show page" do
+        other_user = create(:user)
+        interaction = create(:interaction, user: other_user)
+        sign_in(user)
+        get edit_interaction_path(interaction)
+        expect(response).to redirect_to(interaction_path(interaction))
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        interaction = create(:interaction, user: user)
+        get edit_interaction_path(interaction)
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
+
+  describe "PATCH /interactions/:id" do
+    let(:interaction) { create(:interaction, user: user) }
+
+    context "when the user is the creator with valid parameters" do
+      before { sign_in(user) }
+
+      it "updates the interaction" do
+        patch interaction_path(interaction),
+            params: { interaction: { request_content: "新規要望" } }
+        expect(interaction.reload.request_content).to eq("新規要望")
+      end
+
+      it "redirects to the show page" do
+        patch interaction_path(interaction),
+            params: { interaction: { request_content: "新規要望" } }
+        expect(response).to redirect_to(interaction_path(interaction))
+      end
+    end
+
+    context "when the user is the creator with invalid parameters" do
+      before { sign_in(user) }
+
+      it "re-renders the edit template" do
+        patch interaction_path(interaction),
+              params: { interaction: { channel: nil } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when the user is not the creator" do
+      it "does not update the interaction and redirects to the show page" do
+        other_user = create(:user)
+        sign_in(other_user)
+        patch interaction_path(interaction),
+            params: { interaction: { request_content: "無効な更新" } }
+        expect(interaction.reload.request_content).not_to eq("無効な更新")
+        expect(response).to redirect_to(interaction_path(interaction))
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        patch interaction_path(interaction), params: {}
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
 end

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -43,6 +43,84 @@ RSpec.describe "Interactions", type: :request do
     end
   end
 
+  describe "GET /interactions/new" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "returns 200" do
+        get new_interaction_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "inherits the same customer name if parent_id is present" do
+        parent = create(:interaction, user: user)
+        get new_interaction_path(parent_id: parent.id)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get interactions_path
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
+
+  describe "POST /interactions" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      let(:customer) { create(:customer) }
+      let(:valid_params) do
+        {
+          interaction: {
+            customer_id: customer.id,
+            channel: "phone",
+            occurred_at: Time.current,
+            request_content: "新規要望",
+            response_result: "対応しました！",
+            completed: true
+          }
+        }
+      end
+
+      it "creates an Interaction with valid params" do
+        expect {
+          post interactions_path, params: valid_params
+        }.to change(Interaction, :count).by(1)
+      end
+
+      it "redirects to the show page with valid params" do
+        post interactions_path, params: valid_params
+        expect(response).to redirect_to(interaction_path(Interaction.last))
+      end
+
+      it "records the user who created it" do
+        post interactions_path, params: valid_params
+        expect(Interaction.last.user).to eq(user)
+      end
+
+      it "does not create an Interaction with invalid params" do
+        expect {
+          post interactions_path, params: { interaction: { channel: nil } }
+        }.not_to change(Interaction, :count)
+      end
+
+      it "re-renders the new template with invalid params" do
+        post interactions_path, params: { interaction: { channel: nil } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        post interactions_path, params: {}
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
+
   describe "GET /interactions/:id" do
     let(:interaction) { create(:interaction, user: user) }
 

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -1,7 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe "Interactions", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /interactions" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "returns 200" do
+        get interactions_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the interaction history list" do
+        interaction = create(:interaction, user: user)
+        get interactions_path
+        expect(response.body).to include(interaction.request_content)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get interactions_path
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
   end
 end

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -19,7 +19,17 @@ RSpec.describe "Interactions", type: :request do
       it "displays the interaction history list" do
         interaction = create(:interaction, user: user)
         get interactions_path
+        expect(response.body).to include(interaction.customer.name)
+        expect(response.body).to include(interaction.user.name)
         expect(response.body).to include(interaction.request_content)
+      end
+
+      it "displays completed status badge" do
+        create(:interaction, user: user, completed: true)
+        create(:interaction, user: user, completed: false)
+        get interactions_path
+        expect(response.body).to include("完了")
+        expect(response.body).to include("対応中")
       end
     end
 

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Interactions", type: :request do
+  include InteractionsHelper
+
   let(:user) { create(:user) }
 
   def sign_in(user)
@@ -36,6 +38,66 @@ RSpec.describe "Interactions", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get interactions_path
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
+
+  describe "GET /interactions/:id" do
+    let(:interaction) { create(:interaction, user: user) }
+
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "returns 200" do
+        get interaction_path(interaction)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the customer and user information" do
+        get interaction_path(interaction)
+        expect(response.body).to include(interaction.customer.name)
+        expect(response.body).to include(interaction.user.name)
+      end
+
+      it "displays the interaction content" do
+        get interaction_path(interaction)
+        expect(response.body).to include(I18n.l(interaction.occurred_at))
+        expect(response.body).to include(interaction.request_content)
+        expect(response.body).to include(interaction.response_result)
+      end
+
+      it "displays the interaction channel" do
+        get interaction_path(interaction)
+        expect(response.body).to include(interaction_channel_label(interaction))
+      end
+
+      it "displays the completion status" do
+        get interaction_path(interaction)
+        expect(response.body).to include("対応中")
+      end
+
+      it "displays completed status when interaction is completed" do
+        completed_interaction = create(:interaction, user: user, completed: true)
+        get interaction_path(completed_interaction)
+        expect(response.body).to include("対応完了")
+      end
+
+      it "displays the edit button when the user is the owner" do
+        get interaction_path(interaction)
+        expect(response.body).to include(edit_interaction_path(interaction))
+      end
+
+      it "does not display the edit button when the user is not the owner" do
+        other_interaction = create(:interaction)
+        get interaction_path(other_interaction)
+        expect(response.body).not_to include(edit_interaction_path(other_interaction))
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get interaction_path(interaction)
         expect(response).to redirect_to(new_session_path)
       end
     end


### PR DESCRIPTION
## 変更内容
* InteractionsController を作成し、以下のアクションを実装
  * `index` — 応対履歴一覧（preload による N+1 対策済み）
  * `new` — 新規登録（全くの新規 / 親IDを引き継いだ子の登録に対応）
  * `create` — 登録処理（ログインユーザーへの紐付け）
  * `show` — 詳細表示（タイムライン表示含む）
  * `edit` — 編集（作成者本人のみ）
  * `update` — 更新処理（作成者本人のみ）
* Strong Parameters を実装
* バリデーションエラー時に `unprocessable_entity` を返し、フォームを再表示
* `require_creator` による認可チェックを実装（作成者以外は編集不可）
* 顧客フィールドは新規登録時のみ変更可、編集時および子として登録時は固定表示
* 以下のビューを作成
  * `index.html.erb`
  * `show.html.erb`
  * `new.html.erb`
  * `edit.html.erb`
  * `_form.html.erb`（new / edit 共用）
  * `_timeline.html.erb`
* Request Spec を追加

## 確認済み
- [x] ブラウザ上で応対履歴の参照・作成・更新が動作することを確認
- [x] 親IDを渡した場合に顧客・parent_id が引き継がれることを確認
- [x] 作成者以外が編集URLに直アクセスした場合にリダイレクトされることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

## 補足
* 削除機能（論理削除含む）はこのPRでは実装しない
* 関連タスク・関連お知らせのパーシャルは Task / Notice の実装後に追加予定
* ページネーション・検索機能は今後のPRで追加予定

Closes #26