### PR TITLE
Introduce TaskForm for task creation flow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     bullet (8.1.3)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,35 +10,25 @@ class TasksController < ApplicationController
   def new
     @parent_task = Task.find_by(id: params[:parent_id])
     @task = Task.new(parent: @parent_task)
+    @form = TaskForm.new(task: @task)
   end
 
   def create
     @task = Current.user.tasks.build(task_params)
     @parent_task = @task.parent
 
-    assignee_ids = Array(params[:assignee_ids]).reject(&:blank?)
+    @form = TaskForm.new(
+      task:           @task,
+      assignee_ids:   params[:assignee_ids],
+      interaction_id: params[:interaction_id],
+      notice_id:      params[:notice_id]
+    )
 
-    @task.valid?
-
-    @task.errors.add(:base, "担当者を1人以上選択してください") if assignee_ids.empty?
-
-    if @task.errors.any?
+    if @form.save
+      redirect_to @task, notice: "タスクを登録しました"
+    else
       render :new, status: :unprocessable_entity
-      return
     end
-
-    ActiveRecord::Base.transaction do
-      @task.save!
-
-      @task.interactions << Interaction.find(params[:interaction_id]) if params[:interaction_id].present?
-      @task.notices << Notice.find(params[:notice_id]) if params[:notice_id].present?
-
-      assignee_ids.each do |user_id|
-        @task.task_assignments.create!(user_id: user_id, status: :todo)
-      end
-    end
-
-    redirect_to @task, notice: "タスクを登録しました"
   end
 
   def show
@@ -46,12 +36,15 @@ class TasksController < ApplicationController
   end
 
   def edit
+    @form = TaskForm.new(task: @task)
   end
 
   def update
     if @task.update(task_params)
       redirect_to @task, notice: "タスクを更新しました"
     else
+      @form = TaskForm.new(task: @task)
+      @form.valid? # task.errors を form.errors に取り込む
       render :edit, status: :unprocessable_entity
     end
   end
@@ -72,13 +65,11 @@ class TasksController < ApplicationController
 
   def authorize_view!
     return if Current.user.admin? || !@task.restricted
-
     redirect_to tasks_path, alert: "アクセス権限がありません"
   end
 
   def authorize_edit!
     return if @task.user == Current.user
-
     redirect_to @task, alert: "編集権限がありません"
   end
 
@@ -89,9 +80,7 @@ class TasksController < ApplicationController
       :due_at,
       :parent_id
     ]
-
     permitted << :restricted if Current.user.admin?
-
     params.require(:task).permit(*permitted, images: [])
   end
 end

--- a/app/forms/task_form.rb
+++ b/app/forms/task_form.rb
@@ -1,0 +1,54 @@
+class TaskForm
+  include ActiveModel::Model
+
+  attr_reader :task
+  attr_accessor :assignee_ids, :interaction_id, :notice_id
+
+  validate :task_must_be_valid
+  validate :at_least_one_assignee, if: -> { task.new_record? }
+
+  def initialize(task:, assignee_ids: [], interaction_id: nil, notice_id: nil)
+    @task           = task
+    @assignee_ids   = Array(assignee_ids).reject(&:blank?).uniq
+    @interaction_id = interaction_id
+    @notice_id      = notice_id
+  end
+
+  def save
+    return false unless valid?
+
+    # TaskForm#save は新規作成のみを想定している。
+    # 担当者の追加・削除・status変更を含む更新対応は別Issueで実装予定。
+    raise "TaskForm#save does not support existing records yet" if task.persisted?
+
+    ActiveRecord::Base.transaction do
+      task.save!
+      task.interactions << Interaction.find(interaction_id) if interaction_id.present?
+      task.notices      << Notice.find(notice_id)           if notice_id.present?
+
+      assignee_ids.each do |user_id|
+        task.task_assignments.create!(user_id: user_id, status: :todo)
+      end
+    end
+
+    true
+  end
+
+  private
+
+  # Task自身のバリデーション(title, description, restricted, images)を
+  # TaskFormのエラーとして取り込む
+  def task_must_be_valid
+    return if task.valid?
+
+    task.errors.each do |error|
+      errors.add(:base, task.errors.full_message(error.attribute, error.message))
+    end
+  end
+
+  # 新規作成時のみ、担当者が1人以上選択されているかチェック
+  def at_least_one_assignee
+    return if assignee_ids.any?
+    errors.add(:base, "担当者を1人以上選択してください")
+  end
+end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,11 +1,11 @@
 <%= form_with model: task, class: "space-y-4" do |f| %>
-  <% if task.errors.any? %>
+  <% if form.errors.any? %>
     <div class="bg-red-50 border border-red-300 rounded p-4">
       <p class="text-red-700 font-semibold text-sm mb-2">
