### PR TITLE
Implement User CRUD

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   private
 
   def require_admin
-    unless current_user&.admin?
+    unless Current.user&.admin?
       redirect_to root_path, alert: "管理者権限が必要です"
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,8 +23,16 @@ class UsersController < ApplicationController
     end
   end
 
-  def edit; end
-  def update; end
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to @user, notice: "従業員情報を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   private
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,8 +9,20 @@ class UsersController < ApplicationController
   def show
   end
 
-  def new; end
-  def create; end
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to @user, notice: "従業員を登録しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def edit; end
   def update; end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,11 @@ class UsersController < ApplicationController
     @users = User.order(:name)
   end
 
+  def show
+  end
+
   def new; end
   def create; end
-  def show; end
   def edit; end
   def update; end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,32 @@
 class UsersController < ApplicationController
+  before_action :set_user, only: %i[show edit update]
+  before_action :require_admin, only: %i[new create edit update]
+
+  def index
+    @users = User.order(:name)
+  end
+
+  def new; end
+  def create; end
+  def show; end
+  def edit; end
+  def update; end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    permitted = %i[
+      name
+      email_address
+      admin
+    ]
+
+    permitted << :password if params.require(:user)[:password].present?
+
+    params.require(:user).permit(permitted)
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -22,7 +22,6 @@
           class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
   </div>
   <div>
-    <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.label :password,
       user.persisted? ? "パスワード（変更する場合のみ）" : "パスワード",
       class: "block text-sm font-medium text-gray-700 mb-1" %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,43 @@
+<%= form_with model: user, class: "space-y-4" do |f| %>
+  <% if user.errors.any? %>
+    <div class="bg-red-50 border border-red-300 rounded p-4">
+      <p class="text-red-700 font-semibold text-sm mb-2">
+        <%= user.errors.count %>件のエラーがあります
+      </p>
+      <ul class="list-disc list-inside text-red-600 text-sm space-y-1">
+        <% user.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div>
+    <%= f.label :name, "氏名", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :name,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div>
+    <%= f.label :email_address, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.email_field :email_address,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <div>
+    <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :password,
+      user.persisted? ? "パスワード（変更する場合のみ）" : "パスワード",
+      class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.password_field :password,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+  </div>
+  <% if Current.user.admin? %>
+    <div class="flex items-center gap-2">
+      <%= f.check_box :admin, class: "rounded" %>
+      <%= f.label :admin, "管理者権限を付与", class: "text-sm text-gray-700" %>
+    </div>
+  <% end %>
+
+  <div class="flex justify-end pt-2">
+    <%= f.submit user.new_record? ? "登録する" : "更新する",
+          class: "px-6 py-2 bg-blue-500 text-white rounded hover:bg-yellow-600 text-sm cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/users/_related_interactions.html.erb
+++ b/app/views/users/_related_interactions.html.erb
@@ -1,0 +1,21 @@
+<div class="mb-6 border-t-4 border-gray-500 pt-6">
+  <h2 class="text-lg font-semibore mb-3 border-b-2 border-gray-300 pb-2">担当応対履歴</h2>
+  <% interactions = user.interactions %>
+  <% if interactions.any? %>
+    <ul class="space-y-2">
+      <% interactions.each do |interaction| %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
+          <span class="text-gray-600">応対履歴</span>
+          <%= link_to interaction.request_content, interaction_path(interaction), class: "flex-1 hover:text-blue-600" %>
+          <span class="text-xs text-gray-500">
+            <%= l interaction.occurred_at %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <div class="text-sm text-gray-500">
+      まだ担当応対履歴は登録されていません。
+    </div>
+  <% end %>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,14 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-2xl mx-auto px-4">
+    <div class="mb-4">
+      <%= link_to "← 詳細に戻る", user_path(@user),
+            class: "text-blue-600 hover:underline text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-blue-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">従業員情報を編集</h1>
+      </div>
+      <%= render "form", user: @user %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,42 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-6xl mx-auto px-4">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">従業員一覧</h1>
+      <% if Current.user&.admin? %>
+        <%= link_to "新規登録", new_user_path, class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm" %>
+      <% end %>
+    </div>
+    <div class="bg-white rounded-lg shadow">
+      <% if @users.any? %>
+        <table class="w-full text-sm">
+          <thead class="bg-gray-50 border-b">
+            <tr>
+              <th class="text-left p-3 text-gray-600">氏名</th>
+              <th class="text-left p-3 text-gray-600">メールアドレス</th>
+              <th class="text-left p-3 text-gray-600">権限</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">
+            <% @users.each do |user| %>
+              <tr class="hover:bg-gray-50">
+                <td class="p-3">
+                  <%= link_to user.name, user_path(user), class: "text-blue-600 hover:underline font-medium" %>
+                </td>
+                <td class="p-3 text-gray-700">
+                  <%= user.email_address %>
+                </td>
+                <td class="p-3 text-gray-700">
+                  <%= user.admin? ? "管理者" : "一般" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="p-8 text-center text-gray-500 text-sm">
+          従業員が登録されていません。
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,14 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-2xl mx-auto px-4">
+    <div class="mb-4">
+      <%= link_to "← 一覧に戻る", users_path,
+            class: "text-blue-600 hover:underline text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-blue-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold">従業員を新規登録</h1>
+      </div>
+      <%= render "form", user: @user %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,47 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-4xl mx-auto px-4">
+    <div class="mb-4">
+      <%= link_to "← 一覧に戻る", users_path, class: "text-blue-600 hover:underline text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <div class="border-b-4 border-blue-500 pb-4 mb-6">
+        <h1 class="text-2xl font-bold flex items-center gap-3">
+          <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+          <%= @user.name %>
+        </h1>
+      </div>
+      <div class="mb-6">
+        <h2 class="text-lg font-semibore mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
+        <div class="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <span class="text-gray-600">メールアドレス:</span>
+            <span class="ml-2"><%= @user.email_address %></span>
+          </div>
+          <div>
+            <span class="text-gray-600">登録日時:</span>
+            <span class="ml-2"><%= l @user.created_at %></span>
+          </div>
+          <div>
+            <span class="text-gray-600">権限:</span>
+            <span class="ml-2"><%= @user.admin? ? "管理者" : "一般" %></span>
+          </div>
+          <div>
+            <span class="text-gray-600">更新日時:</span>
+            <span class="ml-2"><%= l @user.updated_at %></span>
+          </div>
+        </div>
+      </div>
+
+      <%= render "related_interactions", user: @user %>
+
+      <% if Current.user&.admin? %>
+        <div class="mt-6 flex justify-end border-t pt-4">
+          <%= link_to "編集", edit_user_path(@user),
+              class: "px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 text-sm" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,15 @@
 ja:
