### PR TITLE
Implement Interaction-Notice Integration

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -18,6 +18,10 @@ class NoticesController < ApplicationController
     @parent_notice = @notice.parent
 
     if @notice.save
+      if params[:interaction_id].present?
+        @notice.interactions << Interaction.find(params[:interaction_id])
+      end
+
       redirect_to @notice, notice: "お知らせを更新しました"
     else
       render :new, status: :unprocessable_entity

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -12,8 +12,8 @@ class Interaction < ApplicationRecord
   belongs_to :root, class_name: "Interaction", optional: true
   has_many :thread_interactions, class_name: "Interaction", foreign_key: :root_id, dependent: :nullify
 
-  # add associations after other models are created
-  # has_many :notices
+  has_many :interaction_notices
+  has_many :notices, through: :interaction_notices
   # has_many :tasks
 
   enum :channel, {

--- a/app/models/interaction_notice.rb
+++ b/app/models/interaction_notice.rb
@@ -1,0 +1,4 @@
+class InteractionNotice < ApplicationRecord
+  belongs_to :interaction
+  belongs_to :notice
+end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -10,8 +10,8 @@ class Notice < ApplicationRecord
   belongs_to :root, class_name: "Notice", optional: true
   has_many :thread_notices, class_name: "Notice", foreign_key: :root_id, dependent: :nullify
 
-  # add associations after other models are created
-  # has_many :interactions
+  has_many :interaction_notices
+  has_many :interactions, through: :interaction_notices
   # has_many :tasks
 
   enum :level, {

--- a/app/views/interactions/_related_notices.html.erb
+++ b/app/views/interactions/_related_notices.html.erb
@@ -1,0 +1,26 @@
+<div class="mb-6 border-t-4 border-yellow-500 pt-6">
+  <h2 class="text-lg font-semibold mb-3">関連お知らせ</h2>
+  <% notices = interaction.notices %>
+  <% if notices.any? %>
+    <ul class="space-y-2">
+      <% notices.each do |notice| %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
+          <span class="text-gray-600">お知らせ</span>
+          <%= link_to notice.content, notice_path(notice), class: "flex-1 hover:text-blue-600" %>
+          <span class="text-xs text-gray-500">
+            <%= l notice.start_at %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <div class="text-sm text-gray-500">
+      まだ関連するお知らせは登録されていません。
+    </div>
+  <% end %>
+  <div class="mt-4">
+    <%= link_to "関連お知らせを作成",
+        new_notice_path(interaction_id: interaction.id),
+        class: "text-sm px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600" %>
+  </div>
+</div>

--- a/app/views/interactions/show.html.erb
+++ b/app/views/interactions/show.html.erb
@@ -53,6 +53,7 @@
       </div>
 
       <%= render "timeline", timeline: @timeline, current_item: @interaction %>
+      <%= render "related_notices", interaction: @interaction %>
 
       <% if @interaction.user == Current.user %>
         <div class="mt-6 flex justify-end border-t pt-4">

--- a/app/views/notices/_form.html.erb
+++ b/app/views/notices/_form.html.erb
@@ -12,6 +12,7 @@
     </div>
   <% end %>
   <%= f.hidden_field :parent_id %>
+  <%= hidden_field_tag :interaction_id, params[:interaction_id] if params[:interaction_id].present? %>
   <div>
     <%= f.label :title, "件名", class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_field :title,

--- a/app/views/notices/_related_interactions.html.erb
+++ b/app/views/notices/_related_interactions.html.erb
@@ -1,0 +1,21 @@
+<div class="mb-6 border-t-4 border-blue-500 pt-6">
+  <h2 class="text-lg font-semibold mb-3">関連応対履歴</h2>
+  <% interactions = notice.interactions %>
+  <% if interactions.any? %>
+    <ul class="space-y-2">
+      <% interactions.each do |interaction| %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
+          <span class="text-gray-600">応対履歴</span>
+          <%= link_to interaction.request_content, interaction_path(interaction), class: "flex-1 hover:text-blue-600" %>
+          <span class="text-xs text-gray-500">
+            <%= l interaction.occurred_at %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <div class="text-sm text-gray-500">
+      まだ関連応対履歴は登録されていません。
+    </div>
+  <% end %>
+</div>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -49,6 +49,7 @@
       </div>
 
       <%= render "timeline", timeline: @timeline, current_item: @notice %>
+      <%= render "related_interactions", notice: @notice %>
 
       <% if @notice.user == Current.user %>
         <div class="mt-6 flex justify-end border-t pt-4">

--- a/db/migrate/20260525134459_create_interaction_notices.rb
+++ b/db/migrate/20260525134459_create_interaction_notices.rb
@@ -1,0 +1,12 @@
+class CreateInteractionNotices < ActiveRecord::Migration[8.1]
+  def change
+    create_table :interaction_notices do |t|
+      t.references :interaction, null: false, foreign_key: true
+      t.references :notice, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :interaction_notices, [:interaction_id, :notice_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_24_090829) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_25_134459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -23,6 +23,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_090829) do
     t.datetime "updated_at", null: false
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["uuid"], name: "index_customers_on_uuid", unique: true
+  end
+
+  create_table "interaction_notices", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "interaction_id", null: false
+    t.bigint "notice_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["interaction_id", "notice_id"], name: "index_interaction_notices_on_interaction_id_and_notice_id", unique: true
+    t.index ["interaction_id"], name: "index_interaction_notices_on_interaction_id"
+    t.index ["notice_id"], name: "index_interaction_notices_on_notice_id"
   end
 
   create_table "interactions", force: :cascade do |t|
@@ -107,6 +117,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_090829) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "interaction_notices", "interactions"
+  add_foreign_key "interaction_notices", "notices"
   add_foreign_key "interactions", "customers"
   add_foreign_key "interactions", "interactions", column: "parent_id"
   add_foreign_key "interactions", "interactions", column: "root_id"

