### PR TITLE
Implement Notice-Task Integration

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -21,6 +21,10 @@ class TasksController < ApplicationController
         @task.interactions << Interaction.find(params[:interaction_id])
       end
 
+      if params[:notice_id].present?
+        @task.notices << Notice.find(params[:notice_id])
+      end
+
       redirect_to @task, notice: "タスクを登録しました"
     else
       render :new, status: :unprocessable_entity

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -12,7 +12,9 @@ class Notice < ApplicationRecord
 
   has_many :interaction_notices
   has_many :interactions, through: :interaction_notices
-  # has_many :tasks
+
+  has_many :notice_tasks
+  has_many :tasks, through: :notice_tasks
 
   enum :level, {
     important: "important",

--- a/app/models/notice_task.rb
+++ b/app/models/notice_task.rb
@@ -1,0 +1,4 @@
+class NoticeTask < ApplicationRecord
+  belongs_to :notice
+  belongs_to :task
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,6 +16,9 @@ class Task < ApplicationRecord
   has_many :interaction_tasks
   has_many :interactions, through: :interaction_tasks
 
+  has_many :notice_tasks
+  has_many :notices, through: :notice_tasks
+
   validates :title, presence: true, length: { maximum: 50 }
   validates :description, presence: true, length: { maximum: 2000 }
   validates :restricted, inclusion: { in: [ true, false ] }

--- a/app/views/notices/_related_tasks.html.erb
+++ b/app/views/notices/_related_tasks.html.erb
@@ -1,0 +1,26 @@
+<div class="mb-6 border-t-4 border-purple-500 pt-6">
+  <h2 class="text-lg font-semibold mb-3">関連タスク</h2>
+  <% tasks = notice.tasks %>
+  <% if tasks.any? %>
+    <ul class="space-y-2">
+      <% tasks.each do |task| %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
+          <span class="text-gray-600">タスク</span>
+          <%= link_to task.title, task_path(task), class: "flex-1 hover:text-blue-600" %>
+          <span class="text-xs text-gray-500">
+            <%= l task.due_at %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <div class="text-sm text-gray-500">
+      まだ関連するタスクは登録されていません。
+    </div>
+  <% end %>
+  <div class="mt-4">
+    <%= link_to "関連タスクを作成",
+        new_task_path(notice_id: notice.id),
+        class: "text-sm px-4 py-2 bg-purple-500 text-white rounded hover:bg-yellow-600" %>
+  </div>
+</div>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -50,6 +50,7 @@
 
       <%= render "timeline", timeline: @timeline, current_item: @notice %>
       <%= render "related_interactions", notice: @notice %>
+      <%= render "related_tasks", notice: @notice %>
 
       <% if @notice.user == Current.user %>
         <div class="mt-6 flex justify-end border-t pt-4">

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -13,6 +13,7 @@
   <% end %>
   <%= f.hidden_field :parent_id %>
   <%= hidden_field_tag :interaction_id, params[:interaction_id] if params[:interaction_id].present? %>
+  <%= hidden_field_tag :notice_id, params[:notice_id] if params[:notice_id].present? %>
   <div>
     <%= f.label :title, "件名", class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_field :title,

--- a/app/views/tasks/_related_notices.html.erb
+++ b/app/views/tasks/_related_notices.html.erb
@@ -1,0 +1,21 @@
+<div class="mb-6 border-t-4 border-yellow-500 pt-6">
+  <h2 class="text-lg font-semibold mb-3">関連お知らせ</h2>
+  <% notices = task.notices %>
+  <% if notices.any? %>
+    <ul class="space-y-2">
+      <% notices.each do |notice| %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
+          <span class="text-gray-600">お知らせ</span>
+          <%= link_to notice.content, notice_path(notice), class: "flex-1 hover:text-blue-600" %>
+          <span class="text-xs text-gray-500">
+            <%= l notice.start_at %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <div class="text-sm text-gray-500">
+      まだ関連お知らせは登録されていません。
+    </div>
+  <% end %>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -36,6 +36,7 @@
 
       <%= render "timeline", timeline: @timeline, current_item: @task %>
       <%= render "related_interactions", task: @task %>
+      <%= render "related_notices", task: @task %>
 
       <% if @task.user == Current.user %>
         <div class="mt-6 flex justify-end border-t pt-4">

--- a/db/migrate/20260527134402_create_notice_tasks.rb
+++ b/db/migrate/20260527134402_create_notice_tasks.rb
@@ -1,0 +1,11 @@
+class CreateNoticeTasks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :notice_tasks do |t|
+      t.references :notice, null: false, foreign_key: true
+      t.references :task, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :notice_tasks, [:notice_id, :task_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_224507) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_134402) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -62,6 +62,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_224507) do
     t.index ["parent_id"], name: "index_interactions_on_parent_id"
     t.index ["root_id"], name: "index_interactions_on_root_id"
     t.index ["user_id", "occurred_at"], name: "index_interactions_on_user_id_and_occurred_at"
