### PR TITLE
Implement Notice CRUD

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,0 +1,2 @@
+class NoticesController < ApplicationController
+end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -25,6 +25,7 @@ class NoticesController < ApplicationController
   end
 
   def show
+    @timeline = @notice.root.thread_notices.order(:created_at)
   end
 
   def edit

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -10,7 +10,10 @@ class NoticesController < ApplicationController
 
   def new; end
   def create; end
-  def show; end
+
+  def show
+  end
+
   def edit; end
   def update; end
 

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -27,8 +27,16 @@ class NoticesController < ApplicationController
   def show
   end
 
-  def edit; end
-  def update; end
+  def edit
+  end
+
+  def update
+    if @notice.update(notice_params)
+      redirect_to @notice, notice: "お知らせを更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   private
 

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -8,8 +8,21 @@ class NoticesController < ApplicationController
     @notices = visible_notices.preload(:user).order(start_at: :desc)
   end
 
-  def new; end
-  def create; end
+  def new
+    @parent_notice = Notice.find_by(id: params[:parent_id])
+    @notice = Notice.new(parent: @parent_notice)
+  end
+
+  def create
+    @notice = Current.user.notices.build(notice_params)
+    @parent_notice = @notice.parent
+
+    if @notice.save
+      redirect_to @notice, notice: "お知らせを更新しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
 
   def show
   end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,2 +1,53 @@
 class NoticesController < ApplicationController
+  before_action :set_notice, only: %i[show edit update]
+  before_action :authorize_view!, only: %i[show edit update]
+  before_action :authorize_edit!, only: %i[edit update]
+
+
+  def index
+    @notices = visible_notices.preload(:user).order(start_at: :desc)
+  end
+
+  def new; end
+  def create; end
+  def show; end
+  def edit; end
+  def update; end
+
+  private
+
+  def set_notice
+    @notice = Notice.preload(:user).find(params[:id])
+  end
+
+  def visible_notices
+    Current.user.admin? ? Notice.all : Notice.where(restricted: false)
+  end
+
+  def authorize_view!
+    return if Current.user.admin? || !@notice.restricted
+
+    redirect_to notices_path, alert: "アクセス権限がありません"
+  end
+
+  def authorize_edit!
+    return if @notice.user == Current.user
+
+    redirect_to @notice, alert: "編集権限がありません"
+  end
+
+  def notice_params
+    permitted = %i[
+      title
+      content
+      level
+      start_at
+      end_at
+      parent_id
+    ]
+
+    permitted << :restricted if Current.user.admin?
+
+    params.require(:notice).permit(permitted)
+  end
 end

--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -1,0 +1,2 @@
+module NoticesHelper
+end

--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -1,2 +1,5 @@
 module NoticesHelper
+  def notice_level_label(notice)
+    I18n.t("enums.notice.level.#{notice.level}", default: notice.level)
+  end
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,8 +1,14 @@
 class Notice < ApplicationRecord
+  before_validation :assign_root
+  after_create :assign_self_as_root
+
   belongs_to :user
 
   belongs_to :parent, class_name: "Notice", optional: true
   has_many :children, class_name: "Notice", foreign_key: "parent_id"
+
+  belongs_to :root, class_name: "Notice", optional: true
+  has_many :thread_notices, class_name: "Notice", foreign_key: :root_id, dependent: :nullify
 
   # add associations after other models are created
   # has_many :interactions
@@ -20,4 +26,16 @@ class Notice < ApplicationRecord
   validates :start_at, presence: true
   validates :end_at, presence: true
   validates :end_at, comparison: { greater_than: :start_at }, if: -> { start_at.present? && end_at.present? }
+
+  private
+
+  def assign_root
+    return unless parent
+
+    self.root = parent.root || parent
+  end
+
+  def assign_self_as_root
+    update_column(:root_id, id) if root_id.nil?
+  end
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -19,5 +19,5 @@ class Notice < ApplicationRecord
   validates :restricted, inclusion: { in: [ true, false ] }
   validates :start_at, presence: true
   validates :end_at, presence: true
-validates :end_at, comparison: { greater_than: :start_at }, if: -> { start_at.present? && end_at.present? }
+  validates :end_at, comparison: { greater_than: :start_at }, if: -> { start_at.present? && end_at.present? }
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -18,5 +18,6 @@ class Notice < ApplicationRecord
   validates :level, presence: true
   validates :restricted, inclusion: { in: [ true, false ] }
   validates :start_at, presence: true
-  validates :end_at, presence: true, comparison: { greater_than: :start_at }
+  validates :end_at, presence: true
+validates :end_at, comparison: { greater_than: :start_at }, if: -> { start_at.present? && end_at.present? }
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -10,8 +10,7 @@ class Notice < ApplicationRecord
 
   enum :level, {
     important: "important",
-    normal: "normal",
-    confidential: "confidential"
+    normal: "normal"
   }
 
   validates :title, presence: true, length: { maximum: 50 }

