### PR TITLE
Implement Task Assignee Creation and Display

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -83,12 +83,11 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    permitted = %i[
-      title
-      description
-      due_at
-      parent_id
-      images: []
+    permitted = [
+      :title,
+      :description,
+      :due_at,
+      :parent_id
     ]
 
     permitted << :restricted if Current.user.admin?

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,19 +16,29 @@ class TasksController < ApplicationController
     @task = Current.user.tasks.build(task_params)
     @parent_task = @task.parent
 
-    if @task.save
-      if params[:interaction_id].present?
-        @task.interactions << Interaction.find(params[:interaction_id])
-      end
+    assignee_ids = Array(params[:assignee_ids]).reject(&:blank?)
 
-      if params[:notice_id].present?
-        @task.notices << Notice.find(params[:notice_id])
-      end
+    @task.valid?
 
-      redirect_to @task, notice: "タスクを登録しました"
-    else
+    @task.errors.add(:base, "担当者を1人以上選択してください") if assignee_ids.empty?
+
+    if @task.errors.any?
       render :new, status: :unprocessable_entity
+      return
     end
+
+    ActiveRecord::Base.transaction do
+      @task.save!
+
+      @task.interactions << Interaction.find(params[:interaction_id]) if params[:interaction_id].present?
+      @task.notices << Notice.find(params[:notice_id]) if params[:notice_id].present?
+
+      assignee_ids.each do |user_id|
+        @task.task_assignments.create!(user_id: user_id, status: :todo)
+      end
+    end
+
+    redirect_to @task, notice: "タスクを登録しました"
   end
 
   def show
@@ -51,6 +61,7 @@ class TasksController < ApplicationController
   def set_task
     @task = Task.preload(
       :user,
+      task_assignments: [ :user ],
       comments: [ :user ]
     ).find(params[:id])
   end

--- a/app/helpers/task_assignments_helper.rb
+++ b/app/helpers/task_assignments_helper.rb
@@ -1,0 +1,5 @@
+module TaskAssignmentsHelper
+  def task_status_label(assignment)
+    I18n.t("enums.task_assignment.status.#{assignment.status}")
+  end
+end

--- a/app/views/tasks/_assignees.html.erb
+++ b/app/views/tasks/_assignees.html.erb
@@ -1,0 +1,32 @@
+<div class="mb-6 border-t-4 border-blue-500 pt-6">
+  <h2 class="text-lg font-semibold mb-3">割り当て者と進捗状況</h2>
+  <% if task.task_assignments.any? %>
+    <div class="bg-gray-50 rounded overflow-hidden">
+      <table class="w-full text-sm">
+        <thead class="bg-gray-100 text-gray-600">
+          <tr>
+            <th class="px-16 py-3 text-left font-medium w-1/2">担当者</th>
+            <th class="px-16 py-3 text-left font-medium w-1/2">進捗状況</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+          <% task.task_assignments.each do |assignment| %>
+            <tr class="hover:bg-gray-100">
+              <td class="px-16 py-3">
+                <%= link_to assignment.user.name, user_path(assignment.user),
+                      class: "text-blue-600 hover:text-blue-800" %>
+              </td>
+              <td class="px-16 py-3 text-gray-600">
+                <%= task_status_label(assignment) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500 bg-gray-50 p-4 rounded">
+      まだ誰にも割り当てられていません。
+    </p>
+  <% end %>
+</div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -29,6 +29,16 @@
     <%= f.datetime_local_field :due_at,
           class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
   </div>
+  <div>
+    <%= label_tag :assignee_ids, "担当者", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= select_tag "assignee_ids[]",
+          options_from_collection_for_select(User.order(:name), :id, :name, params[:assignee_ids]),
+          multiple: true,
+          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+    <p class="mt-1 text-xs text-gray-400">
+      複数選択可。Windows: Ctrl+クリック / Mac: Command+クリックで複数選択
+    </p>
+  </div>
   <% if Current.user.admin? %>
     <div class="flex items-center gap-2">
       <%= f.check_box :restricted, class: "rounded" %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -36,6 +36,7 @@
 
       <%= render "shared/images", record: @task %>
 
+      <%= render "assignees", task: @task %>
       <%= render "timeline", timeline: @timeline, current_item: @task %>
       <%= render "related_interactions", task: @task %>
       <%= render "related_notices", task: @task %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -46,4 +46,9 @@ ja:
       level:
         important: "高"
         normal: "低"
+    task_assignment:
+      status:
+        todo: "未着手"
+        in_progress: "進行中"
+        done: "完了"
 

--- a/spec/requests/task_assignments_spec.rb
+++ b/spec/requests/task_assignments_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "Task Assignments", type: :request do
+  let(:task_creator)     { create(:user) }
+  let(:first_assignee) { create(:user) }
+  let(:second_assignee) { create(:user) }
+
+  let(:valid_task_attributes) do
+    {
+      title:       "タスク割り当てテスト",
+      description: "タスク割り当てテストの説明",
+      restricted:  false
+    }
+  end
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  before { sign_in(task_creator) }
+
+  describe "POST /tasks with assignee_ids" do
+    context "with assignees" do
+      it "creates task_assignments with status todo for each assignee" do
+        expect {
+          post tasks_path, params: {
+            task:         valid_task_attributes,
+            assignee_ids: [ first_assignee.id, second_assignee.id ]
+          }
+        }.to change(TaskAssignment, :count).by(2)
+
+        assignments = TaskAssignment.last(2)
+        expect(assignments.map(&:status)).to all(eq("todo"))
+        expect(assignments.map(&:user_id)).to contain_exactly(first_assignee.id, second_assignee.id)
+      end
+
+      it "redirects to the created task show page" do
+        post tasks_path, params: {
+          task:         valid_task_attributes,
+          assignee_ids: [ first_assignee.id ]
+        }
+        expect(response).to redirect_to(task_path(Task.last))
+      end
+    end
+
+    context "without assignees" do
+      it "returns 422 and shows error when assignee_ids is empty" do
+        post tasks_path, params: { task: valid_task_attributes, assignee_ids: [] }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("担当者を1人以上選択してください")
+      end
+
+      it "does not create a task when assignee_ids is empty" do
+        expect {
+          post tasks_path, params: { task: valid_task_attributes, assignee_ids: [] }
+        }.not_to change(Task, :count)
+      end
+    end
+  end
+
+  describe "GET /tasks/:id" do
+    let(:task) { create(:task, user: task_creator) }
+
+    context "with assignees" do
+      before do
+        create(:task_assignment, task: task, user: first_assignee, status: :todo)
+        create(:task_assignment, task: task, user: second_assignee, status: :todo)
+      end
+
+      it "displays assignee names on the show page" do
+        get task_path(task)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(first_assignee.name)
+        expect(response.body).to include(second_assignee.name)
+      end
+    end
+
+    context "without assignees" do
+      it "displays the empty state message" do
+        get task_path(task)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("まだ誰にも割り当てられていません")
+      end
+    end
+  end
+end

--- a/spec/requests/task_interactions_spec.rb
+++ b/spec/requests/task_interactions_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Task Interactions", type: :request do
+  include TaskRequestHelpers
+
   let(:user) { create(:user) }
   let(:interaction) { create(:interaction) }
 
@@ -32,19 +34,19 @@ RSpec.describe "Task Interactions", type: :request do
     end
 
     it "links the task to the interaction" do
-      post tasks_path, params: valid_params
+      post tasks_path, params: create_task_with_assignees(valid_params)
 
       expect(Task.last.interactions).to include(interaction)
     end
 
     it "redirects to the created task" do
-      post tasks_path, params: valid_params
+      post tasks_path, params: create_task_with_assignees(valid_params)
 
       expect(response).to redirect_to(task_path(Task.last))
     end
 
     it "does not link when interaction_id is absent" do
-      post tasks_path, params: valid_params.except(:interaction_id)
+      post tasks_path, params: create_task_with_assignees(valid_params).except(:interaction_id)
 
       expect(Task.last.interactions).to be_empty
     end

--- a/spec/requests/task_notices_spec.rb
+++ b/spec/requests/task_notices_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Task Notices", type: :request do
+  include TaskRequestHelpers
+
   let(:user) { create(:user) }
   let(:notice) { create(:notice) }
 
@@ -32,19 +34,19 @@ RSpec.describe "Task Notices", type: :request do
     end
 
     it "links the task to the notice" do
-      post tasks_path, params: valid_params
+      post tasks_path, params: create_task_with_assignees(valid_params)
 
       expect(Task.last.notices).to include(notice)
     end
 
     it "redirects to the created task" do
-      post tasks_path, params: valid_params
+      post tasks_path, params: create_task_with_assignees(valid_params)
 
       expect(response).to redirect_to(task_path(Task.last))
     end
 
     it "does not link when notice_id is absent" do
-      post tasks_path, params: valid_params.except(:notice_id)
+      post tasks_path, params: create_task_with_assignees(valid_params).except(:notice_id)
 
       expect(Task.last.notices).to be_empty
     end

--- a/spec/requests/tasks_parent_child_spec.rb
+++ b/spec/requests/tasks_parent_child_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Tasks parent-child", type: :request do
+  include TaskRequestHelpers
+
   let(:user)  { create(:user) }
   let(:admin) { create(:user, admin: true) }
 
@@ -187,14 +189,14 @@ RSpec.describe "Tasks parent-child", type: :request do
 
       it "creates a task and associates it with the parent" do
         expect {
-          post tasks_path, params: child_params
+          post tasks_path, params: create_task_with_assignees(child_params)
         }.to change(Task, :count).by(1)
 
         expect(Task.last.parent).to eq(parent)
       end
 
       it "redirects to the child task page" do
-        post tasks_path, params: child_params
+        post tasks_path, params: create_task_with_assignees(child_params)
 
         expect(response).to redirect_to task_path(Task.last)
       end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks", type: :request do
+  include TaskRequestHelpers
+
   let(:user) { create(:user) }
   let(:admin) { create(:user, admin: true) }
   let!(:task) { create(:task, user: user) }
@@ -148,53 +150,49 @@ RSpec.describe "Tasks", type: :request do
 
       let(:valid_params) do
         {
-          task: {
-            title: "テストタスク",
-            description: "テストタスクの詳細",
-            due_at: 1.week.from_now
-          }
+          title:       "テストタスク",
+          description: "テストタスクの詳細",
+          due_at:      1.week.from_now
         }
       end
 
       it "creates a Task with valid params" do
         expect {
-          post tasks_path, params: valid_params
+          post tasks_path, params: create_task_with_assignees({ task: valid_params })
         }.to change(Task, :count).by(1)
       end
 
       it "redirects to the show page with valid params" do
-        post tasks_path, params: valid_params
-
+        post tasks_path, params: create_task_with_assignees({ task: valid_params })
         expect(response).to redirect_to(task_path(Task.last))
       end
 
       it "records the user who created it" do
-        post tasks_path, params: valid_params
-
+        post tasks_path, params: create_task_with_assignees({ task: valid_params })
         expect(Task.last.user).to eq(user)
       end
 
       it "does not create a Task with invalid params" do
         expect {
-          post tasks_path, params: { task: { title: nil } }
+          post tasks_path, params: create_task_with_assignees({ task: { title: nil } })
         }.not_to change(Task, :count)
       end
 
       it "re-renders the new template with invalid params" do
-        post tasks_path, params: { task: { title: nil } }
-
+        post tasks_path, params: create_task_with_assignees({ task: { title: nil } })
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it "ignores restricted parameter" do
-        post tasks_path, params: {
-          task: {
-            title: "テストタスク",
-            description: "テストタスクの詳細",
-            restricted: true
+        post tasks_path, params: create_task_with_assignees(
+          {
+            task: {
+              title:       "テストタスク",
+              description: "テストタスクの詳細",
+              restricted:  true
+            }
           }
-        }
-
+        )
         expect(Task.last.restricted).to be(false)
       end
     end
@@ -203,14 +201,15 @@ RSpec.describe "Tasks", type: :request do
       before { sign_in(admin) }
 
       it "allows to set restricted" do
-        post tasks_path, params: {
-          task: {
-            title: "テストタスク",
-            description: "テストタスクの詳細",
-            restricted: true
+        post tasks_path, params: create_task_with_assignees(
+          {
+            task: {
+              title:       "テストタスク",
+              description: "テストタスクの詳細",
+              restricted:  true
+            }
           }
-        }
-
+        )
         expect(Task.last.restricted).to be(true)
       end
     end
@@ -218,7 +217,6 @@ RSpec.describe "Tasks", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         post tasks_path, params: {}
-
         expect(response).to redirect_to(new_session_path)
       end
     end
@@ -226,9 +224,9 @@ RSpec.describe "Tasks", type: :request do
 
   describe "POST /tasks (with images)" do
     subject(:perform_request) do
-      post tasks_path, params: {
+      post tasks_path, params: create_task_with_assignees({
         task: attributes_for(:task).merge(images: images)
-      }
+      })
     end
 
     before { sign_in(user) }

--- a/spec/support/task_request_helpers.rb
+++ b/spec/support/task_request_helpers.rb
@@ -1,0 +1,5 @@
+module TaskRequestHelpers
+  def create_task_with_assignees(params, user: create(:user))
+    params.merge(assignee_ids: [ user.id ])
+  end
+end


### PR DESCRIPTION
## 変更内容

- `TasksController#create` に担当者必須チェックを追加（`assignee_ids` が空なら `422`）
- `Task` 保存・`TaskAssignment` 作成を `transaction` で実行し、各担当者を `status: todo` で登録
- `task_params` の `%i[]` 内に `images: []` が混在していた不正な記法を修正
- `set_task` の `preload` に `task_assignments: [:user]` を追加
- `tasks/_form.html.erb` に担当者の複数選択UIを追加
- `tasks/show.html.erb` に担当者・作業状況セクションを `_assignees` パーシャルとして追加
- `task_assignments_helper.rb` に `task_status_label` を追加
- `config/locales/ja.yml` の `enums.task_assignment.status` に日本語訳を追加
- `spec/requests/task_assignments_spec.rb` を新規追加
- `spec/support/task_request_helpers.rb` を新規追加（`create_task_with_assignees`）
- `assignee_ids` 必須化に伴い既存specを修正
  - `spec/requests/tasks_spec.rb`
  - `spec/requests/task_interactions_spec.rb`
  - `spec/requests/task_notices_spec.rb`
  - `spec/requests/tasks_parent_child_spec.rb`

## 確認済み

- [x] タスク登録フォームで担当者を複数選択できることを確認
- [x] 登録時に `task_assignments` が `status: todo` で作成されることを確認
- [x] 担当者未選択で登録しようとすると `422` とエラーメッセージが表示されることを確認
- [x] タスク詳細画面で担当者名と作業状況が表示されることを確認
- [x] 担当者がいない場合に空状態メッセージが表示されることを確認
- [x] 管理者が `restricted: true` を設定できることを確認
- [x] `interaction_id` / `notice_id` の連携が引き続き動作することを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

## 補足

- 担当者の追加・解除・ステータス変更は別 Issue で実装予定

Closes #110 
