### PR TITLE
Implement Task CRUD

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,26 @@
+---
+include:
+  - "./**/*.rb"
+exclude:
+  - spec/**/*
+  - test/**/*
+  - vendor/**/*
+  - ".bundle/**/*"
+require:
+  - rails
+domains: []
+reporters:
+  - rubocop
+  - require_not_found
+formatter:
+  rubocop:
+    cops: safe
+    except: []
+    only: []
+    extra_args: []
+type_checker:
+  rules: {}
+require_paths: []
+plugins:
+  - solargraph-rails
+max_files: 5000

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
   gem "bullet"
+  gem "solargraph"
+  gem "solargraph-rails"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,12 +78,14 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    backport (1.2.0)
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
+    benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.4)
+    bootsnap (1.24.3)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
@@ -153,6 +155,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jaro_winkler (1.7.0)
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -168,6 +171,10 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -218,6 +225,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
+    observer (0.1.2)
+    open3 (0.2.1)
     ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.11.1)
@@ -288,6 +297,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
+    rbs (4.0.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -295,6 +308,8 @@ GEM
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    reverse_markdown (3.0.2)
+      nokogiri
     rexml (3.4.4)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
@@ -348,14 +363,40 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    rubyzip (3.3.0)
+    rubyzip (3.2.2)
     securerandom (0.4.1)
-    selenium-webdriver (4.44.0)
+    selenium-webdriver (4.43.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    solargraph (0.59.0)
+      ast (~> 2.4.3)
+      backport (~> 1.2)
+      benchmark (~> 0.4)
+      bundler (>= 2.0)
+      diff-lcs (~> 1.4)
+      jaro_winkler (~> 1.6, >= 1.6.1)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      logger (~> 1.6)
+      observer (~> 0.1)
+      open3 (~> 0.2.1)
+      ostruct (~> 0.6)
+      parser (~> 3.0)
+      prism (~> 1.4)
+      rbs (>= 3.10.0)
+      reverse_markdown (~> 3.0)
+      rubocop (~> 1.76)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
+      yard-activesupport-concern (~> 0.0)
+      yard-solargraph (~> 0.1)
+    solargraph-rails (1.3)
+      activesupport
+      solargraph (>= 0.48.0)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -396,6 +437,7 @@ GEM
     thruster (0.1.20-aarch64-linux)
     thruster (0.1.20-arm64-darwin)
     thruster (0.1.20-x86_64-linux)
+    tilt (2.7.0)
     timeout (0.6.1)
     tsort (0.2.0)
     turbo-rails (2.0.23)
@@ -420,6 +462,11 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.43)
+    yard-activesupport-concern (0.0.1)
+      yard (>= 0.8)
+    yard-solargraph (0.1.0)
+      yard (~> 0.9)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -457,6 +504,8 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubocop-rspec
   selenium-webdriver
+  solargraph
+  solargraph-rails
   solid_cable
   solid_cache
   solid_queue
@@ -482,16 +531,17 @@ CHECKSUMS
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  backport (1.2.0) sha256=912c7dfdd9ee4625d013ddfccb6205c3f92da69a8990f65c440e40f5b2fc7f75
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
   bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
-  bootsnap (1.24.4) sha256=a4d939fc2cc5242a83d3a7cb4fb97743ac58475afe91e0600479a3df6f117541
+  bootsnap (1.24.3) sha256=f7fa3d20597e2f0aa52b0a1aba83fb54d4f79e9c2e210ec4fa1e8895514dcad8
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bullet (8.1.1) sha256=3ddecdf3787c64a3f1e5b316256840bc034d60c1070b1b16d3fe5b5932d42b87
-  bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
@@ -524,9 +574,12 @@ CHECKSUMS
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  jaro_winkler (1.7.0) sha256=8daa05a5cd05bf7d27c1c65caa8ab0d47c05419d80210feaa17126db24044ada
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   kamal (2.11.0) sha256=1408864425e0dec7e0a14d712a3b13f614e9f3a425b7661d3f9d287a51d7dd75
+  kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -553,6 +606,8 @@ CHECKSUMS
   nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
   nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
   nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
+  observer (0.1.2) sha256=d8a3107131ba661138d748e7be3dbafc0d82e732fffba9fccb3d7829880950ac
+  open3 (0.2.1) sha256=8e2d7d2113526351201438c1aa35c8139f0141c9e8913baa007c898973bf3952
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
@@ -582,9 +637,11 @@ CHECKSUMS
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  reverse_markdown (3.0.2) sha256=818ebb92ce39dbb1a291690dd1ec9a6d62530d4725296b17e9c8f668f9a5b8af
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
@@ -599,9 +656,11 @@ CHECKSUMS
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
-  rubyzip (3.3.0) sha256=a372fc67892a4f8c0bc8ec906b720353d8e48807a64b2e63adf99b1e3583a034
+  rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  selenium-webdriver (4.44.0) sha256=6f1df072529af369589c46f0e01132952aabb250cfd683c274d74dc1eb5d8477
+  selenium-webdriver (4.43.0) sha256=a634377b964b701c6ac0a009ce3a08fa34ec1e1e7fe9a6d57e3088d14529a65c
+  solargraph (0.59.0) sha256=229845d4ce99b6259e3d7fd9c8238f9cd74c3056e59a4a16fb1525d6a790dad3
+  solargraph-rails (1.3) sha256=0af6159f4fe2b716857884a9d758d124eae2bd64c27cb43028792027f2973114
   solid_cable (3.0.12) sha256=a168a54731a455d5627af48d8441ea3b554b8c1f6e6cd6074109de493e6b0460
   solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
   solid_queue (1.4.0) sha256=e6a18d196f0b27cb6e3c77c5b31258b05fb634f8ed64fb1866ed164047216c2a
@@ -620,6 +679,7 @@ CHECKSUMS
   thruster (0.1.20-aarch64-linux) sha256=754f1701061235235165dde31e7a3bc87ec88066a02981ff4241fcda0d76d397
   thruster (0.1.20-arm64-darwin) sha256=630cf8c273f562063b92ea5ccd7a721d7ba6130cc422c823727f4744f6d0770e
   thruster (0.1.20-x86_64-linux) sha256=d579f252bf67aee6ba6d957e48f566b72e019d7657ba2f267a5db1e4d91d2479
+  tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
@@ -634,6 +694,9 @@ CHECKSUMS
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
+  yard (0.9.43) sha256=cf8733a8f0485df2a162927e9b5f182215a61f6d22de096b8f402c726a1c5821
+  yard-activesupport-concern (0.0.1) sha256=be790cb0efc23e2e87677063598ac8b743586154657bbd9655a7f03ce78390ef
+  yard-solargraph (0.1.0) sha256=a19a4619c942181a618fb9458970a9d2534cf7fda69fc43949629a7948a5930e
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 BUNDLED WITH

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,2 @@
+class TasksController < ApplicationController
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,2 +1,50 @@
 class TasksController < ApplicationController
+  before_action :set_task, only: [ :show, :edit, :update ]
+  before_action :authorize_view!, only: [ :show, :edit, :update ]
+  before_action :authorize_edit!, only: [ :edit, :update ]
+
+  def index
+    @tasks = visible_tasks.preload(:user).order(due_at: :asc)
+  end
+
+  def new; end
+  def create; end
+  def show; end
+  def edit; end
+  def update; end
+
+  private
+
+  def set_task
+    @task = Task.preload(:user).find(params[:id])
+  end
+
+  def visible_tasks
+    Current.user.admin? ? Task.all : Task.where(restricted: false)
+  end
+
+  def authorize_view!
+    return if Current.user.admin? || !@task.restricted
+
+    redirect_to tasks_path, alert: "アクセス権限がありません"
+  end
+
+  def authorize_edit!
+    return if @task.user == Current.user
+
+    redirect_to @task, alert: "編集権限がありません"
+  end
+
+  def task_params
+    permitted = %i[
+      title
+      description
+      due_at
+      parent_id
+    ]
+
+    permitted << :restricted if Current.user.admin?
+
+    params.require(:task).permit(permitted)
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -26,8 +26,16 @@ class TasksController < ApplicationController
   def show
   end
 
-  def edit; end
-  def update; end
+  def edit
+  end
+
+  def update
+    if @task.update(task_params)
+      redirect_to @task, notice: "タスクを更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   private
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,8 +7,21 @@ class TasksController < ApplicationController
     @tasks = visible_tasks.preload(:user).order(due_at: :asc)
   end
 
-  def new; end
-  def create; end
+  def new
+    @parent_task = Task.find_by(id: params[:parent_id])
+    @task = Task.new(parent: @parent_task)
+  end
+
+  def create
+    @task = Current.user.tasks.build(task_params)
+    @parent_task = @task.parent
+
+    if @task.save
+      redirect_to @task, notice: "タスクを登録しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
 
   def show
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,7 +9,10 @@ class TasksController < ApplicationController
 
   def new; end
   def create; end
-  def show; end
+
+  def show
+  end
+
   def edit; end
   def update; end
 

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,0 +1,2 @@
+module TasksHelper
+end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,0 +1,40 @@
+<%= form_with model: task, class: "space-y-4" do |f| %>
+  <% if task.errors.any? %>
+    <div class="bg-red-50 border border-red-300 rounded p-4">
+      <p class="text-red-700 font-semibold text-sm mb-2">
+        <%= task.errors.count %>件のエラーがあります
+      </p>
+      <ul class="list-disc list-inside text-red-600 text-sm space-y-1">
+        <% task.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= f.hidden_field :parent_id %>
+  <div>
+    <%= f.label :title, "件名", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :title,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div>
+    <%= f.label :description, "内容", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :description, rows: 4,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div>
+    <%= f.label :due_at, "期限", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.datetime_local_field :due_at,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <% if Current.user.admin? %>
+    <div class="flex items-center gap-2">
+      <%= f.check_box :restricted, class: "rounded" %>
+      <%= f.label :restricted, "管理者のみ", class: "text-sm text-gray-700" %>
+    </div>
+  <% end %>
+  <div class="flex justify-end pt-2">
+    <%= f.submit task.new_record? ? "登録する" : "更新する",
+          class: "px-6 py-2 bg-purple-500 text-white rounded hover:bg-purple-600 text-sm cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,14 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-2xl mx-auto px-4">
+    <div class="mb-4">
+      <%= link_to "← 詳細に戻る", task_path(@task),
+            class: "text-blue-600 hover:underline text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-purple-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">タスクを編集</h1>
+      </div>
+      <%= render "form", task: @task %>
+    </div>
+  </div>
+</div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,0 +1,40 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-4xl mx-auto px-4">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">タスク一覧</h1>
+      <%= link_to "新規登録", new_task_path,
+            class: "px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600 text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow">
+      <% if @tasks.any? %>
+        <table class="w-full text-sm">
+          <thead class="bg-gray-50 border-b">
+            <tr>
+              <th class="text-left p-3 text-gray-600">タイトル</th>
+              <th class="text-left p-3 text-gray-600">担当者</th>
+              <th class="text-left p-3 text-gray-600">期限</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">
+            <% @tasks.each do |task| %>
+              <tr class="hover:bg-gray-50">
+                <td class="p-3">
+                  <%= link_to task.title, task_path(task),
+                        class: "text-blue-600 hover:underline" %>
+                </td>
+                <td class="p-3"><%= task.user.name %></td>
+                <td class="p-3">
+                  <%= task.due_at ? l(task.due_at) : "未設定" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="p-8 text-center text-gray-500 text-sm">
+          まだタスクは登録されていません。
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,21 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-2xl mx-auto px-4">
+    <div class="mb-4">
+      <% if @parent_task %>
+        <%= link_to "← 関連タスクに戻る", task_path(@parent_task),
+              class: "text-blue-600 hover:underline text-sm" %>
+      <% else %>
+        <%= link_to "← 一覧に戻る", tasks_path,
+              class: "text-blue-600 hover:underline text-sm" %>
+      <% end %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-purple-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">
+          <%= @parent_task ? "関連タスクを登録" : "タスクを新規登録" %>
+        </h1>
+      </div>
+      <%= render "form", task: @task %>
+    </div>
+  </div>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -12,7 +12,7 @@
         <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
         <div class="bg-gray-50 p-4 rounded text-sm space-y-2">
           <div>
-            <span class="text-gray-600">タイトル:</span>
+            <span class="text-gray-600">件名</span>
             <span class="ml-2"><%= @task.title %></span>
           </div>
           <div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,44 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-4xl mx-auto px-4">
+    <div class="mb-4">
+      <%= link_to "← 一覧に戻る", tasks_path,
+            class: "text-blue-600 hover:underline text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-purple-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">タスク詳細</h1>
+      </div>
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
+        <div class="bg-gray-50 p-4 rounded text-sm space-y-2">
+          <div>
+            <span class="text-gray-600">タイトル:</span>
+            <span class="ml-2"><%= @task.title %></span>
+          </div>
+          <div>
+            <span class="text-gray-600">作成者:</span>
+            <span class="ml-2"><%= @task.user.name %></span>
+          </div>
+          <div>
+            <span class="text-gray-600">期限:</span>
+            <span class="ml-2">
+              <%= @task.due_at ? l(@task.due_at) : "未設定" %>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">内容</h2>
+        <div class="bg-gray-50 p-4 rounded text-sm whitespace-pre-wrap">
+          <%= @task.description %>
+        </div>
+      </div>
+      <% if @task.user == Current.user %>
+        <div class="mt-6 flex justify-end border-t pt-4">
+          <%= link_to "編集", edit_task_path(@task),
+                class: "px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 text-sm" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,10 @@ ja:
         email: "メールアドレス"
         phone: "電話番号"
         key_notes: "重要メモ"
+      task:
+        title: "件名"
+        description: "内容"
+        due_at: "期限"
   time:
     formats:
       default: "%Y/%m/%d %H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :interactions, except: :destroy
   resources :customers, except: :destroy
+  resources :tasks, except: :destroy
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -6,8 +6,9 @@ FactoryBot.define do
       association :parent, factory: :task
     end
 
-    title { "タイトル" }
+    sequence(:title) { |n| "タイトル#{n}" }
     description { "説明" }
     restricted { false }
+    due_at { 1.week.from_now }
   end
 end

--- a/spec/helpers/tasks_helper_spec.rb
+++ b/spec/helpers/tasks_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the TasksHelper. For example:
+#
+# describe TasksHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe TasksHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Tasks", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -57,4 +57,53 @@ RSpec.describe "Tasks", type: :request do
       end
     end
   end
+
+  describe "GET /tasks/:id" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "responds with HTTP 200 OK" do
+        get task_path(task)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the task information" do
+        get task_path(task)
+
+        expect(response.body).to include(task.title)
+        expect(response.body).to include(task.user.name)
+        expect(response.body).to include(I18n.l(task.due_at))
+        expect(response.body).to include(task.description)
+      end
+
+      it "cannot access a restricted task" do
+        restricted_task = create(:task, user: admin, restricted: true)
+
+        get task_path(restricted_task)
+
+        expect(response).to redirect_to tasks_path
+      end
+    end
+
+    context "when the user is an admin" do
+      before { sign_in(admin) }
+
+      it "can access a restricted task" do
+        restricted_task = create(:task, user: admin, restricted: true)
+
+        get task_path(restricted_task)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get task_path(task)
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -1,7 +1,60 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:admin) { create(:user, admin: true) }
+  let!(:task) { create(:task, user: user) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /tasks" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "responds with HTTP 200 OK" do
+        get tasks_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the tasks list" do
+        get tasks_path
+
+        expect(response.body).to include(task.title)
+        expect(response.body).to include(task.user.name)
+        expect(response.body).to include(I18n.l(task.due_at))
+      end
+
+      it "does not display restricted tasks when the user is not an admin" do
+        restricted_task = create(:task, user: admin, restricted: true)
+
+        get tasks_path
+
+        expect(response.body).not_to include(restricted_task.title)
+      end
+    end
+
+    context "when the user is an admin" do
+      before { sign_in(admin) }
+
+      it "displays all tasks including restricted tasks" do
+        restricted_task = create(:task, user: admin, restricted: true)
+
+        get tasks_path
+
+        expect(response.body).to include(task.title)
+        expect(response.body).to include(restricted_task.title)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get tasks_path
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
   end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -251,4 +251,152 @@ RSpec.describe "Tasks", type: :request do
       end
     end
   end
+
+  describe "GET /tasks/:id/edit" do
+    let(:other_user) { create(:user) }
+
+    context "when the user is the creator" do
+      before { sign_in(user) }
+
+      it "responds with HTTP 200 OK" do
+        get edit_task_path(task)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not display restricted check box" do
+        get edit_task_path(task)
+
+        expect(response.body).not_to include("管理者のみ")
+      end
+
+      it "cannot access a restricted task and redirects to the index page" do
+        get edit_task_path(restricted_task)
+
+        expect(response).to redirect_to tasks_path
+      end
+    end
+
+    context "when the user is not the creator" do
+      before { sign_in(other_user) }
+
+      it "redirects to the show page" do
+        get edit_task_path(task)
+
+        expect(response).to redirect_to(task_path(task))
+      end
+    end
+
+    context "when the user is admin and the creator" do
+      before do
+        restricted_task
+        sign_in(admin)
+      end
+
+      it "can access a restricted task" do
+        get edit_task_path(restricted_task)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays restricted check box" do
+        get edit_task_path(restricted_task)
+
+        expect(response.body).to include("管理者のみ")
+      end
+    end
+
+    context "when the user is admin but not the creator" do
+      before { sign_in(admin) }
+
+      it "redirects to the show page" do
+        get edit_task_path(task)
+
+        expect(response).to redirect_to task_path(task)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get edit_task_path(task)
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
+
+  describe "PATCH /tasks/:id" do
+    let(:other_user) { create(:user) }
+
+    context "when the user is the creator" do
+      before { sign_in(user) }
+
+      it "updates the task and redirects to the show page with valid parameters" do
+        patch task_path(task),
+          params: { task: { description: "追記" } }
+
+        expect(task.reload.description).to eq("追記")
+        expect(response).to redirect_to(task_path(task))
+      end
+
+      it "does not update the task and re-renders the edit template with invalid parameters" do
+        patch task_path(task), params: { task: { title: nil } }
+
+        expect(task.reload.title).not_to be_nil
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "cannot update a restricted task and redirects to the index template" do
+        patch task_path(restricted_task),
+          params: { task: { description: "追記" } }
+
+        expect(restricted_task.reload.description).not_to eq("追記")
+        expect(response).to redirect_to tasks_path
+      end
+    end
+
+    context "when the user is not the creator" do
+      before { sign_in(other_user) }
+
+      it "does not update the task and redirects to the show page" do
+        patch task_path(task), params: { task: { description: "追記" } }
+
+        expect(task.reload.description).not_to eq("追記")
+        expect(response).to redirect_to task_path(task)
+      end
+    end
+
+    context "when the user is admin and the creator" do
+      before do
+        restricted_task
+        sign_in(admin)
+      end
+
+      it "updates the restricted task and redirects to the show page" do
+        patch task_path(restricted_task), params: { task: { description: "追記" } }
+
+        expect(restricted_task.reload.description).to eq("追記")
+        expect(response).to redirect_to task_path(restricted_task)
+      end
+    end
+
+    context "when the user is admin but not the creator" do
+      before { sign_in(admin) }
+
+      it "does not update the task and redirects to the show page" do
+        patch task_path(task), params: { task: { description: "追記" } }
+
+        expect(task.reload.description).not_to eq("追記")
+        expect(response).to redirect_to task_path(task)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        patch task_path(task), params: {}
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Tasks", type: :request do
   let(:user) { create(:user) }
   let(:admin) { create(:user, admin: true) }
   let!(:task) { create(:task, user: user) }
+  let(:restricted_task) { create(:task, user: admin, restricted: true) }
 
   def sign_in(user)
     post session_path, params: { email_address: user.email_address, password: "password55" }
@@ -11,7 +12,10 @@ RSpec.describe "Tasks", type: :request do
 
   describe "GET /tasks" do
     context "when the user is logged in" do
-      before { sign_in(user) }
+      before do
+        restricted_task
+        sign_in(user)
+      end
 
       it "responds with HTTP 200 OK" do
         get tasks_path
@@ -28,8 +32,6 @@ RSpec.describe "Tasks", type: :request do
       end
 
       it "does not display restricted tasks when the user is not an admin" do
-        restricted_task = create(:task, user: admin, restricted: true)
-
         get tasks_path
 
         expect(response.body).not_to include(restricted_task.title)
@@ -37,11 +39,12 @@ RSpec.describe "Tasks", type: :request do
     end
 
     context "when the user is an admin" do
-      before { sign_in(admin) }
+      before do
+        restricted_task
+        sign_in(admin)
+      end
 
       it "displays all tasks including restricted tasks" do
-        restricted_task = create(:task, user: admin, restricted: true)
-
         get tasks_path
 
         expect(response.body).to include(task.title)
@@ -78,8 +81,6 @@ RSpec.describe "Tasks", type: :request do
       end
 
       it "cannot access a restricted task" do
-        restricted_task = create(:task, user: admin, restricted: true)
-
         get task_path(restricted_task)
 
         expect(response).to redirect_to tasks_path
@@ -90,8 +91,6 @@ RSpec.describe "Tasks", type: :request do
       before { sign_in(admin) }
 
       it "can access a restricted task" do
-        restricted_task = create(:task, user: admin, restricted: true)
-
         get task_path(restricted_task)
 
         expect(response).to have_http_status(:ok)
@@ -101,6 +100,152 @@ RSpec.describe "Tasks", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get task_path(task)
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
+
+  describe "GET /tasks/new" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "responds with HTTP 200 OK" do
+        get new_task_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not display restricted check box" do
+        get new_task_path
+
+        expect(response.body).not_to include("管理者のみ")
+      end
+    end
+
+    context "when the user is admin" do
+      before { sign_in(admin) }
+
+      it "displays restricted check box" do
+        get new_task_path
+
+        expect(response.body).to include("管理者のみ")
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get new_task_path
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
+
+  describe "POST /tasks" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      let(:valid_params) do
+        {
+          task: {
+            title: "テストタスク",
+            description: "テストタスクの詳細",
+            due_at: 1.week.from_now
+          }
+        }
+      end
+
+      it "creates a Task with valid params" do
+        expect {
+          post tasks_path, params: valid_params
+        }.to change(Task, :count).by(1)
+      end
+
+      it "redirects to the show page with valid params" do
+        post tasks_path, params: valid_params
+
+        expect(response).to redirect_to(task_path(Task.last))
+      end
+
+      it "records the user who created it" do
+        post tasks_path, params: valid_params
+
+        expect(Task.last.user).to eq(user)
+      end
+
+      it "creates a child task" do
+        parent = create(:task, user: user)
+
+        expect {
+          post tasks_path, params: {
+            task: {
+              title: "子テストタスク",
+              description: "子テストタスクの詳細",
+              parent_id: parent.id
+            }
+          }
+        }.to change(Task, :count).by(1)
+      end
+
+      it "associates the parent task correctly" do
+        parent = create(:task, user: user)
+
+        post tasks_path, params: {
+          task: {
+            title: "子テストタスク",
+            description: "子テストタスクの詳細",
+            parent_id: parent.id
+          }
+        }
+
+        expect(Task.last.parent).to eq(parent)
+      end
+
+      it "does not create a Task with invalid params" do
+        expect {
+          post tasks_path, params: { task: { title: nil } }
+        }.not_to change(Task, :count)
+      end
+
+      it "re-renders the new template with invalid params" do
+        post tasks_path, params: { task: { title: nil } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "ignores restricted parameter" do
+        post tasks_path, params: {
+          task: {
+            title: "テストタスク",
+            description: "テストタスクの詳細",
+            restricted: true
+          }
+        }
+
+        expect(Task.last.restricted).to be(false)
+      end
+    end
+
+    context "when the user is admin" do
+      before { sign_in(admin) }
+
+      it "allows to set restricted" do
+        post tasks_path, params: {
+          task: {
+            title: "テストタスク",
+            description: "テストタスクの詳細",
+            restricted: true
+          }
+        }
+
+        expect(Task.last.restricted).to be(true)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        post tasks_path, params: {}
 
         expect(response).to redirect_to(new_session_path)
       end


### PR DESCRIPTION
## 変更内容
* TasksController を作成し、以下のアクションを実装
  * `index` — タスク一覧（preload による N+1 対策済み）
  * `new` — 新規登録（全くの新規 / 親IDを引き継いだ子の登録に対応）
  * `create` — 登録処理（ログインユーザーへの紐付け）
  * `show` — 詳細表示
  * `edit` — 編集（作成者本人のみ）
  * `update` — 更新処理（作成者本人のみ）
* Strong Parameters を実装
* バリデーションエラー時に `unprocessable_entity` を返し、フォームを再表示
* `authorize_edit!` による認可チェックを実装（作成者以外は編集不可）
* `authorize_view!` による認可チェックを実装（restricted タスクは管理者のみ閲覧・編集可）
* 管理者フラグによるフォーム出し分け（`管理者のみ` チェックボックスの表示制御および `restricted` パラメータの許可）を実装
* 以下のビューを作成
  * `index.html.erb`
  * `show.html.erb`
  * `new.html.erb`
  * `edit.html.erb`
  * `_form.html.erb`（new / edit 共用）
* Request Spec を追加

## 確認済み
- [x] ブラウザ上でタスクの参照・作成・更新が動作することを確認
- [x] 親IDを渡した場合に parent_id が引き継がれることを確認
- [x] 作成者以外（管理者含む）が編集URLに直アクセスした場合にリダイレクトされることを確認
- [x] 管理者以外が restricted タスクの詳細・編集URLに直アクセスした場合にリダイレクトされることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

## 補足
* 削除機能（論理削除含む）はこのPRでは実装しない
** 関連タスク・関連お知らせのパーシャルは Notice の実装後に追加予定
* ページネーション・検索機能は今後のPRで追加予定

Closes #58