--- a/app/views/notices/_form.html.erb
+++ b/app/views/notices/_form.html.erb
@@ -1,0 +1,52 @@
+<%= form_with model: notice, class: "space-y-4" do |f| %>
+  <% if notice.errors.any? %>
+    <div class="bg-red-50 border border-red-300 rounded p-4">
+      <p class="text-red-700 font-semibold text-sm mb-2">
+        <%= notice.errors.count %>件のエラーがあります
+      </p>
+      <ul class="list-disc list-inside text-red-600 text-sm space-y-1">
+        <% notice.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= f.hidden_field :parent_id %>
+  <div>
+    <%= f.label :title, "件名", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :title,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div>
+    <%= f.label :level, "重要度", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.select :level,
+          [["高", "important"], ["低", "normal"]],
+          { prompt: "選択してください" },
+          { class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" } %>
+  </div>
+  <div>
+    <%= f.label :start_at, "開始日時", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.datetime_local_field :start_at,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div>
+    <%= f.label :end_at, "終了日時", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.datetime_local_field :end_at,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div>
+    <%= f.label :content, "内容", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :content, rows: 4,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <% if Current.user.admin? %>
+    <div class="flex items-center gap-2">
+      <%= f.check_box :restricted, class: "rounded" %>
+      <%= f.label :restricted, "管理者のみ", class: "text-sm text-gray-700" %>
+    </div>
+  <% end %>
+  <div class="flex justify-end pt-2">
+    <%= f.submit notice.new_record? ? "登録する" : "更新する",
+          class: "px-6 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 text-sm cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/notices/_timeline.html.erb
+++ b/app/views/notices/_timeline.html.erb
@@ -1,0 +1,25 @@
+<div class="mb-6 border-t-4 border-blue-500 pt-6">
+  <h2 class="text-lg font-semibold mb-3">この案件の流れ</h2>
+  <div class="space-y-2 text-sm">
+    <% timeline.each do |item| %>
+      <div class="pl-4 border-l-2 <%= item == current_item ? 'border-blue-500' : 'border-gray-300' %>">
+        <% if item == current_item %>
+          <span class="font-medium">
+            <%= l item.created_at %>
+            <%= truncate(item.content, length: 30) %>
+            <span class="text-blue-600">★ 現在</span>
+          </span>
+        <% else %>
+          <%= link_to notice_path(item), class: "text-gray-700 hover:text-blue-600" do %>
+            <%= l item.created_at %> <%= truncate(item.content, length: 40) %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+  <div class="mt-4">
+    <%= link_to "続きのお知らせを作成",
+          new_notice_path(parent_id: current_item.id),
+          class: "text-sm px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+  </div>
+</div>

--- a/app/views/notices/edit.html.erb
+++ b/app/views/notices/edit.html.erb
@@ -1,0 +1,14 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-2xl mx-auto px-4">
+    <div class="mb-4">
+      <%= link_to "← 詳細に戻る", notice_path(@notice),
+            class: "text-blue-600 hover:underline text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-yellow-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">お知らせを編集</h1>
+      </div>
+      <%= render "form", notice: @notice %>
+    </div>
+  </div>
+</div>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,0 +1,38 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-4xl mx-auto px-4">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">お知らせ一覧</h1>
+      <%= link_to "新規登録", new_notice_path,
+            class: "px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow">
+      <% if @notices.any? %>
+        <table class="w-full text-sm">
+          <thead class="bg-gray-50 border-b">
+            <tr>
+              <th class="text-left p-3 text-gray-600 w-1/2">タイトル</th>
+              <th class="text-left p-3 text-gray-600 w-1/4">重要度</th>
+              <th class="text-left p-3 text-gray-600 w-1/4">作成者</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">
+            <% @notices.each do |notice| %>
+              <tr class="hover:bg-gray-50">
+                <td class="p-3">
+                  <%= link_to notice.title, notice_path(notice),
+                        class: "text-blue-600 hover:underline" %>
+                </td>
+                <td class="p-3"><%= notice_level_label(notice) %></td>
+                <td class="p-3"><%= notice.user.name %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="p-8 text-center text-gray-500 text-sm">
+          まだお知らせはありません。
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/notices/new.html.erb
+++ b/app/views/notices/new.html.erb
@@ -1,8 +1,13 @@
 <div class="min-h-screen bg-gray-50 py-8">
   <div class="max-w-2xl mx-auto px-4">
     <div class="mb-4">
-      <%= link_to "← 一覧に戻る", notices_path,
-            class: "text-blue-600 hover:underline text-sm" %>
+      <% if @notice.parent %>
+        <%= link_to "← 元のお知らせに戻る", notice_path(@notice.parent),
+              class: "text-blue-600 hover:underline text-sm" %>
+      <% else %>
+        <%= link_to "← 一覧に戻る", notices_path,
+              class: "text-blue-600 hover:underline text-sm" %>
+      <% end %>
     </div>
     <div class="bg-white rounded-lg shadow-lg p-6">
       <div class="border-b-4 border-yellow-500 pb-4 mb-6">

--- a/app/views/notices/new.html.erb
+++ b/app/views/notices/new.html.erb
@@ -1,0 +1,20 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-2xl mx-auto px-4">
+    <div class="mb-4">
+      <%= link_to "← 一覧に戻る", notices_path,
+            class: "text-blue-600 hover:underline text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-yellow-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">
+          <% if @parent_notice %>
+            続きのお知らせを登録
+          <% else %>
+            お知らせを新規登録
+          <% end %>
+        </h1>
+      </div>
+      <%= render "form", notice: @notice %>
+    </div>
+  </div>
+</div>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -1,14 +1,8 @@
 <div class="min-h-screen bg-gray-50 py-8">
   <div class="max-w-4xl mx-auto px-4">
     <div class="mb-4">
-      <%= link_to notices_path, class: "text-blue-600 hover:text-blue-800 flex items-center gap-2 text-sm" do %>
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-        </svg>
-        一覧に戻る
-      <% end %>
+      <%= link_to "← 一覧に戻る", notices_path, class: "text-blue-600 hover:underline text-sm" %>
     </div>
-
     <div class="bg-white rounded-lg shadow-lg p-6">
       <div class="border-b-4 border-yellow-500 pb-4 mb-6">
         <h1 class="text-2xl font-bold">お知らせ詳細</h1>
@@ -53,6 +47,8 @@
         <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">内容</h2>
         <div class="bg-gray-50 p-4 rounded text-sm whitespace-pre-wrap"><%= @notice.content %></div>
       </div>
+
+      <%= render "timeline", timeline: @timeline, current_item: @notice %>
 
       <% if @notice.user == Current.user %>
         <div class="mt-6 flex justify-end border-t pt-4">

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -1,0 +1,65 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-4xl mx-auto px-4">
+    <div class="mb-4">
+      <%= link_to notices_path, class: "text-blue-600 hover:text-blue-800 flex items-center gap-2 text-sm" do %>
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+        </svg>
+        一覧に戻る
+      <% end %>
+    </div>
+
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-yellow-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">お知らせ詳細</h1>
+      </div>
+
+      <div class="mb-6">
+        <h2 class="text-lg font-semibore mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
+        <div class="mb-3">
+          <h3 class="text-xl font-bold"><%= @notice.title %></h3>
+        </div>
+        <div class="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <span class="text-gray-600">作成者:</span>
+            <span class="ml-2"><%= @notice.user.name %></span>
+          </div>
+          <div>
+            <span class="text-gray-600">作成日時:</span>
+            <span class="ml-2"><%= l @notice.created_at %></span>
+          </div>
+          <div>
+            <span class="text-gray-600">重要度:</span>
+            <span class="ml-2 px-2 py-0.5 rounded text-xs bg-gray-200 text-gray-700">
+              <%= notice_level_label(@notice) %>
+            </span>
+          </div>
+          <div>
+            <span class="text-gray-600">対象:</span>
+            <span class="ml-2"><%= @notice.restricted? ? "管理者のみ" : "全員" %></span>
+          </div>
+          <div>
+            <span class="text-gray-600">開始日時:</span>
+            <span class="ml-2"><%= l @notice.start_at %></span>
+          </div>
+          <div>
+            <span class="text-gray-600">終了日時:</span>
+            <span class="ml-2"><%= l @notice.end_at %></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">内容</h2>
+        <div class="bg-gray-50 p-4 rounded text-sm whitespace-pre-wrap"><%= @notice.content %></div>
+      </div>
+
+      <% if @notice.user == Current.user %>
+        <div class="mt-6 flex justify-end border-t pt-4">
+          <%= link_to "編集", edit_notice_path(@notice),
+              class: "px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 text-sm" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,12 @@ ja:
         title: "件名"
         description: "内容"
         due_at: "期限"
+      notice:
+        title: "件名"
+        content: "内容"
+        level: "重要度"
+        start_at: "開始日時"
+        end_at: "終了日時"
   time:
     formats:
       default: "%Y/%m/%d %H:%M"
@@ -27,4 +33,8 @@ ja:
         web: "Web"
         sns: "SNS"
         in_person: "対面"
+    notice:
+      level:
+        important: "高"
+        normal: "低"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :interactions, except: :destroy
   resources :customers, except: :destroy
   resources :tasks, except: :destroy
+  resources :notices, except: :destroy
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/db/migrate/20260523033703_add_root_to_notices.rb
+++ b/db/migrate/20260523033703_add_root_to_notices.rb
@@ -1,0 +1,9 @@
+class AddRootToNotices < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :notices,
+                  :root,
+                  foreign_key: {
+                    to_table: :notices
+                  }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,49 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_10_145148) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_23_033703) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.bigint "commentable_id", null: false
+    t.string "commentable_type", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
+    t.index ["created_at"], name: "index_comments_on_created_at"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "customers", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -25,8 +65,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_10_145148) do
     t.index ["uuid"], name: "index_customers_on_uuid", unique: true
   end
 
