### PR TITLE
Implement Interaction-Task Integration

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,6 +17,10 @@ class TasksController < ApplicationController
     @parent_task = @task.parent
 
     if @task.save
+      if params[:interaction_id].present?
+        @task.interactions << Interaction.find(params[:interaction_id])
+      end
+
       redirect_to @task, notice: "タスクを登録しました"
     else
       render :new, status: :unprocessable_entity

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -14,7 +14,9 @@ class Interaction < ApplicationRecord
 
   has_many :interaction_notices
   has_many :notices, through: :interaction_notices
-  # has_many :tasks
+
+  has_many :interaction_tasks
+  has_many :tasks, through: :interaction_tasks
 
   enum :channel, {
     phone: "phone",

--- a/app/models/interaction_task.rb
+++ b/app/models/interaction_task.rb
@@ -1,0 +1,4 @@
+class InteractionTask < ApplicationRecord
+  belongs_to :interaction
+  belongs_to :task
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -10,9 +10,11 @@ class Task < ApplicationRecord
   belongs_to :root, class_name: "Task", optional: true
   has_many :thread_tasks, class_name: "Task", foreign_key: :root_id, dependent: :nullify
 
-  # add associations after other models are created
   has_many :task_assignments
   has_many :assigned_users, through: :task_assignments, source: :user
+
+  has_many :interaction_tasks
+  has_many :interactions, through: :interaction_tasks
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :description, presence: true, length: { maximum: 2000 }

--- a/app/views/interactions/_related_tasks.html.erb
+++ b/app/views/interactions/_related_tasks.html.erb
@@ -1,0 +1,26 @@
+<div class="mb-6 border-t-4 border-purple-500 pt-6">
+  <h2 class="text-lg font-semibold mb-3">関連タスク</h2>
+  <% tasks = interaction.tasks %>
+  <% if tasks.any? %>
+    <ul class="space-y-2">
+      <% tasks.each do |task| %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
+          <span class="text-gray-600">タスク</span>
+          <%= link_to task.title, task_path(task), class: "flex-1 hover:text-blue-600" %>
+          <span class="text-xs text-gray-500">
+            <%= l task.due_at %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <div class="text-sm text-gray-500">
+      まだ関連するタスクは登録されていません。
+    </div>
+  <% end %>
+  <div class="mt-4">
+    <%= link_to "関連タスクを作成",
+        new_task_path(interaction_id: interaction.id),
+        class: "text-sm px-4 py-2 bg-purple-500 text-white rounded hover:bg-yellow-600" %>
+  </div>
+</div>

--- a/app/views/interactions/show.html.erb
+++ b/app/views/interactions/show.html.erb
@@ -54,6 +54,7 @@
 
       <%= render "timeline", timeline: @timeline, current_item: @interaction %>
       <%= render "related_notices", interaction: @interaction %>
+      <%= render "related_tasks", interaction: @interaction %>
 
       <% if @interaction.user == Current.user %>
         <div class="mt-6 flex justify-end border-t pt-4">

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -12,6 +12,7 @@
     </div>
   <% end %>
   <%= f.hidden_field :parent_id %>
+  <%= hidden_field_tag :interaction_id, params[:interaction_id] if params[:interaction_id].present? %>
   <div>
     <%= f.label :title, "件名", class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_field :title,

--- a/app/views/tasks/_related_interactions.html.erb
+++ b/app/views/tasks/_related_interactions.html.erb
@@ -1,0 +1,21 @@
+<div class="mb-6 border-t-4 border-purple-500 pt-6">
+  <h2 class="text-lg font-semibold mb-3">関連応対履歴</h2>
+  <% interactions = task.interactions %>
+  <% if interactions.any? %>
+    <ul class="space-y-2">
+      <% interactions.each do |interaction| %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
+          <span class="text-gray-600">応対履歴</span>
+          <%= link_to interaction.request_content, interaction_path(interaction), class: "flex-1 hover:text-blue-600" %>
+          <span class="text-xs text-gray-500">
+            <%= l interaction.occurred_at %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <div class="text-sm text-gray-500">
+      まだ関連応対履歴は登録されていません。
+    </div>
+  <% end %>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -35,6 +35,7 @@
       </div>
 
       <%= render "timeline", timeline: @timeline, current_item: @task %>
+      <%= render "related_interactions", task: @task %>
 
       <% if @task.user == Current.user %>
         <div class="mt-6 flex justify-end border-t pt-4">

--- a/db/migrate/20260526224507_create_interaction_tasks.rb
+++ b/db/migrate/20260526224507_create_interaction_tasks.rb
@@ -1,0 +1,12 @@
+class CreateInteractionTasks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :interaction_tasks do |t|
+      t.references :interaction, null: false, foreign_key: true
+      t.references :task, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :interaction_tasks, [:interaction_id, :task_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_134459) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_224507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -33,6 +33,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_134459) do
     t.index ["interaction_id", "notice_id"], name: "index_interaction_notices_on_interaction_id_and_notice_id", unique: true
     t.index ["interaction_id"], name: "index_interaction_notices_on_interaction_id"
     t.index ["notice_id"], name: "index_interaction_notices_on_notice_id"