-        <%= task.errors.count %>件のエラーがあります
+        <%= form.errors.count %>件のエラーがあります
       </p>
       <ul class="list-disc list-inside text-red-600 text-sm space-y-1">
-        <% task.errors.full_messages.each do |msg| %>
+        <% form.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
       </ul>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -8,7 +8,7 @@
       <div class="border-b-4 border-purple-500 pb-4 mb-6">
         <h1 class="text-2xl font-bold">タスクを編集</h1>
       </div>
-      <%= render "form", task: @task %>
+      <%= render "form", task: @task, form: @form %>
     </div>
   </div>
 </div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -15,7 +15,7 @@
           <%= @parent_task ? "関連タスクを登録" : "タスクを新規登録" %>
         </h1>
       </div>
-      <%= render "form", task: @task %>
+      <%= render "form", task: @task, form: @form %>
     </div>
   </div>
 </div>

--- a/spec/forms/task_form_spec.rb
+++ b/spec/forms/task_form_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe TaskForm do
+  let(:user)     { create(:user) }
+  let(:assignee) { create(:user) }
+
+  let(:task) do
+    user.tasks.build(
+      title:       "タイトル",
+      description: "説明",
+      due_at:      1.week.from_now
+    )
+  end
+
+  describe "#save" do
+    context "with valid attributes and assignees" do
+      subject(:form) { described_class.new(task: task, assignee_ids: [ assignee.id.to_s ]) }
+
+      it "saves the task" do
+        expect { form.save }.to change(Task, :count).by(1)
+      end
+
+      it "creates a task_assignment with status todo" do
+        form.save
+        assignment = task.task_assignments.last
+        expect(assignment.user).to eq(assignee)
+        expect(assignment.status).to eq("todo")
+      end
+    end
+
+    context "with duplicated assignee_ids" do
+      subject(:form) do
+        described_class.new(
+          task: task,
+          assignee_ids: [ assignee.id.to_s, assignee.id.to_s ]
+        )
+      end
+
+      it "creates only one task_assignment" do
+        expect {
+          form.save
+        }.to change(TaskAssignment, :count).by(1)
+      end
+    end
+
+    context "without assignee_ids on a new record" do
+      subject(:form) { described_class.new(task: task, assignee_ids: []) }
+
+      it "does not save the task" do
+        expect { form.save }.not_to change(Task, :count)
+      end
+
+      it "adds a base error" do
+        form.save
+        expect(form.errors[:base]).to include("担当者を1人以上選択してください")
+      end
+    end
+
+    context "with invalid task attributes" do
+      subject(:form) { described_class.new(task: task, assignee_ids: [ assignee.id.to_s ]) }
+
+      let(:task) { user.tasks.build(title: nil, description: "説明") }
+
+      it "does not save the task" do
+        expect { form.save }.not_to change(Task, :count)
+      end
+
+      it "exposes the task's validation errors" do
+        form.save
+        expect(form.errors[:base]).to be_present
+      end
+    end
+
+    context "when updating an existing task without assignee_ids" do
+      subject(:form) { described_class.new(task: persisted_task, assignee_ids: []) }
+
+      let(:persisted_task) { create(:task, user: user, description: "元の説明") }
+
+      it "does not require an assignee" do
+        persisted_task.description = "更新後の説明"
+        expect(form.valid?).to be(true)
+      end
+
+      it "raises when save is called on a persisted task" do
+        expect { form.save }.to raise_error(/does not support existing records/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容

- `app/forms/task_form.rb` を新規追加
  - Task の保存と TaskAssignment の作成を1つの操作として扱う
  - `assignee_ids` の必須チェック（新規作成時のみ）をバリデーションとして実装
  - 重複した `assignee_ids` を `uniq` で除去
  - Task 自体のバリデーションエラーを `TaskForm` のエラーとして取り込み、二重管理を回避
- `TasksController` の `new` / `create` / `edit` / `update` で `TaskForm` を使用
  - `update` の保存ロジック自体（`@task.update(task_params)`）は変更なし
- `_form.html.erb` のエラー表示を `form.errors` に変更
- `spec/forms/task_form_spec.rb` を新規追加

## 確認済み

- [x] タスク登録フォームで担当者を複数選択できることを確認
- [x] 担当者未選択で登録しようとするとエラーが表示されることを確認
- [x] 重複した担当者を選択しても TaskAssignment が1件のみ作成されることを確認
- [x] 既存のタスク編集機能が引き続き動作することを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過
- [x] GitHub Actions が正常に動作

## 補足

- `interaction_id` / `notice_id` の存在チェックは別Issueで対応予定
- 担当者の追加・削除・status変更を含む編集機能は別Issueで対応予定

Closes #114 