+  users:
+    admin:
+      true: "管理者"
+      false: "一般"
   activerecord:
     attributes:
+      user:
+        name: "従業員名"
+        email_address: "メールアドレス"
+        password_digest: "パスワード"
+        admin: "権限"
       interaction:
         customer: "顧客"
         occurred_at: "対応日時"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resource :session
   resources :passwords, param: :token
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  resources :users, except: :destroy
   resources :customers, except: :destroy
   resources :interactions, except: :destroy
   resources :tasks, except: :destroy

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UsersHelper. For example:
+#
+# describe UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,7 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let!(:admin) { create(:user, admin: true) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /users" do
+    context "when the user is logged in" do
+      before { sign_in(user) }
+
+      it "responds with HTTP 200 OK" do
+        get users_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the users list" do
+        get users_path
+
+        expect(response.body).to include(user.name)
+        expect(response.body).to include(admin.name)
+        expect(response.body).to include(I18n.t("users.admin.#{user.admin?}"))
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get users_path
+
+        expect(response).to redirect_to new_session_path
+      end
+    end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -35,4 +35,83 @@ RSpec.describe "Users", type: :request do
       end
     end
   end
+
+  describe "GET /users/:id" do
+    let(:interaction) do
+      create(
+        :interaction,
+        user: user,
+        request_content: "テスト",
+        occurred_at: Time.zone.local(2025, 1, 10, 14, 30)
+      )
+    end
+
+    context "when the user is logged in" do
+      before do
+        sign_in(user)
+        interaction
+      end
+
+      it "responds with HTTP 200 OK" do
+        get user_path(user)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the user basic information" do
+        get user_path(user)
+
+        expect(response.body).to include(user.name)
+        expect(response.body).to include(user.email_address)
+        expect(response.body).to include(I18n.l(user.created_at))
+        expect(response.body).to include(I18n.l(user.updated_at))
+      end
+
+      it "displays user role" do
+        get user_path(user)
+
+        expect(response.body).to include("一般")
+      end
+
+      it "displays admin role for admin users" do
+        get user_path(admin)
+
+        expect(response.body).to include("管理者")
+      end
+
+      it "displays related interactions" do
+        get user_path(user)
+
+        expect(response.body).to include(interaction.request_content)
+        expect(response.body).to include(I18n.l(interaction.occurred_at))
+        expect(response.body).to include(interaction_path(interaction))
+      end
+
+      it "does not display edit link for non-admin users" do
+        get user_path(user)
+
+        expect(response.body).not_to include(edit_user_path(user))
+      end
+    end
+
+    context "when the user is an admin" do
+      before do
+        sign_in(admin)
+      end
+
+      it "displays edit link" do
+        get user_path(user)
+
+        expect(response.body).to include(edit_user_path(user))
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get user_path(user)
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -239,4 +239,135 @@ RSpec.describe "Users", type: :request do
       end
     end
   end
