### PR TITLE
Refactor Interaction Timeline

### DIFF
--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,6 +1,6 @@
 class InteractionsController < ApplicationController
   before_action :set_interaction, only: [ :show, :edit, :update ]
-  before_action :require_creator, only: [ :edit, :update ]
+  before_action :authorize_edit!, only: [ :edit, :update ]
 
   def index
     @interactions = Interaction
@@ -9,17 +9,16 @@ class InteractionsController < ApplicationController
   end
 
   def new
-    @interaction = Interaction.new
     @parent_interaction = Interaction.find_by(id: params[:parent_id])
-
-    if @parent_interaction
-      @interaction.parent = @parent_interaction
-      @interaction.customer = @parent_interaction.customer
-    end
+    @interaction = Interaction.new(
+      parent: @parent_interaction,
+      customer: @parent_interaction&.customer
+    )
   end
 
   def create
-    @interaction = Current.user.interactions.new(interaction_params)
+    @interaction = Current.user.interactions.build(interaction_params)
+    @parent_interaction = @interaction.parent
 
     if @interaction.save
       redirect_to @interaction, notice: "応対履歴を登録しました"
@@ -29,8 +28,7 @@ class InteractionsController < ApplicationController
   end
 
   def show
-    root = @interaction.parent || @interaction
-    @timeline = [ root, *root.children ].sort_by(&:occurred_at)
+
   end
 
   def edit
@@ -61,9 +59,9 @@ class InteractionsController < ApplicationController
     )
   end
 
-  def require_creator
-    unless @interaction.user == Current.user
-      redirect_to @interaction, alert: "編集権限がありません"
-    end
+  def authorize_edit!
+    return if @interaction.user == Current.user
+
+    redirect_to @interaction, alert: "編集権限がありません"
   end
 end

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -28,7 +28,7 @@ class InteractionsController < ApplicationController
   end
 
   def show
-
+    @timeline = @interaction.root.thread_interactions.order(:occurred_at)
   end
 
   def edit

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -1,5 +1,6 @@
 class Interaction < ApplicationRecord
   before_validation :assign_root
+  before_validation :set_customer_from_parent
   after_create :assign_self_as_root
 
   belongs_to :customer
@@ -35,6 +36,10 @@ class Interaction < ApplicationRecord
     return unless parent
 
     self.root = parent.root || parent
+  end
+
+  def set_customer_from_parent
+    self.customer ||= parent&.customer
   end
 
   def assign_self_as_root

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -1,9 +1,15 @@
 class Interaction < ApplicationRecord
+  before_validation :assign_root
+  after_create :assign_self_as_root
+
   belongs_to :customer
   belongs_to :user
 
   belongs_to :parent, class_name: "Interaction", optional: true
   has_many :children, class_name: "Interaction", foreign_key: "parent_id"
+
+  belongs_to :root, class_name: "Interaction", optional: true
+  has_many :thread_interactions, class_name: "Interaction", foreign_key: :root_id, dependent: :nullify
 
   # add associations after other models are created
   # has_many :notices
@@ -22,4 +28,16 @@ class Interaction < ApplicationRecord
   validates :request_content, presence: true
   validates :response_result, presence: true
   validates :completed, inclusion: { in: [ true, false ] }
+
+  private
+
+  def assign_root
+    return unless parent
+
+    self.root = parent.root || parent
+  end
+
+  def assign_self_as_root
+    update_column(:root_id, id) if root_id.nil?
+  end
 end

--- a/app/views/interactions/_timeline.html.erb
+++ b/app/views/interactions/_timeline.html.erb
@@ -6,12 +6,12 @@
         <% if item == current_item %>
           <span class="font-medium">
             <%= l item.occurred_at %>
-            <%= truncate(item.request_content, length: 30) %>
+            <%= truncate(item.response_result, length: 30) %>
             <span class="text-blue-600">★ 現在</span>
           </span>
         <% else %>
           <%= link_to interaction_path(item), class: "text-gray-700 hover:text-blue-600" do %>
-            <%= l item.occurred_at %> <%= truncate(item.request_content, length: 40) %>
+            <%= l item.occurred_at %> <%= truncate(item.response_result, length: 40) %>
           <% end %>
           <span class="ml-2 text-xs <%= item.completed? ? 'text-gray-600' : 'text-blue-600' %>">
             <%= item.completed? ? "完了" : "対応中" %>
@@ -21,7 +21,7 @@
     <% end %>
   </div>
   <div class="mt-4">
-    <%= link_to "続きの応対履歴を作成",
+    <%= link_to "関連応対履歴を作成",
           new_interaction_path(parent_id: current_item.id),
           class: "text-sm px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
   </div>

--- a/app/views/interactions/new.html.erb
+++ b/app/views/interactions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen bg-gray-50 py-8">
   <div class="max-w-2xl mx-auto px-4">
     <div class="mb-4">
-      <% if @parent_interaction %>
+      <% if @interaction.parent %>
         <%= link_to "← 親の応対履歴に戻る", interaction_path(@parent_interaction),
               class: "text-blue-600 hover:underline text-sm" %>
       <% else %>