+  create_table "interaction_notices", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "interaction_id", null: false
+    t.bigint "notice_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["interaction_id", "notice_id"], name: "index_interaction_notices_on_interaction_and_notice", unique: true
+    t.index ["interaction_id"], name: "index_interaction_notices_on_interaction_id"
+    t.index ["notice_id"], name: "index_interaction_notices_on_notice_id"
+  end
+
   create_table "interactions", force: :cascade do |t|
     t.string "channel", null: false
+    t.integer "children_count", default: 0, null: false
     t.boolean "completed", default: false, null: false
     t.datetime "created_at", null: false
     t.bigint "customer_id", null: false
@@ -49,12 +100,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_10_145148) do
     t.string "level", null: false
     t.bigint "parent_id"
     t.boolean "restricted", default: false, null: false
+    t.bigint "root_id"
     t.datetime "start_at", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["level"], name: "index_notices_on_level"
     t.index ["parent_id"], name: "index_notices_on_parent_id"
+    t.index ["root_id"], name: "index_notices_on_root_id"
     t.index ["start_at", "end_at"], name: "index_notices_on_start_at_and_end_at"
   end
 
@@ -76,6 +129,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_10_145148) do
     t.index ["task_id", "user_id"], name: "index_task_assignments_on_task_id_and_user_id", unique: true
     t.index ["task_id"], name: "index_task_assignments_on_task_id"
     t.index ["user_id"], name: "index_task_assignments_on_user_id"
