### PR TITLE
Re-seeding the seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,39 +2,51 @@
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 
+# ==============================================================================
+# パスワードの読み込み
+# 本番環境では環境変数を必ず設定すること。
+# 例: SEED_ADMIN_PASSWORD=xxxxx rails db:seed
+# 開発・テスト環境ではデフォルト値 "password" にフォールバック。
+# ==============================================================================
+admin_password  = ENV.fetch("SEED_ADMIN_PASSWORD",  Rails.env.production? ? nil : "password")
+admin2_password = ENV.fetch("SEED_ADMIN2_PASSWORD", Rails.env.production? ? nil : "password")
+user_password   = ENV.fetch("SEED_USER_PASSWORD",   Rails.env.production? ? nil : "password")
+
+if Rails.env.production? && [admin_password, admin2_password, user_password].any?(&:nil?)
+  raise "本番環境ではSEED_ADMIN_PASSWORD / SEED_ADMIN2_PASSWORD / SEED_USER_PASSWORD の設定が必要です。"
+end
+
+# ==============================================================================
 # 初期ユーザーの作成
-users = [
+# ==============================================================================
+users_data = [
   {
     name: "管理者",
     email_address: "admin@example.com",
-    password: "password",
-    password_confirmation: "password",
+    password: admin_password,
     admin: true
   },
   {
     name: "管理者2",
     email_address: "admin2@example.com",
-    password: "password",
-    password_confirmation: "password",
+    password: admin2_password,
     admin: true
   },
   {
     name: "山田太郎",
     email_address: "yamada@example.com",
-    password: "password",
-    password_confirmation: "password",
+    password: user_password,
     admin: false
   },
   {
     name: "佐藤大樹",
     email_address: "satou@example.com",
-    password: "password",
-    password_confirmation: "password",
+    password: user_password,
     admin: false
   }
 ]
 
-users.each do |attrs|
+users_data.each do |attrs|
   user = User.find_or_create_by!(email_address: attrs[:email_address]) do |u|
     u.assign_attributes(attrs)
   end
@@ -43,12 +55,19 @@ users.each do |attrs|
     puts "初期ユーザーを作成しました！"
     puts "名前: #{user.name}"
     puts "メールアドレス: #{user.email_address}"
-    puts "パスワード: password"
   end
 end
 
+# 以降でユーザーをメールアドレスで参照
+user_admin  = User.find_by!(email_address: "admin@example.com")
+user_admin2 = User.find_by!(email_address: "admin2@example.com")
+user_yamada = User.find_by!(email_address: "yamada@example.com")
+user_satou  = User.find_by!(email_address: "satou@example.com")
+
+# ==============================================================================
 # 初期顧客の作成
-customers = [
+# ==============================================================================
+customers_data = [
   {
     uuid: "11111111-1111-1111-1111-111111111111",
     name: "山田 花子",
@@ -79,27 +98,30 @@ customers = [
   }
 ]
 
-customers.each do |attrs|
-  customer = Customer.find_or_create_by!(uuid: attrs[:uuid]) do |u|
-    u.assign_attributes(attrs)
+customers_data.each do |attrs|
+  customer = Customer.find_or_create_by!(uuid: attrs[:uuid]) do |c|
+    c.assign_attributes(attrs)
   end
 
   if customer.previously_new_record?
     puts "初期顧客を作成しました！"
     puts "名前: #{customer.name}"
-    puts "UUID #{customer.uuid}"
-    puts "メールアドレス: #{customer.email}"
-    puts "電話番号: #{customer.phone}"
-    puts "重要メモ: #{customer.key_notes}"
+    puts "UUID: #{customer.uuid}"
   end
 end
 
-# 応対履歴のステータスを日本語に変換する
+# 以降で顧客をUUIDで参照
+customer_hanako = Customer.find_by!(uuid: "11111111-1111-1111-1111-111111111111")
+customer_jiro   = Customer.find_by!(uuid: "22222222-2222-2222-2222-222222222222")
+customer_john   = Customer.find_by!(uuid: "33333333-3333-3333-3333-333333333333")
+
+# ==============================================================================
+# ヘルパーメソッド
+# ==============================================================================
 def interaction_status_label(completed)
   completed ? "完了" : "対応中"
 end
 
-# 応対履歴の問合せ方法を日本語に変換する
 def interaction_channel_label(channel)
   {
     phone: "電話",
@@ -110,57 +132,78 @@ def interaction_channel_label(channel)
   }[channel.to_sym]
 end
 
+def notice_level_label(level)
+  { important: "高", normal: "低" }[level.to_sym]
+end
+
+def task_status_label(status)
+  { todo: "未着手", in_progress: "進行中", done: "完了" }[status.to_sym]
+end
+
+# ==============================================================================
 # 初期応対履歴の作成
-interactions = [
+# ==============================================================================
+interactions_data = [
   {
-    customer_id: 1,
-    user_id: 2,
+    customer: customer_hanako,
+    user: user_admin2,
     occurred_at: Time.new(2026, 1, 26, 3, 3, 0, "+09:00"),
     channel: :phone,
-    parent_id: nil,
+    parent_key: nil,
     request_content: "商品Aの在庫問い合わせ。入荷したら連絡してほしいとのこと。",
-    response_result: "在庫確認後、明日入荷予定と回答。 入荷次第連絡する旨を伝えた。",
+    response_result: "在庫確認後、明日入荷予定と回答。入荷次第連絡する旨を伝えた。",
     completed: false
   },
   {
-    customer_id: 1,
-    user_id: 2,
+    customer: customer_hanako,
+    user: user_admin2,
     occurred_at: Time.new(2026, 1, 30, 11, 0, 0, "+09:00"),
     channel: :phone,
-    parent_id: 1,
+    parent_key: 0, # インデックス0が親
     request_content: "入荷連絡の電話するも、不在。",
     response_result: "留守電にメッセージを入れて終話。",
     completed: false
   },
   {
-    customer_id: 2,
-    user_id: 2,
+    customer: customer_jiro,
+    user: user_admin2,
     occurred_at: Time.new(2026, 1, 25, 2, 0, 0, "+09:00"),
     channel: :phone,
-    parent_id: nil,
+    parent_key: nil,
     request_content: "商品Xの不具合報告。一度店頭にて状況を確認してほしいとのこと。",
     response_result: "明日13時に来店予定。2階承りカウンターにお越しいただくように伝えてます。",
     completed: false
   },
   {
-    customer_id: 3,
-    user_id: 3,
+    customer: customer_john,
+    user: user_yamada,
     occurred_at: Time.new(2026, 1, 31, 8, 0, 0, "+09:00"),
     channel: :in_person,
-    parent_id: nil,
+    parent_key: nil,
     request_content: "商品Bの取り寄せ依頼。",
     response_result: "センターにも在庫無。入荷まで2~3週間かかる旨伝える。入荷次第連絡希望。",
     completed: false
   }
 ]
 
-interactions.each do |attrs|
+created_interactions = []
+
+interactions_data.each do |attrs|
+  parent = attrs[:parent_key] ? created_interactions[attrs[:parent_key]] : nil
+
   interaction = Interaction.find_or_create_by!(
-    customer_id: attrs[:customer_id],
+    customer: attrs[:customer],
     occurred_at: attrs[:occurred_at]
-  ) do |u|
-    u.assign_attributes(attrs)
+  ) do |i|
+    i.user            = attrs[:user]
+    i.channel         = attrs[:channel]
+    i.parent          = parent
+    i.request_content = attrs[:request_content]
+    i.response_result = attrs[:response_result]
+    i.completed       = attrs[:completed]
   end
+
+  created_interactions << interaction
 
   if interaction.previously_new_record?
     puts "初期応対履歴を作成しました！"
@@ -168,214 +211,216 @@ interactions.each do |attrs|
     puts "従業員: #{interaction.user.name}"
     puts "応対日時: #{interaction.occurred_at}"
     puts "問合せ方法: #{interaction_channel_label(interaction.channel)}"
-    puts "応対内容: #{interaction.request_content}"
-    puts "対応結果: #{interaction.response_result}"
-    puts "対応状況: #{interaction_status_label(interaction.completed)}"
   end
 end
 
-# 周知事項の種別を日本語に変換する
-def notice_level_label(level)
+# ==============================================================================
+# 初期周知事項の作成
+# ==============================================================================
+notices_data = [
   {
-    important: "高",
-    normal: "低",
-  }[level.to_sym]
-end
-
-# 初期の周知事項の作成
-notices = [
-  {
+    key: :product_x_claim,
     title: "商品Xのクレーム多発について",
-    content: "商品Xに関するクレームが増加しています。 対応時は必ずマニュアルを確認し、丁寧な説明を心がけてください。 不明点があれば必ず店長に確認してください。 【対応のポイント】 ・まずお客様の話をしっかり聞く ・マニュアルP.15の手順に従う ・必要に応じて代替品を提案 ・対応後は必ず記録を残す ご協力よろしくお願いいたします。",
+    content: "商品Xに関するクレームが増加しています。対応時は必ずマニュアルを確認し、丁寧な説明を心がけてください。不明点があれば必ず店長に確認してください。【対応のポイント】・まずお客様の話をしっかり聞く ・マニュアルP.15の手順に従う ・必要に応じて代替品を提案 ・対応後は必ず記録を残す ご協力よろしくお願いいたします。",
     level: :important,
     restricted: false,
     start_at: Time.new(2026, 2, 1, 11, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 1, 11, 0, 0, "+09:00"),
-    user_id: 2,
-    parent_id: nil
+    user: user_admin2,
+    parent_key: nil
   },
   {
+    key: :change_mistake,
     title: "お釣りのお渡し漏れについて",
     content: "最近レジでのお釣りを渡し忘れる事案が多発しています。お客様をお見送りするのも大事ですが、それよりも前にレジのトレーにお釣りやレシートが残っていないか、確認を徹底しましょう。",
     level: :normal,
     restricted: false,
     start_at: Time.new(2026, 2, 1, 13, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 1, 13, 0, 0, "+09:00"),
-    user_id: 1,
-    parent_id: nil
+    user: user_admin,
+    parent_key: nil
   },
   {
+    key: :card_return,
     title: "カードの返し忘れについて",
     content: "先日、レジでのお釣りの返し忘れが多い件について周知しましたが、今度はクレジットカードの返却忘れが発生しました。お釣りやレシートと同様ですが、お客様がクレジットカードをお取りいただいているか、カード決済端末も逐一確認するようお願いいたします。",
     level: :normal,
     restricted: false,
     start_at: Time.new(2026, 2, 2, 13, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 2, 13, 0, 0, "+09:00"),
-    user_id: 1,
-    parent_id: 2
+    user: user_admin,
+    parent_key: :change_mistake
   },
   {
+    key: :retirement_request,
     title: "従業員の退職申出について",
     content: "Uターンするため、退職したいと佐藤さんから申し入れがありました。少し掘り下げると、直近の業務でしんどい部分があったことも影響しているようです。ひとまず慰留しましたが、元気がなさそうであれば声がけするなど、管理者各位もフォローお願いします。",
     level: :important,
     restricted: true,
     start_at: Time.new(2026, 2, 1, 12, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 1, 12, 0, 0, "+09:00"),
-    user_id: 1,
-    parent_id: nil
+    user: user_admin,
+    parent_key: nil
   },
   {
+    key: :retirement_hold,
     title: "退職申出の保留について",
     content: "佐藤さんとフォロー面談を実施した結果、もう少し将来についてゆっくり考えたいので、退職の話は一旦取り下げしたい都申出がありました。Uターンしてカフェを開業するという夢があるようです。全力で応援する気持ちと、現職で辛いことがあれば、管理者に気兼ねなく相談しても大丈夫と伝えてます。佐藤さんから何か相談があれば、快く相談にのってあげてください。",
     level: :important,
     restricted: true,
     start_at: Time.new(2026, 2, 3, 11, 0, 0, "+09:00"),
     end_at: Time.new(2026, 8, 3, 11, 0, 0, "+09:00"),
-    user_id: 1,
-    parent_id: 4
+    user: user_admin,
+    parent_key: :retirement_request
   }
 ]
 
-notices.each do |attrs|
+created_notices = {}
+
+notices_data.each do |attrs|
+  parent = attrs[:parent_key] ? created_notices[attrs[:parent_key]] : nil
+
   notice = Notice.find_or_create_by!(
     title: attrs[:title],
     start_at: attrs[:start_at],
-    user_id: attrs[:user_id]
-  ) do |u|
-    u.assign_attributes(attrs)
+    user: attrs[:user]
+  ) do |n|
+    n.content    = attrs[:content]
+    n.level      = attrs[:level]
+    n.restricted = attrs[:restricted]
+    n.end_at     = attrs[:end_at]
+    n.parent     = parent
   end
+
+  created_notices[attrs[:key]] = notice
 
   if notice.previously_new_record?
     puts "初期周知事項を作成しました！"
-    puts "#{notice.title}"
-    puts "内容: #{notice.content}"
+    puts "タイトル: #{notice.title}"
     puts "種別: #{notice_level_label(notice.level)}"
-    puts "作成日時: #{notice.start_at}"
-    puts "終了日時: #{notice.end_at}"
-    puts "作成者: #{notice.user.name}"
   end
 end
 
+# ==============================================================================
 # 初期タスクの作成
-tasks = [
+# ==============================================================================
+tasks_data = [
   {
+    key: :product_x_prevention,
     title: "商品X再発防止策の検討",
-    description: "クレーム多発のため、メーカーとの協議と対応マニュアル改訂が必要。 再発防止のための体制整備を行う。 各店舗での対応事例を収集し、ベストプラクティスをまとめておいてください。",
+    description: "クレーム多発のため、メーカーとの協議と対応マニュアル改訂が必要。再発防止のための体制整備を行う。各店舗での対応事例を収集し、ベストプラクティスをまとめておいてください。",
     restricted: false,
-    user_id: 1,
-    parent_id: nil,
+    user: user_admin,
+    parent_key: nil,
     due_at: Time.new(2026, 2, 12, 11, 0, 0, "+09:00")
   },
   {
+    key: :maker_inquiry,
     title: "メーカーへの問い合わせ",
     description: "商品Xについてクレームが多発しているため、製造・設計段階で何か不具合があったのではないかメーカーへ確認要。佐藤さんが、各店舗での事例をExcelファイルにまとめてくれているので、そちらを添付の上、メーカーへメールにて問い合わせお願いします。不具合がないということであれば、今後の対応方法について助言を求めてください。",
     restricted: false,
-    user_id: 1,
-    parent_id: 1,
+    user: user_admin,
+    parent_key: :product_x_prevention,
     due_at: Time.new(2026, 2, 9, 11, 0, 0, "+09:00")
   },
   {
+    key: :manual_revision,
     title: "販売マニュアルの改訂",
     description: "メーカーから製造・設計段階による具体的な不具合は確認されなかったと返答。しかしながら、今後リコールへ発展する可能性も考え、同様の申出があった場合は、故意の破損等を除いて、原則交換対応とする。商品Xのクレーム申出があった場合は、メーカーが用意した特設フォームへ情報の入力が必要なため、手順について、期間用途限定のマニュアルを、既存の販売マニュアルへ追加要。改訂作業お願いします。",
     restricted: true,
-    user_id: 1,
-    parent_id: 2,
+    user: user_admin,
+    parent_key: :maker_inquiry,
     due_at: Time.new(2026, 2, 9, 11, 0, 0, "+09:00")
   },
   {
+    key: :product_y_stocking,
     title: "商品Yの品出し",
-    description: "昨日の閉店作業時間内に商品Yの品出しが終わりませんでした。。すみませんが、朝番の方、商品Yの棚がスカスカになっているので、開店作業中に優先して品出しをお願いします。",
+    description: "昨日の閉店作業時間内に商品Yの品出しが終わりませんでした。すみませんが、朝番の方、商品Yの棚がスカスカになっているので、開店作業中に優先して品出しをお願いします。",
     restricted: false,
-    user_id: 3,
-    parent_id: nil,
+    user: user_yamada,
+    parent_key: nil,
     due_at: nil
   },
   {
+    key: :everyone,
     title: "扶養控除申告書の提出について",
-    description: "今年も年末調整の時期がやってきました!つきましては、扶養控除申告書の提出が必要となります。書面は2Fの事務室に置いてあります。各自1部お取りいただき、期日までに提出をお願いいたします。何か不明点があれば管理者まで。",
+    description: "今年も年末調整の時期がやってきました！つきましては、扶養控除申告書の提出が必要となります。書面は2Fの事務室に置いてあります。各自1部お取りいただき、期日までに提出をお願いいたします。何か不明点があれば管理者まで。",
     restricted: false,
-    user_id: 1,
-    parent_id: nil,
+    user: user_admin,
+    parent_key: nil,
     due_at: Time.new(2026, 2, 14, 11, 0, 0, "+09:00")
   },
   {
+    key: :admin_only,
     title: "管理者各位 期末評価について",
     description: "社長との1on1面談が実施されます。面談にあたり、今年度の自己評価表の提出が必要となります。業務システムの管理者項目、期末評価から、期日までに提出をお願いいたします。",
     restricted: true,
-    user_id: 1,
-    parent_id: nil,
+    user: user_admin,
+    parent_key: nil,
     due_at: Time.new(2026, 2, 14, 11, 0, 0, "+09:00")
   }
 ]
 
-tasks.each do |attrs|
+created_tasks = {}
+
+tasks_data.each do |attrs|
+  parent = attrs[:parent_key] ? created_tasks[attrs[:parent_key]] : nil
+
   task = Task.find_or_create_by!(
     title: attrs[:title],
-    user_id: attrs[:user_id],
-    parent_id: attrs[:parent_id]
-  ) do |u|
-    u.assign_attributes(attrs)
+    user: attrs[:user],
+    parent: parent
+  ) do |t|
+    t.description = attrs[:description]
+    t.restricted  = attrs[:restricted]
+    t.due_at      = attrs[:due_at]
   end
+
+  created_tasks[attrs[:key]] = task
 
   if task.previously_new_record?
     puts "初期タスクを作成しました！"
-    puts "#{task.title}"
-    puts "説明: #{task.description}"
+    puts "タイトル: #{task.title}"
     puts "作成者: #{task.user.name}"
     puts "期限: #{task.due_at}"
   end
 end
 
-# タスクのステータスを日本語に変換する
-def task_status_label(status)
-  {
-    todo: "未着手",
-    in_progress: "進行中",
-    done: "完了"
-  }[status.to_sym]
-end
-
-# 初期のタスク割り当てを作成
-task_assignments = [
-  {
-    task_id: 1,
-    user_id: 3,
-    status: :todo
-  },
-  {
-    task_id: 2,
-    user_id: 4,
-    status: :todo
-  },
-  {
-    task_id: 3,
-    user_id: 2,
-    status: :todo
-  },
-  {
-    task_id: 4,
-    user_id: 4,
-    status: :todo
-  },
-  # 作成者を含めて、従業員全員に割り当てるタスク
-  *User.pluck(:id).map { |uid| { task_id: 5, user_id: uid } },
-
-  # 作成者を含めて、管理者権限を持つ全員に割り当てるタスク
-  *User.where(admin: true).pluck(:id).map { |uid| { task_id: 6, user_id: uid } }
+# ==============================================================================
+# 初期タスク割り当ての作成
+# ==============================================================================
+task_assignments_data = [
+  { task_key: :product_x_prevention, user: user_yamada,  status: :todo },
+  { task_key: :maker_inquiry,        user: user_satou,   status: :todo },
+  { task_key: :manual_revision,      user: user_admin2,  status: :todo },
+  { task_key: :product_y_stocking,   user: user_satou,   status: :todo },
 ]
 
-task_assignments.each do |attrs|
-  task_assignment = TaskAssignment.find_or_create_by!(
-    user_id: attrs[:user_id],
-    task_id: attrs[:task_id]
-  ) do |u|
-    u.assign_attributes(attrs)
+# 作成者を含めて、従業員全員に割り当てるタスク
+User.find_each do |u|
+  task_assignments_data << { task_key: :everyone, user: u, status: :todo }
+end
+
+# 作成者を含めて、管理者権限を持つ全員に割り当てるタスク
+User.where(admin: true).find_each do |u|
+  task_assignments_data << { task_key: :admin_only, user: u, status: :todo }
+end
+
+task_assignments_data.each do |attrs|
+  task = created_tasks[attrs[:task_key]]
+  next unless task
+
+  assignment = TaskAssignment.find_or_create_by!(
+    task: task,
+    user: attrs[:user]
+  ) do |a|
+    a.status = attrs[:status]
   end
 
-  if task_assignment.previously_new_record?
-    puts "初期のタスク割り当てを作成しました"
-    puts "#{task_assignment.task.title}"
-    puts "担当: #{task_assignment.user.name}"
-    puts "状態: #{task_status_label(task_assignment.status)}"
+  if assignment.previously_new_record?
+    puts "初期タスク割り当てを作成しました"
+    puts "タスク: #{assignment.task.title}"
+    puts "担当: #{assignment.user.name}"
+    puts "状態: #{task_status_label(assignment.status)}"
   end
 end


### PR DESCRIPTION
## 変更内容

### `db/seeds.rb`

- パスワードのハードコードを廃止し、環境変数から読み込む形に変更
  - `SEED_ADMIN_PASSWORD`
  - `SEED_ADMIN2_PASSWORD`
  - `SEED_USER_PASSWORD`

- ユーザー・顧客・タスク・周知事項の親子関係をIDではなくオブジェクト参照で解決

- `password_confirmation` を削除（Rails 7.1以降不要）

---

## 本番反映手順

### 1. Render ダッシュボードで環境変数を設定

対象サービスの **Environment** タブで以下を追加：

| Key | Value |
|------|------|
| `SEED_ADMIN_PASSWORD` | 任意の強いパスワード |
| `SEED_ADMIN2_PASSWORD` | 任意の強いパスワード |
| `SEED_USER_PASSWORD` | 任意の強いパスワード |

### 2. シードデータの投入

Render ダッシュボードの **Shell** タブを開いて実行：

```bash
bin/rails db:seed
```


### 3. 動作確認

以下を確認してください。

- [ ] アプリにアクセスして500エラーが解消されている
- [ ] 管理者アカウントでログインできる
- [ ] 顧客・応対履歴・周知事項・タスクが表示される

---

## チェックリスト

### 開発・レビュー

- [ ] ローカルで `rails db:seed` が正常に完了することを確認
- [ ] `seeds.rb` にパスワードのハードコードがないことを確認
- [ ] レビュワーによるコードレビュー完了

### 本番反映

- [ ] Render に環境変数を設定
- [ ] Render 上で `bin/rails db:seed` を実行
- [ ] 本番環境で動作確認を実施

Closes #97