@@ -12,11 +12,7 @@
     <div class="bg-white rounded-lg shadow-lg p-6">
       <div class="border-b-4 border-blue-500 pb-4 mb-6">
         <h1 class="text-2xl font-bold">
-          <% if @parent_interaction %>
-            続きの応対履歴を登録
-          <% else %>
-            応対履歴を新規登録
-          <% end %>
+          <%= @parent_interaction ? "関連応対履歴を登録" : "応対履歴を新規登録" %>
         </h1>
       </div>
       <%= render "form", interaction: @interaction %>

--- a/app/views/interactions/show.html.erb
+++ b/app/views/interactions/show.html.erb
@@ -1,13 +1,8 @@
 <div class="min-h-screen bg-gray-50 py-8">
   <div class="max-w-4xl mx-auto px-4">
     <div class="mb-4">
-      <% if @interaction.parent %>
-        <%= link_to "← 親の応対履歴に戻る", interaction_path(@interaction.parent),
-              class: "text-blue-600 hover:underline text-sm" %>
-      <% else %>
-        <%= link_to "← 一覧に戻る", interactions_path,
-              class: "text-blue-600 hover:underline text-sm" %>
-      <% end %>
+      <%= link_to "← 一覧に戻る", interactions_path,
+            class: "text-blue-600 hover:underline text-sm" %>
     </div>
     <div class="bg-white rounded-lg shadow-lg p-6">
       <div class="border-b-4 border-blue-500 pb-4 mb-6">

--- a/db/migrate/20260524014132_add_root_to_interactions.rb
+++ b/db/migrate/20260524014132_add_root_to_interactions.rb
@@ -1,0 +1,7 @@
+class AddRootToInteractions < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :interactions,
+              :root,
+              foreign_key: { to_table: :interactions }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_23_134727) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_24_014132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -85,11 +85,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_23_134727) do
     t.bigint "parent_id"
     t.text "request_content", null: false
     t.text "response_result", null: false
+    t.bigint "root_id"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["channel"], name: "index_interactions_on_channel"
     t.index ["customer_id", "occurred_at"], name: "index_interactions_on_customer_id_and_occurred_at"
     t.index ["parent_id"], name: "index_interactions_on_parent_id"
+    t.index ["root_id"], name: "index_interactions_on_root_id"
     t.index ["user_id", "occurred_at"], name: "index_interactions_on_user_id_and_occurred_at"
   end
 
@@ -174,6 +176,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_23_134727) do
   add_foreign_key "interaction_notices", "notices"
   add_foreign_key "interactions", "customers"
   add_foreign_key "interactions", "interactions", column: "parent_id"
+  add_foreign_key "interactions", "interactions", column: "root_id"
   add_foreign_key "interactions", "users"
   add_foreign_key "notices", "notices", column: "parent_id"
   add_foreign_key "notices", "notices", column: "root_id"