+
+  describe "GET /users/:id/edit" do
+    context "when the current user is an admin" do
+      before { sign_in(admin) }
+
+      it "responds with HTTP 200 OK" do
+        get edit_user_path(user)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the edit template" do
+        get edit_user_path(user)
+
+        expect(response.body).to include("氏名")
+        expect(response.body).to include("メールアドレス")
+        expect(response.body).to include("パスワード（変更する場合のみ）")
+        expect(response.body).to include("管理者権限を付与")
+      end
+    end
+
+    context "when the current user is not an admin" do
+      before { sign_in(user) }
+
+      it "redirects to the root page" do
+        get edit_user_path(user)
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "sets an alert message" do
+        get edit_user_path(user)
+
+        expect(flash[:alert]).to eq("管理者権限が必要です")
+      end
+    end
+  end
+
+  describe "PATCH /users/:id" do
+    let(:valid_params) do
+      {
+        user: {
+          name: "Updated Name",
+          email_address: "updated@example.com"
+        }
+      }
+    end
+
+    let(:invalid_params) do
+      {
+        user: {
+          name: "",
+          email_address: ""
+        }
+      }
+    end
+
+    context "when the current user is an admin" do
+      before { sign_in(admin) }
+
+      it "updates the user" do
+        patch user_path(user), params: valid_params
+
+        expect(user.reload.name).to eq("Updated Name")
+        expect(user.reload.email_address).to eq("updated@example.com")
+      end
+
+      it "redirects to the user page" do
+        patch user_path(user), params: valid_params
+
+        expect(response).to redirect_to user_path(user)
+      end
+
+      it "sets a success notice" do
+        patch user_path(user), params: valid_params
+
+        expect(flash[:notice]).to eq("従業員情報を更新しました")
+      end
+
+      it "does not update the password when password is blank" do
+        old_digest = user.password_digest
+
+        patch user_path(user), params: {
+          user: {
+            name: "Updated Name",
+            password: ""
+          }
+        }
+
+        expect(user.reload.password_digest).to eq(old_digest)
+      end
+
+      it "does not update the user with invalid parameters" do
+        original_name = user.name
+
+        patch user_path(user), params: invalid_params
+
+        expect(user.reload.name).to eq(original_name)
+      end
+
+      it "re-renders the edit template with invalid params" do
+        patch user_path(user), params: invalid_params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when the current user is not an admin" do
+      before { sign_in(user) }
+
+      it "does not update the user" do
+        original_name = user.name
+
+        patch user_path(user), params: valid_params
+
+        expect(user.reload.name).to eq(original_name)
+      end
+
+      it "redirects to the root page" do
+        patch user_path(user), params: valid_params
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "sets an alert message" do
+        patch user_path(user), params: valid_params
+
+        expect(flash[:alert]).to eq("管理者権限が必要です")
+      end
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -114,4 +114,129 @@ RSpec.describe "Users", type: :request do
       end
     end
   end