+  end
+
+  create_table "notice_tasks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "notice_id", null: false
+    t.bigint "task_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notice_id", "task_id"], name: "index_notice_tasks_on_notice_id_and_task_id", unique: true
+    t.index ["notice_id"], name: "index_notice_tasks_on_notice_id"
+    t.index ["task_id"], name: "index_notice_tasks_on_task_id"
   end
 
   create_table "notices", force: :cascade do |t|
@@ -135,6 +145,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_224507) do
   add_foreign_key "interactions", "interactions", column: "parent_id"
   add_foreign_key "interactions", "interactions", column: "root_id"
   add_foreign_key "interactions", "users"
+  add_foreign_key "notice_tasks", "notices"
+  add_foreign_key "notice_tasks", "tasks"
   add_foreign_key "notices", "notices", column: "parent_id"
   add_foreign_key "notices", "notices", column: "root_id"
   add_foreign_key "notices", "users"

--- a/spec/factories/notice_tasks.rb
+++ b/spec/factories/notice_tasks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :notice_task do
+    association :notice
+    association :task
+  end
+end

--- a/spec/models/notice_task_spec.rb
+++ b/spec/models/notice_task_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe NoticeTask, type: :model do
+  describe "associations" do
+    it 'belongs to notice' do
+      expect(described_class.reflect_on_association(:notice).macro)
+        .to eq(:belongs_to)
+    end
+
+    it 'belongs to task' do
+      expect(described_class.reflect_on_association(:task).macro)
+        .to eq(:belongs_to)
+    end
+  end
+end

--- a/spec/requests/task_notices_spec.rb
+++ b/spec/requests/task_notices_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Task Notices", type: :request do
+  let(:user) { create(:user) }
+  let(:notice) { create(:notice) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  before { sign_in(user) }
+
+  describe "GET/tasks/new with notice_id" do
+    it "passes notice_id to the form" do
+      get new_task_path(notice_id: notice.id)
+
+      expect(response.body).to include(notice.id.to_s)
+    end
+  end
+
+  describe "POST /tasks with notice_id" do
+    let(:valid_params) do
+      {
+        task: {
+          title: "テストタスク",
+          description: "テストタスクの詳細",
+          restricted: false,
+          due_at: 7.days.from_now
+        },
+        notice_id: notice.id
+      }
+    end
+
+    it "links the task to the notice" do
+      post tasks_path, params: valid_params
+
+      expect(Task.last.notices).to include(notice)
+    end
+
+    it "redirects to the created task" do
+      post tasks_path, params: valid_params
+
+      expect(response).to redirect_to(task_path(Task.last))
+    end
+
+    it "does not link when notice_id is absent" do
+      post tasks_path, params: valid_params.except(:notice_id)
+
+      expect(Task.last.notices).to be_empty
+    end
+
+    it "does not link when task save fails" do
+      invalid_params = valid_params.deep_merge(task: { title: "" })
+
+      expect {
+        post tasks_path, params: invalid_params
+      }.not_to change(Task, :count)
+    end
+  end
+
+  describe "GET /tasks/:id - related notices display" do
+    let(:task) { create(:task, user: user) }
+
+    context "when the task has linked notices" do
+      before { task.notices << notice }
+
+      it "displays the linked notice" do
+        get task_path(task)
+
+        expect(response.body).to include(notice.content)
+      end
+    end
+
+    context "when the task has no linked notices" do
+      it "displays the empty message" do
+        get task_path(task)
+
+        expect(response.body).to include("まだ関連お知らせは登録されていません")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容
* Notice と Task の多対多の紐付けを実装
  * `notice_tasks` 中間テーブルを通じた関連を追加
  * お知らせ登録時に `notice_id` を受け取り、自動で紐付ける機能を実装
* 以下のビューを編集
  * `tasks/show.html.erb`
    * 関連お知らせ履歴一覧を追加
  * `notices/show.html.erb`
    * 関連タスク一覧を追加
  * タスク登録フォーム
    * `notice_id` の hidden field を追加
* Request Spec を追加
  * `spec/requests/task_notices_spec.rb`

## 確認済み
- [x] お知らせ詳細画面から関連タスクを作成可能なことを確認
- [x] 作成時に `notice_id` が引き継がれ、紐付けが保存されることを確認
- [x] タスク詳細画面にて関連お知らせの一覧が表示されていることを確認
- [x] お知らせ詳細画面にて関連タスクの一覧が表示されていることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

Closes #80