--- a/spec/requests/interactions_parent_child_spec.rb
+++ b/spec/requests/interactions_parent_child_spec.rb
@@ -1,0 +1,225 @@
+require "rails_helper"
+
+RSpec.describe "Interactions parent-child", type: :request do
+  let(:user)  { create(:user) }
+  let(:admin) { create(:user, admin: true) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /interactions/:id - back link" do
+    before { sign_in(user) }
+
+    context "when the interaction has no parent" do
+      let(:interaction) { create(:interaction, user: user) }
+
+      it "links back to the index" do
+        get interaction_path(interaction)
+
+        expect(response.body).to include(interactions_path)
+        expect(response.body).to include("一覧に戻る")
+      end
+    end
+
+    context "when the interaction has a parent" do
+      let(:parent) { create(:interaction, user: user) }
+      let(:child) { create(:interaction, user: user, parent: parent) }
+
+      it "links back to the index" do
+        get interaction_path(child)
+
+        expect(response.body).to include(interactions_path)
+        expect(response.body).to include("一覧に戻る")
+      end
+    end
+  end
+
+  describe "/GET /interactions/:id - timeline" do
+    before { sign_in(user) }
+
+    context "when the interaction has no children" do
+      let(:interaction) { create(:interaction, user: user) }
+
+      it "renders a timeline including only itself" do
+        get interaction_path(interaction)
+
+        expect(response.body).to include(interaction.response_result.truncate(30))
+      end
+    end
+
+    context "when viewing a parent interaction" do
+      let(:parent) { create(:interaction, user: user) }
+      let!(:child) { create(:interaction, user: user, parent: parent) }
+      let!(:grandchild) { create(:interaction, user: user, parent: child) }
+
+      it "displays all children in the timeline" do
+        get interaction_path(parent)
+
+        expect(response.body).to include(child.response_result.truncate(40))
+        expect(response.body).to include(grandchild.response_result.truncate(40))
+      end
+    end
+
+    context "when viewing a child interaction" do
+      let(:parent) { create(:interaction, user: user) }
+      let!(:child) { create(:interaction, user: user, parent: parent) }
+      let!(:grandchild) { create(:interaction, user: user, parent: child) }
+
+      it "displays the parent in the timeline" do
+        get interaction_path(child)
+
+        expect(response.body).to include(parent.response_result.truncate(40))
+      end
+
+      it "displays sibling interactions in the timeline" do
+        get interaction_path(child)
+
+        expect(response.body).to include(grandchild.response_result.truncate(40))
+      end
+    end
+
+    context "when the interaction has descendants" do
+      let(:parent) { create(:interaction, user: user) }
+      let!(:child) { create(:interaction, user: user, parent: parent) }
+
+      it "marks the currently viewed interaction with ★ 現在" do
+        get interaction_path(parent)
+
+        expect(response.body).to include("★ 現在")
+      end
+
+      it "links to other timeline items" do
+        get interaction_path(parent)
+
+        expect(response.body).to include(interaction_path(child))
+      end
+
+      it "does not link to the current interaction in the timeline" do
+        get interaction_path(child)
+
+        expect(response.body).not_to include(%(href="#{interaction_path(child)}"))
+      end
+    end
+
+    context "when the interaction belongs to a hierarchy" do
+      let!(:parent) { create(:interaction, user: user, occurred_at: 2.hours.ago) }
+      let!(:child) do
+        create(
+          :interaction,
+          user: user,
+          parent: parent,
+          request_content: "子応対履歴",
+          response_result: "子応対履歴の詳細",
+          occurred_at: 1.hour.ago
+        )
+      end
+
+      let!(:grandchild) do
+        create(
+          :interaction,
+          user: user,
+          parent: child,
+          request_content: "孫応対履歴",
+          response_result: "孫応対履歴の詳細",
+          occurred_at: 30.minutes.ago
+        )
+      end
+
+      it "displays items in chronological order" do
+        get interaction_path(parent)
+
+        expect(response.body).to match(/#{child.response_result}.*#{grandchild.response_result}/m)
+      end
+    end
+
+    context "when the interaction can be followed up" do
+      let(:interaction) { create(:interaction, user: user) }
+
+      it "includes a link to create a child with parent_id" do
+        get interaction_path(interaction)
+        expect(response.body).to include(new_interaction_path(parent_id: interaction.id))
+      end
+    end
+  end
+
+  describe "GET /interactions/new with parent_id" do
+    before { sign_in(user) }
+
+    context "when creating a follow-up interaction from an existing interaction" do
+      let(:parent) { create(:interaction, user: user) }
+
+      it "responds with HTTP 200 OK" do
+        get new_interaction_path(parent_id: parent.id)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "includes the parent interaction id in the form" do
+        get new_interaction_path(parent_id: parent.id)
+
+        expect(response.body).to include(parent.id.to_s)
+      end
+    end
+
+    context "when creating a follow-up interaction with a non-existent parent interaction" do
+      it "responds with HTTP 200 OK and ignores the invalid parent_id" do
+        get new_interaction_path(parent_id: 0)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "POST /interactions with parent_id" do
+    let!(:parent) { create(:interaction, user: user) }
+    let(:child_params) do
+      {
+        interaction: {
+          request_content: "子応対履歴",
+          response_result: "子の応対履歴の詳細",
+          completed: false,
+          channel: "phone",
+          occurred_at: 1.hour.ago,
+          parent_id: parent.id
+        }
+      }
+    end
+
+    context "when creating a follow-up interaction" do
+      before { sign_in(user) }
+
+      it "creates a interaction and associates it with the parent" do
+        expect {
+          post interactions_path, params: child_params
+        }.to change(Interaction, :count).by(1)
+
+        expect(Interaction.last.parent).to eq(parent)
+      end
+
+      it "redirects to the child interaction page" do
+        post interactions_path, params: child_params
+
+        expect(response).to redirect_to interaction_path(Interaction.last)
+      end
+    end
+
+    context "when creating a root interaction" do
+      before { sign_in(user) }
+
+      it "creates a interaction without a parent" do
+        post interactions_path, params: {
+          interaction: {
+            request_content: "ルート応対履歴",
+            response_result: "ルート応対履歴の詳細",
+            completed: false,
+            channel: "phone",
+            occurred_at: 1.hour.ago
+          }
+        }
+
+        expect(Interaction.last.parent).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容
* 親子構造に対応
  * `root_id` を追加し、関連応対履歴を紐づける自己参照関連を実装
  * 関連する応対履歴の取得ロジックを変更
  * 関連する応対履歴（子応対履歴）の作成機能を改修
  * 関連する応対履歴一覧を表示するタイムラインを改修
* 以下のビューを編集
  * `_timeline.html.erb`
  * `new.html.erb`
  * `show.html.erb`
* Request Spec を追加

## 確認済み
- [x] 親IDを渡した場合に parent_id が引き継がれることを確認
- [x] 詳細画面から関連する応対履歴を作成可能なことを確認
- [x] 詳細画面にて関連する応対履歴の一覧が表示されていることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

Closes #70