### PR TITLE
Resolving the Render deployment error - Ver.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 2.0"
+gem "active_storage_validations"
 
 gem "rails-i18n"
 
@@ -51,8 +52,6 @@ group :development, :test do
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
-
-  gem "active_storage_validations"
   gem "rspec-rails", "~> 8.0.0"
   gem "factory_bot_rails"
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]


### PR DESCRIPTION
## 変更内容
- `active_storage_validations` を `group :development, :test` の外に移動

## 変更理由
production環境で `ContentTypeValidator` が読み込まれずアプリが起動できなかったため。

Closes #95 