### PR TITLE
Resolving the Render deployment error

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -87,18 +87,13 @@ test:
 production:
   primary: &primary_production
     <<: *default
-    database: wfm_single_production
-    username: wfm_single
-    password: <%= ENV["WFM_SINGLE_DATABASE_PASSWORD"] %>
+    url: <%= ENV["DATABASE_URL"] %>
   cache:
     <<: *primary_production
-    database: wfm_single_production_cache
     migrations_paths: db/cache_migrate
   queue:
     <<: *primary_production
-    database: wfm_single_production_queue
     migrations_paths: db/queue_migrate
   cable:
     <<: *primary_production
-    database: wfm_single_production_cable
     migrations_paths: db/cable_migrate


### PR DESCRIPTION
## 変更内容
- `config/database.yml` のproductionセクションで `ENV["DATABASE_URL"]` を参照するように修正
- primary・cache・queue・cable すべてRenderの1つのPostgreSQLインスタンスに接続するように変更

## 変更理由
Renderは `DATABASE_URL` 環境変数でPostgreSQLの接続情報を提供する。
修正前はローカル用の接続情報が直接記載されており、Render 上でソケット接続を試みてエラーになっていた

## 確認事項
- [ ] Render でのデプロイが成功する
- [ ] `bin/rails db:migrate` がエラーなく実行される
- [ ] アプリが起動しDBに正常に接続できる

Closes #93 