--- a/spec/factories/interaction_notices.rb
+++ b/spec/factories/interaction_notices.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :interaction_notice do
+    association :interaction
+    association :notice
+  end
+end

--- a/spec/models/interaction_notice_spec.rb
+++ b/spec/models/interaction_notice_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe InteractionNotice, type: :model do
+  describe 'associations' do
+    it 'belongs to interaction' do
+      expect(described_class.reflect_on_association(:interaction).macro)
+        .to eq(:belongs_to)
+    end
+
+    it 'belongs to notice' do
+      expect(described_class.reflect_on_association(:notice).macro)
+        .to eq(:belongs_to)
+    end
+  end
+end

--- a/spec/requests/notice_interactions_spec.rb
+++ b/spec/requests/notice_interactions_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "Notice Interactions", type: :request do
+  let(:user) { create(:user) }
+  let(:interaction) { create(:interaction) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  before { sign_in(user) }
+
+  describe "GET/notices/new with interaction_id" do
+    it "passes interaction_id to the form" do
+      get new_notice_path(interaction_id: interaction.id)
+
+      expect(response.body).to include(interaction.id.to_s)
+    end
+  end
+
+  describe "POST /notices with interaction_id" do
+    let(:valid_params) do
+      {
+        notice: {
+          title: "テストお知らせ",
+          content: "テストお知らせの詳細",
+          level: "normal",
+          start_at: 1.day.from_now,
+          end_at: 7.days.from_now
+        },
+        interaction_id: interaction.id
+      }
+    end
+
+    it "links the notice to the interaction" do
+      post notices_path, params: valid_params
+
+      expect(Notice.last.interactions).to include(interaction)
+    end
+
+    it "redirects to the created notice" do
+      post notices_path, params: valid_params
+
+      expect(response).to redirect_to(notice_path(Notice.last))
+    end
+
+    it "does not link when interaction_id is absent" do
+      post notices_path, params: valid_params.except(:interaction_id)
+
+      expect(Notice.last.interactions).to be_empty
+    end
+
+    it "does not link when notice save fails" do
+      invalid_params = valid_params.deep_merge(notice: { title: "" })
+
+      expect {
+        post notices_path, params: invalid_params
+      }.not_to change(Notice, :count)
+    end
+  end
+
+  describe "GET /notices/:id - related interactions display" do
+    let(:notice) { create(:notice, user: user) }
+
+    context "when the notice has linked interactions" do
+      before { notice.interactions << interaction }
+
+      it "displays the linked interaction" do
+        get notice_path(notice)
+
+        expect(response.body).to include(interaction.request_content)
+      end
+    end
+
+    context "when the notice has no linked interactions" do
+      it "displays the empty message" do
+        get notice_path(notice)
+
+        expect(response.body).to include("まだ関連応対履歴は登録されていません")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容
* NoticeとInteractionの多対多の紐付けを実装
  * `interaction_notices` 中間テーブルを通じた関連を追加
  * お知らせ登録時に `interaction_id` を受け取り、自動で紐付ける機能を実装
* 以下のビューを編集
  * `notices/show.html.erb`
    * 関連応対履歴一覧を追加
  * `interactions/show.html.erb`
    * 関連お知らせ一覧を追加
  * お知らせ登録フォーム
    * `interaction_id` の hidden field を追加
* Request Spec を追加
  * `spec/requests/notice_interactions_spec.rb`

## 確認済み
- [x] 応対履歴詳細画面から関連お知らせを作成可能なことを確認
- [x] 作成時に `interaction_id` が引き継がれ、紐付けが保存されることを確認
- [x] お知らせ詳細画面にて関連応対履歴の一覧が表示されていることを確認
- [x] 応対履歴詳細画面にて関連お知らせの一覧が表示されていることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

Closes #76