+  end
+
+  create_table "task_relations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "relatable_id", null: false
+    t.string "relatable_type", null: false
+    t.bigint "task_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["relatable_type", "relatable_id"], name: "index_task_relations_on_relatable_type_and_relatable_id"
+    t.index ["task_id", "relatable_type", "relatable_id"], name: "index_task_relations_on_task_and_relatable", unique: true
+    t.index ["task_id"], name: "index_task_relations_on_task_id"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -101,14 +165,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_10_145148) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "users"
+  add_foreign_key "interaction_notices", "interactions"
+  add_foreign_key "interaction_notices", "notices"
   add_foreign_key "interactions", "customers"
   add_foreign_key "interactions", "interactions", column: "parent_id"
   add_foreign_key "interactions", "users"
   add_foreign_key "notices", "notices", column: "parent_id"
+  add_foreign_key "notices", "notices", column: "root_id"
   add_foreign_key "notices", "users"
   add_foreign_key "sessions", "users"
   add_foreign_key "task_assignments", "tasks"
   add_foreign_key "task_assignments", "users"
+  add_foreign_key "task_relations", "tasks"
   add_foreign_key "tasks", "tasks", column: "parent_id"
   add_foreign_key "tasks", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -177,9 +177,8 @@ end
 # 周知事項の種別を日本語に変換する
 def notice_level_label(level)
   {
-    important: "重要",
-    normal: "通常",
-    confidential: "管理者"
+    important: "高",
+    normal: "低",
   }[level.to_sym]
 end
 