+
+  describe "GET /users/new" do
+    context "when the current user is an admin" do
+      before { sign_in(admin) }
+
+      it "responds with HTTP 200 OK" do
+        get new_user_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the new template" do
+        get new_user_path
+
+        expect(response.body).to include("氏名")
+        expect(response.body).to include("メールアドレス")
+        expect(response.body).to include("パスワード")
+        expect(response.body).to include("管理者権限を付与")
+      end
+    end
+
+    context "when the current user is not an admin" do
+      before { sign_in(user) }
+
+      it "redirects to the root page" do
+        get new_user_path
+
+        expect(response).to redirect_to root_path
+      end
+
+      it "sets an alert message" do
+        get new_user_path
+
+        expect(flash[:alert]).to eq("管理者権限が必要です")
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        get new_user_path
+
+        expect(response).to redirect_to new_session_path
+      end
+    end
+  end
+
+  describe "POST /users" do
+    let(:valid_params) do
+      {
+        user: {
+          name: "John Doe",
+          email_address: "john@example.com",
+          password: "password123"
+        }
+      }
+    end
+
+    let(:invalid_params) do
+      {
+        user: {
+          name: "",
+          email_address: "",
+          password: ""
+        }
+      }
+    end
+
+    context "when the current user is an admin" do
+      before { sign_in(admin) }
+
+      it "creates a User with valid params" do
+        expect {
+          post users_path, params: valid_params
+        }.to change(User, :count).by(1)
+      end
+
+      it "redirects to the show page with valid params" do
+        post users_path, params: valid_params
+
+        expect(response).to redirect_to(user_path(User.last))
+      end
+
+      it "sets a success notice" do
+        post users_path, params: valid_params
+
+        expect(flash[:notice]).to eq("従業員を登録しました")
+      end
+
+      it "re-renders the new template with invalid params" do
+        post users_path, params: invalid_params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when the current user is not an admin" do
+      before { sign_in(user) }
+
+      it "does not create a user" do
+        expect {
+          post users_path, params: valid_params
+        }.not_to change(User, :count)
+      end
+
+      it "redirects to the root page" do
+        post users_path, params: valid_params
+
+        expect(response).to redirect_to root_path
+      end
+
+      it "sets an alert message" do
+        post users_path, params: valid_params
+
+        expect(flash[:alert]).to eq("管理者権限が必要です")
+      end
+    end
+
+    context "when the user is not logged in" do
+      it "redirects to the login page" do
+        post users_path, params: {}
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 変更内容
* UsersController を作成し、以下のアクションを実装
  * `index` — 従業員一覧表示
  * `show` — 従業員詳細表示
  * `new` — 従業員新規登録
  * `create` — 登録処理
  * `edit` — 従業員情報編集
  * `update` — 更新処理
* Strong Parameters を実装
* 管理者権限チェック（`require_admin`）を実装
  * 管理者のみ新規登録・編集・更新が可能
  * 権限がない場合はトップページへリダイレクト
* パスワード更新処理を実装
  * パスワード入力時のみ更新対象に含める
  * 空欄の場合は既存パスワードを維持
* バリデーションエラー時に `unprocessable_entity` を返し、フォームを再表示
* 管理者フラグによるフォーム出し分けを実装
  * 管理者のみ「管理者権限を付与」チェックボックスを表示
* 以下のビューを作成
  * `index.html.erb`
  * `show.html.erb`
  * `new.html.erb`
  * `edit.html.erb`
  * `_form.html.erb`（new / edit 共用）
* Tailwind CSS を用いてフォーム・一覧・詳細画面を整備
* Request Spec を追加

## 確認済み
- [x] ブラウザ上で従業員一覧が表示されることを確認
- [x] ブラウザ上で従業員詳細が表示されることを確認
- [x] 管理者ユーザーが従業員を新規登録できることを確認
- [x] 管理者ユーザーが従業員情報を更新できることを確認
- [x] パスワードを空欄で更新した場合に既存パスワードが維持されることを確認
- [x] 管理者以外が新規登録画面へアクセスした場合にリダイレクトされることを確認
- [x] 管理者以外が編集画面へアクセスした場合にリダイレクトされることを確認
- [x] 管理者以外が更新処理を実行した場合にリダイレクトされることを確認
- [x] バリデーションエラー時にフォームが再表示されることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

## 補足
* 削除機能（論理削除含む）はこのPRでは実装しない
* パスワード変更機能の強化（確認入力・現在パスワード確認等）は今後のPRで検討予定
* ページネーション・検索機能は今後のPRで追加予定

Closes #101 