### PR TITLE
Disable Solid Cache

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :solid_cache_store
+  # config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue


### PR DESCRIPTION
## 問題
本番環境（Render）で `solid_cache_entries` テーブルが存在しないため500エラーが発生。

## 原因
Rails 8からSolid CacheがデフォルトになったがDBマイグレーションが未実行。
本プロジェクトではSolid Cacheを使用していないため無効化する。

## 対応
production.rbでSolid Cacheの設定をコメントアウト。

## 確認事項
- [ ] ローカルで動作確認
- [ ] Renderデプロイ後に500エラーが解消されること

Closes #99 