@@ -213,12 +212,12 @@ notices = [
     start_at: Time.new(2026, 2, 2, 13, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 2, 13, 0, 0, "+09:00"),
     user_id: 1,
-    parent_id: 3
+    parent_id: 2
   },
   {
     title: "従業員の退職申出について",
     content: "Uターンするため、退職したいと佐藤さんから申し入れがありました。少し掘り下げると、直近の業務でしんどい部分があったことも影響しているようです。ひとまず慰留しましたが、元気がなさそうであれば声がけするなど、管理者各位もフォローお願いします。",
-    level: :confidential,
+    level: :important,
     restricted: true,
     start_at: Time.new(2026, 2, 1, 12, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 1, 12, 0, 0, "+09:00"),
@@ -228,7 +227,7 @@ notices = [
   {
     title: "退職申出の保留について",
     content: "佐藤さんとフォロー面談を実施した結果、もう少し将来についてゆっくり考えたいので、退職の話は一旦取り下げしたい都申出がありました。Uターンしてカフェを開業するという夢があるようです。全力で応援する気持ちと、現職で辛いことがあれば、管理者に気兼ねなく相談しても大丈夫と伝えてます。佐藤さんから何か相談があれば、快く相談にのってあげてください。",
-    level: :confidential,
+    level: :important,
     restricted: true,
     start_at: Time.new(2026, 2, 3, 11, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 3, 11, 0, 0, "+09:00"),

--- a/spec/factories/notices.rb
+++ b/spec/factories/notices.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       association :parent, factory: :notice
     end
 
-    title { "タイトル" }
+    sequence(:title) { |n| "タイトル#{n}" }
     content { "内容" }
     level { "important" }
     restricted { false }

--- a/spec/helpers/notices_helper_spec.rb
+++ b/spec/helpers/notices_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the NoticesHelper. For example:
+#
+# describe NoticesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe NoticesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -34,6 +34,38 @@ RSpec.describe Notice, type: :model do
     end
   end
 
+  describe "root assignment" do
+    let(:user) { create(:user) }
+
+    it "sets root_id for a child notice" do
+      parent = create(:notice, user: user)
+      child  = create(:notice, user: user, parent: parent)
+
+      expect(child.root_id).to eq(parent.id)
+    end
+
+    it "sets itself as root when it has no parent" do
+      notice = create(:notice, user: user)
+
+      expect(notice.root).to eq(notice)
+    end
+
+    it "inherits root from parent" do
+      parent = create(:notice, user: user)
+      child  = create(:notice, user: user, parent: parent)
+
+      expect(child.root).to eq(parent)
+    end
+
+    it "inherits root from the top-level notice" do
+      parent = create(:notice, user: user)
+      child = create(:notice, user: user, parent: parent)
+      grandchild = create(:notice, user: user, parent: child)
+
+      expect(grandchild.root).to eq(parent)
+    end
+  end
+
   describe 'enum' do
     it 'defines correct level values' do
       expect(described_class.levels.keys).to match_array(

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Notice, type: :model do
   describe 'enum' do
     it 'defines correct level values' do
       expect(described_class.levels.keys).to match_array(
-        %w[important normal confidential]
+        %w[important normal]
       )
     end
   end

--- a/spec/requests/notices_parent_child_spec.rb
+++ b/spec/requests/notices_parent_child_spec.rb
@@ -1,0 +1,223 @@
+require "rails_helper"
+
+RSpec.describe "Notices parent-child", type: :request do
+  let(:user)  { create(:user) }
+  let(:admin) { create(:user, admin: true) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /notices/:id - back link" do
+    before { sign_in(user) }
+
+    context "when the notice has no parent" do
+      let(:notice) { create(:notice, user: user) }
+
+      it "links back to the index" do
+        get notice_path(notice)
+
+        expect(response.body).to include(notices_path)
+        expect(response.body).to include("一覧に戻る")
+      end
+    end
+
+    context "when the notice has a parent" do
+      let(:parent) { create(:notice, user: user) }
+      let(:child) { create(:notice, user: user, parent: parent) }
+
+      it "links back to the index" do
+        get notice_path(child)
+
+        expect(response.body).to include(notices_path)
+        expect(response.body).to include("一覧に戻る")
+      end
+    end
+  end
+
+  describe "/GET /notices/:id - timeline" do
+    before { sign_in(user) }
+
+    context "when the notice has no children" do
+      let(:notice) { create(:notice, user: user) }
+
+      it "renders a timeline including only itself" do
+        get notice_path(notice)
+
+        expect(response.body).to include(notice.content.truncate(30))
+      end
+    end
+
+    context "when viewing a parent notice" do
+      let(:parent) { create(:notice, user: user) }
+      let!(:child) { create(:notice, user: user, parent: parent) }
+      let!(:grandchild) { create(:notice, user: user, parent: child) }
+
+      it "displays all children in the timeline" do
+        get notice_path(parent)
+
+        expect(response.body).to include(child.content.truncate(40))
+        expect(response.body).to include(grandchild.content.truncate(40))
+      end
+    end
+
+    context "when viewing a child notice" do
+      let(:parent) { create(:notice, user: user) }
+      let!(:child) { create(:notice, user: user, parent: parent) }
+      let!(:grandchild) { create(:notice, user: user, parent: child) }
+
+      it "displays the parent in the timeline" do
+        get notice_path(child)
+
+        expect(response.body).to include(parent.content.truncate(40))
+      end
+
+      it "displays sibling notices in the timeline" do
+        get notice_path(child)
+
+        expect(response.body).to include(grandchild.content.truncate(40))
+      end
+    end
+
+    context "when the notice has descendants" do
+      let(:parent) { create(:notice, user: user) }
+      let!(:child) { create(:notice, user: user, parent: parent) }
+
+      it "marks the currently viewed notice with ★ 現在" do
+        get notice_path(parent)
+
+        expect(response.body).to include("★ 現在")
+      end
+
+      it "links to other timeline items" do
+        get notice_path(parent)
+
+        expect(response.body).to include(notice_path(child))
+      end
+
+      it "does not link to the current notice in the timeline" do
+        get notice_path(child)
+
+        expect(response.body).not_to include(%(href="#{notice_path(child)}"))
+      end
+    end
+
+    context "when the notice belongs to a hierarchy" do
+      let!(:parent) { create(:notice, user: user, created_at: 2.hours.ago) }
+      let!(:child) do
+        create(
+          :notice,
+          user: user,
+          parent: parent,
+          content: "子お知らせの詳細",
+          created_at: 1.hour.ago
+        )
+      end
+
+      let!(:grandchild) do
+        create(
+          :notice,
+          user: user,
+          parent: child,
+          content: "孫お知らせの詳細",
+          created_at: 30.minutes.ago
+        )
+      end
+
+      it "displays items in chronological order" do
+        get notice_path(parent)
+
+        expect(response.body).to match(/#{child.content}.*#{grandchild.content}/m)
+      end
+    end
+
+    context "when the notice can be followed up" do
+      let(:notice) { create(:notice, user: user) }
+
+      it "includes a link to create a child with parent_id" do
+        get notice_path(notice)
+        expect(response.body).to include(new_notice_path(parent_id: notice.id))
+      end
+    end
+  end
+
+  describe "GET /notices/new with parent_id" do
+    before { sign_in(user) }
+
+    context "when creating a follow-up notice from an existing notice" do
+      let(:parent) { create(:notice, user: user) }
+
+      it "responds with HTTP 200 OK" do
+        get new_notice_path(parent_id: parent.id)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "includes the parent notice id in the form" do
+        get new_notice_path(parent_id: parent.id)
+
+        expect(response.body).to include(parent.id.to_s)
+      end
+    end
+
+    context "when creating a follow-up notice with a non-existent parent notice" do
+      it "responds with HTTP 200 OK and ignores the invalid parent_id" do
+        get new_notice_path(parent_id: 0)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "POST /notices with parent_id" do
+    let!(:parent) { create(:notice, user: user) }
+    let(:child_params) do
+      {
+        notice: {
+          title: "子お知らせ",
+          content: "子の詳細",
+          level: "normal",
+          start_at: 1.hour.ago,
+          end_at: 1.week.from_now,
+          parent_id: parent.id
+        }
+      }
+    end
+
+    context "when creating a follow-up notice" do
+      before { sign_in(user) }
+
+      it "creates a notice and associates it with the parent" do
+        expect {
+          post notices_path, params: child_params
+        }.to change(Notice, :count).by(1)
+
+        expect(Notice.last.parent).to eq(parent)
+      end
+
+      it "redirects to the child notice page" do
+        post notices_path, params: child_params
+
+        expect(response).to redirect_to notice_path(Notice.last)
+      end
+    end
+
+    context "when creating a root notice" do
+      before { sign_in(user) }
+
+      it "creates a notice without a parent" do
+        post notices_path, params: {
+          notice: {
+            title: "ルートお知らせ",
+            content: "詳細",
+            level: "normal",
+            start_at: 1.hour.ago,
+            end_at: 1.week.from_now
+          }
+        }
+
+        expect(Notice.last.parent).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Notices", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -228,22 +228,6 @@ RSpec.describe "Notices", type: :request do
         expect(Notice.last.user).to eq(user)
       end
 
-      it "creates a child notice" do
-        parent = create(:notice, user: user)
-
-        expect {
-          post notices_path, params: { notice: child_params[:notice].merge(parent_id: parent.id) }
-        }.to change(Notice, :count).by(1)
-      end
-
-      it "associates the parent notice correctly" do
-        parent = create(:notice, user: user)
-
-        post notices_path, params: { notice: child_params[:notice].merge(parent_id: parent.id) }
-
-        expect(Notice.last.parent).to eq(parent)
-      end
-
       it "does not create a Notice with invalid params" do
         expect {
           post notices_path, params: { notice: { title: nil } }

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -10,6 +10,30 @@ RSpec.describe "Notices", type: :request do
     post session_path, params: { email_address: user.email_address, password: "password55" }
   end
 
+  def valid_params
+    {
+      notice: {
+        title: "テストお知らせ",
+        content: "テストタスクの詳細",
+        level: "important",
+        start_at: 1.hour.ago,
+        end_at: 1.week.from_now
+      }
+    }
+  end
+
+  def child_params
+    {
+      notice: {
+        title: "子テストタスク",
+        content: "子テストタスクの詳細",
+        level: "important",
+        start_at: 1.hour.ago,
+        end_at: 1.week.from_now
+      }
+    }
+  end
+
   describe "GET /notices" do
     context "when the user is logged in" do
       before { sign_in(user) }
@@ -139,6 +163,118 @@ RSpec.describe "Notices", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get notice_path(notice)
+
+        expect(response).to redirect_to new_session_path
+      end
+    end
+  end
+
+  describe "GET /notices/new" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "responds with HTTP 200 OK" do
+        get new_notice_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not display restricted check box" do
+        get new_notice_path
+
+        expect(response.body).not_to include("管理者のみ")
+      end
+    end
+
+    context "when the user is an admin" do
+      before { sign_in(admin) }
+
+      it "displays restricted check box" do
+        get new_notice_path
+
+        expect(response.body).to include("管理者のみ")
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get new_notice_path
+
+        expect(response).to redirect_to new_session_path
+      end
+    end
+  end
+
+  describe "POST /notices" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "creates a Notice with valid params" do
+        expect {
+          post notices_path, params: valid_params
+        }.to change(Notice, :count).by(1)
+      end
+
+      it "redirects to the show page with valid params" do
+        post notices_path, params: valid_params
+
+        expect(response).to redirect_to(notice_path(Notice.last))
+      end
+
+      it "records the user who created it" do
+        post notices_path, params: valid_params
+
+        expect(Notice.last.user).to eq(user)
+      end
+
+      it "creates a child notice" do
+        parent = create(:notice, user: user)
+
+        expect {
+          post notices_path, params: { notice: child_params[:notice].merge(parent_id: parent.id) }
+        }.to change(Notice, :count).by(1)
+      end
+
+      it "associates the parent notice correctly" do
+        parent = create(:notice, user: user)
+
+        post notices_path, params: { notice: child_params[:notice].merge(parent_id: parent.id) }
+
+        expect(Notice.last.parent).to eq(parent)
+      end
+
+      it "does not create a Notice with invalid params" do
+        expect {
+          post notices_path, params: { notice: { title: nil } }
+        }.not_to change(Notice, :count)
+      end
+
+      it "re-renders the new template with invalid params" do
+        post notices_path, params: { notice: { title: nil } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "ignores restricted parameter" do
+        post notices_path, params: { notice: child_params[:notice].merge(restricted: true) }
+
+        expect(Notice.last.restricted).to be(false)
+      end
+    end
+
+    context "when the user is an admin" do
+      before { sign_in(admin) }
+
+      it "allows to set restricted" do
+        post notices_path, params: { notice: child_params[:notice].merge(restricted: true) }
+
+        expect(Notice.last.restricted).to be(true)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        post notices_path, params: {}
 
         expect(response).to redirect_to new_session_path
       end

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -1,7 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe "Notices", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:admin) { create(:user, admin: true) }
+  let!(:notice) { create(:notice, user: user) }
+  let!(:restricted_notice) { create(:notice, user: admin, restricted: true) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /notices" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "responds with HTTP 200 OK" do
+        get notices_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the notices list" do
+        get notices_path
+
+        expect(response.body).to include(notice.title)
+        expect(response.body).to include(I18n.t("enums.notice.level.#{notice.level}"))
+        expect(response.body).to include(notice.user.name)
+      end
+
+      it "does not display restricted notices when the user is not an admin" do
+        get notices_path
+
+        expect(response.body).not_to include(restricted_notice.title)
+      end
+    end
+
+    context "when the user is admin" do
+      before { sign_in(admin) }
+
+      it "displays all notices including restricted notices" do
+        get notices_path
+
+        expect(response.body).to include(notice.title)
+        expect(response.body).to include(restricted_notice.title)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get notices_path
+
+        expect(response).to redirect_to new_session_path
+      end
+    end
   end
 end

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -54,4 +54,94 @@ RSpec.describe "Notices", type: :request do
       end
     end
   end
+
+  describe "GET /notices/:id" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "responds with HTTP 200 OK" do
+        get notice_path(notice)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the notice basic information" do
+        get notice_path(notice)
+
+        expect(response.body).to include(notice.title)
+        expect(response.body).to include(notice.user.name)
+        expect(response.body).to include(I18n.l(notice.created_at))
+      end
+
+      it "displays the notice level and non-restricted status" do
+        get notice_path(notice)
+
+        expect(response.body).to include(I18n.t("enums.notice.level.#{notice.level}"))
+        expect(response.body).to include("全員")
+      end
+
+      it "displays publication period" do
+        get notice_path(notice)
+
+        expect(response.body).to include(I18n.l(notice.start_at))
+        expect(response.body).to include(I18n.l(notice.end_at))
+      end
+
+      it "displays edit link when the user is the creator" do
+        get notice_path(notice)
+
+        expect(response.body).to include(edit_notice_path(notice))
+      end
+
+      it "does not display edit link when the user is not the creator" do
+        other_notice = create(:notice)
+
+        get notice_path(other_notice)
+
+        expect(response.body).not_to include(edit_notice_path(other_notice))
+      end
+
+      it "cannot access a restricted notice" do
+        get notice_path(restricted_notice)
+
+        expect(response).to redirect_to notices_path
+      end
+    end
+
+    context "when the user is an admin" do
+      before { sign_in(admin) }
+
+      it "can access a restricted notice" do
+        get notice_path(restricted_notice)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays restricted status" do
+        get notice_path(restricted_notice)
+
+        expect(response.body).to include("管理者のみ")
+      end
+
+      it "displays edit link when an admin is the creator" do
+        get notice_path(restricted_notice)
+
+        expect(response.body).to include(edit_notice_path(restricted_notice))
+      end
+
+      it "does not display edit link when an admin is not the creator" do
+        get notice_path(notice)
+
+        expect(response.body).not_to include(edit_notice_path(notice))
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get notice_path(notice)
+
+        expect(response).to redirect_to new_session_path
+      end
+    end
+  end
 end

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Notices", type: :request do
   let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
   let(:admin) { create(:user, admin: true) }
   let!(:notice) { create(:notice, user: user) }
   let!(:restricted_notice) { create(:notice, user: admin, restricted: true) }
@@ -275,6 +276,144 @@ RSpec.describe "Notices", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         post notices_path, params: {}
+
+        expect(response).to redirect_to new_session_path
+      end
+    end
+  end
+
+  describe "GET /notices/:id/edit" do
+    context "when the user is the creator" do
+      before { sign_in(user) }
+
+      it "responds with HTTP 200 OK" do
+        get edit_notice_path(notice)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not display restricted check box" do
+        get edit_notice_path(notice)
+
+        expect(response.body).not_to include("管理者のみ")
+      end
+
+      it "cannot access a restricted notice and redirects to the index page" do
+        get edit_notice_path(restricted_notice)
+
+        expect(response).to redirect_to notices_path
+      end
+    end
+
+    context "when the user is not the creator" do
+      before { sign_in(other_user) }
+
+      it "redirects to the show page" do
+        get edit_notice_path(notice)
+
+        expect(response).to redirect_to notice_path(notice)
+      end
+    end
+
+    context "when the user is an admin and the creator" do
+      before { sign_in(admin) }
+
+      it "can access a restricted notice" do
+        get edit_notice_path(restricted_notice)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays restricted check box" do
+        get edit_notice_path(restricted_notice)
+
+        expect(response.body).to include("管理者のみ")
+      end
+    end
+
+    context "when the user is an admin but not the creator" do
+      before { sign_in(admin) }
+
+      it "redirects to the show page" do
+        get edit_notice_path(notice)
+
+        expect(response).to redirect_to notice_path(notice)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get edit_notice_path(notice)
+
+        expect(response).to redirect_to new_session_path
+      end
+    end
+  end
+
+  describe "PATCH /notices/:id" do
+    context "when the user is the creator" do
+      before { sign_in(user) }
+
+      it "updates the notice and redirects to the show page with valid params" do
+        patch notice_path(notice),
+          params: { notice: { content: "追記" } }
+
+        expect(notice.reload.content).to eq("追記")
+        expect(response).to redirect_to notice_path(notice)
+      end
+
+      it "does not update the notice and re-renders the edit template with invalid params" do
+        patch notice_path(notice), params: { notice: { title: nil } }
+
+        expect(notice.reload.title).not_to be_nil
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "cannot update a restricted notice and redirects to the index template" do
+        patch notice_path(restricted_notice),
+          params: { notice: { content: "追記" } }
+
+        expect(restricted_notice.reload.content).not_to eq("追記")
+        expect(response).to redirect_to notices_path
+      end
+    end
+
+    context "when the user is not the creator" do
+      before { sign_in(other_user) }
+
+      it "does not update the notice and redirects to the show page" do
+        patch notice_path(notice), params: { notice: { content: "追記" } }
+
+        expect(notice.reload.content).not_to eq("追記")
+        expect(response).to redirect_to notice_path(notice)
+      end
+    end
+
+    context "when the usee is an admin and the creator" do
+      before { sign_in(admin) }
+
+      it "updates the restricted notice and redirects to the show page" do
+        patch notice_path(restricted_notice), params: { notice: { content: "追記" } }
+
+        expect(restricted_notice.reload.content).to eq("追記")
+        expect(response).to redirect_to notice_path(restricted_notice)
+      end
+    end
+
+    context "when the user is an admin but not the creator" do
+      before { sign_in(admin) }
+
+      it "does not update the notice and redirects to the show page" do
+        patch notice_path(notice), params: { notice: { content: "追記" } }
+
+        expect(notice.reload.content).not_to eq("追記")
+        expect(response).to redirect_to notice_path(notice)
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        patch notice_path(notice), params: {}
 
         expect(response).to redirect_to new_session_path
       end


### PR DESCRIPTION
## 変更内容
* NoticesController を作成し、以下のアクションを実装
  * `index` — タスク一覧（preload による N+1 対策済み）
  * `new` — 新規登録（全くの新規 / 親IDを引き継いだ子の登録に対応）
  * `create` — 登録処理（ログインユーザーへの紐付け）
  * `show` — 詳細表示
  * `edit` — 編集（作成者本人のみ）
  * `update` — 更新処理（作成者本人のみ）
* Strong Parameters を実装
* バリデーションエラー時に `unprocessable_entity` を返し、フォームを再表示
* `authorize_edit!` による認可チェックを実装（作成者以外は編集不可）
* `authorize_view!` による認可チェックを実装（restricted お知らせは管理者のみ閲覧・編集可）
* 管理者フラグによるフォーム出し分け（`管理者のみ` チェックボックスの表示制御および `restricted` パラメータの許可）を実装
* 親子構造に対応
  * `root_id` を追加し、関連お知らせを紐づける自己参照関連を実装
  * 関連するお知らせ（子お知らせ）の作成機能を実装
  * 関連するお知らせ一覧を表示するタイムラインを実装
* 以下のビューを作成
  * `index.html.erb`
  * `show.html.erb`
  * `new.html.erb`
  * `edit.html.erb`
  * `_form.html.erb`（new / edit 共用）
  * `_timeline.html.erb`
* Request Spec を追加

## 確認済み
- [x] ブラウザ上でお知らせの参照・作成・更新が動作することを確認
- [x] 親IDを渡した場合に parent_id が引き継がれることを確認
- [x] 詳細画面から関連するお知らせを作成可能なことを確認
- [x] 詳細画面にて関連するお知らせの一覧が表示されていることを確認
- [x] 作成者以外（管理者含む）が編集URLに直アクセスした場合にリダイレクトされることを確認
- [x] 管理者以外が restricted お知らせの詳細・編集URLに直アクセスした場合にリダイレクトされることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

## 補足
* 削除機能（論理削除含む）はこのPRでは実装しない
* 関連タスク・関連お知らせのパーシャルは 今後のPRで追加予定
* ページネーション・検索機能は今後のPRで追加予定

Closes #60