+  end
+
+  create_table "interaction_tasks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "interaction_id", null: false
+    t.bigint "task_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["interaction_id", "task_id"], name: "index_interaction_tasks_on_interaction_id_and_task_id", unique: true
+    t.index ["interaction_id"], name: "index_interaction_tasks_on_interaction_id"
+    t.index ["task_id"], name: "index_interaction_tasks_on_task_id"
   end
 
   create_table "interactions", force: :cascade do |t|
@@ -119,6 +129,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_134459) do
 
   add_foreign_key "interaction_notices", "interactions"
   add_foreign_key "interaction_notices", "notices"
+  add_foreign_key "interaction_tasks", "interactions"
+  add_foreign_key "interaction_tasks", "tasks"
   add_foreign_key "interactions", "customers"
   add_foreign_key "interactions", "interactions", column: "parent_id"
   add_foreign_key "interactions", "interactions", column: "root_id"

--- a/spec/factories/interaction_tasks.rb
+++ b/spec/factories/interaction_tasks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :interaction_task do
+    association :interaction
+    association :task
+  end
+end

--- a/spec/models/interaction_task_spec.rb
+++ b/spec/models/interaction_task_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe InteractionTask, type: :model do
+  describe 'associations' do
+    it 'belongs to interaction' do
+      expect(described_class.reflect_on_association(:interaction).macro)
+        .to eq(:belongs_to)
+    end
+
+    it 'belongs to task' do
+      expect(described_class.reflect_on_association(:task).macro)
+        .to eq(:belongs_to)
+    end
+  end
+end

--- a/spec/requests/task_interactions_spec.rb
+++ b/spec/requests/task_interactions_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Task Interactions", type: :request do
+  let(:user) { create(:user) }
+  let(:interaction) { create(:interaction) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  before { sign_in(user) }
+
+  describe "GET/tasks/new with interaction_id" do
+    it "passes interaction_id to the form" do
+      get new_task_path(interaction_id: interaction.id)
+
+      expect(response.body).to include(interaction.id.to_s)
+    end
+  end
+
+  describe "POST /tasks with interaction_id" do
+    let(:valid_params) do
+      {
+        task: {
+          title: "テストタスク",
+          description: "テストタスクの詳細",
+          restricted: false,
+          due_at: 7.days.from_now
+        },
+        interaction_id: interaction.id
+      }
+    end
+
+    it "links the task to the interaction" do
+      post tasks_path, params: valid_params
+
+      expect(Task.last.interactions).to include(interaction)
+    end
+
+    it "redirects to the created task" do
+      post tasks_path, params: valid_params
+
+      expect(response).to redirect_to(task_path(Task.last))
+    end
+
+    it "does not link when interaction_id is absent" do
+      post tasks_path, params: valid_params.except(:interaction_id)
+
+      expect(Task.last.interactions).to be_empty
+    end
+
+    it "does not link when task save fails" do
+      invalid_params = valid_params.deep_merge(task: { title: "" })
+
+      expect {
+        post tasks_path, params: invalid_params
+      }.not_to change(Task, :count)
+    end
+  end
+
+  describe "GET /tasks/:id - related interactions display" do
+    let(:task) { create(:task, user: user) }
+
+    context "when the task has linked interactions" do
+      before { task.interactions << interaction }
+
+      it "displays the linked interaction" do
+        get task_path(task)
+
+        expect(response.body).to include(interaction.request_content)
+      end
+    end
+
+    context "when the task has no linked interactions" do
+      it "displays the empty message" do
+        get task_path(task)
+
+        expect(response.body).to include("まだ関連応対履歴は登録されていません")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容
* Task とInteractionの多対多の紐付けを実装
  * `interaction_tasks` 中間テーブルを通じた関連を追加
  * お知らせ登録時に `interaction_id` を受け取り、自動で紐付ける機能を実装
* 以下のビューを編集
  * `tasks/show.html.erb`
    * 関連応対履歴一覧を追加
  * `interactions/show.html.erb`
    * 関連タスク一覧を追加
  * タスク登録フォーム
    * `interaction_id` の hidden field を追加
* Request Spec を追加
  * `spec/requests/task_interactions_spec.rb`

## 確認済み
- [x] 応対履歴詳細画面から関連タスクを作成可能なことを確認
- [x] 作成時に `interaction_id` が引き継がれ、紐付けが保存されることを確認
- [x] タスク詳細画面にて関連応対履歴の一覧が表示されていることを確認
- [x] 応対履歴詳細画面にて関連タスクの一覧が表示されていることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

Closes #78
