### PR TITLE
Implement Interaction Search with Ransack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ group :test do
 end
 
 gem "tailwindcss-rails", "~> 4.4"
+gem "ransack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
+    ransack (4.4.1)
+      activerecord (>= 7.2)
+      activesupport (>= 7.2)
+      i18n
     rbs (4.0.2)
       logger
       prism (>= 1.6.0)
@@ -494,6 +498,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.2)
   rails-i18n
+  ransack
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase
   rubocop-rspec

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -3,9 +3,10 @@ class InteractionsController < ApplicationController
   before_action :authorize_edit!, only: [ :edit, :update ]
 
   def index
-    @interactions = Interaction
-                      .preload(:customer, :user)
-                      .order(occurred_at: :desc)
+    @q = Interaction.ransack(params[:q])
+    @interactions = @q.result
+                    .preload(:customer, :user)
+                    .order(occurred_at: :desc)
   end
 
   def new

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -8,4 +8,10 @@ class Customer < ApplicationRecord
 
   # add associations after other models are created
   has_many :interactions
+
+  private
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name phone]
+  end
 end

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -53,4 +53,12 @@ class Interaction < ApplicationRecord
   def assign_self_as_root
     update_column(:root_id, id) if root_id.nil?
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[channel completed occurred_at]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[customer user]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,10 @@ class User < ApplicationRecord
   validates :email_address, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :name, presence: true, length: { maximum: 50 }
   validates :password, length: { minimum: 8 }, if: -> { new_record? || !password.nil? }
+
+  private
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
 end

--- a/app/views/interactions/_search_form.html.erb
+++ b/app/views/interactions/_search_form.html.erb
@@ -1,0 +1,53 @@
+<h2 class="text-sm font-semibold mb-3">検索</h2>
+<%= search_form_for @q, url: interactions_path, method: :get, html: { class: "text-sm w-full" } do |f| %>
+  <div class="flex flex-nowrap items-end gap-3 w-full overflow-x-auto">
+    <div class="w-44 shrink-0">
+      <%= f.label :customer_name_cont, "顧客名", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :customer_name_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "例）鈴木" %>
+    </div>
+    <div class="w-44 shrink-0">
+      <%= f.label :customer_phone_cont, "電話番号", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :customer_phone_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "部分一致可" %>
+    </div>
+    <div class="w-40 shrink-0">
+      <%= f.label :user_name_cont, "担当者名", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :user_name_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "例）佐藤" %>
+    </div>
+    <div class="w-28 shrink-0">
+      <%= f.label :channel_eq, "問い合わせ種別", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.select :channel_eq,
+            [["指定なし", ""], ["電話", "phone"], ["メール", "email"], ["Web", "web"], ["SNS", "sns"], ["対面", "in_person"]],
+            {},
+            class: "w-full border rounded px-3 py-2 h-10" %>
+    </div>
+    <div class="w-28 shrink-0">
+      <%= f.label :completed_eq, "対応状況", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.select :completed_eq,
+            [["指定なし", ""], ["対応中", false], ["対応完了", true]],
+            {},
+            class: "w-full border rounded px-3 py-2 h-10" %>
+    </div>
+    <div class="w-28 shrink-0">
+      <%= f.label :occurred_at_gteq, "応対日（いつから）", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.date_field :occurred_at_gteq,
+            class: "w-full border rounded px-3 py-2 h-10" %>
+    </div>
+    <div class="w-28 shrink-0">
+      <%= f.label :occurred_at_lteq, "応対日（いつまで）", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.date_field :occurred_at_lteq,
+            class: "w-full border rounded px-3 py-2 h-10" %>
+    </div>
+    <div class="flex items-end gap-2 ml-auto shrink-0">
+      <%= link_to "クリア", interactions_path,
+            class: "px-3 py-2 border rounded text-gray-600 h-10 inline-flex items-center whitespace-nowrap" %>
+      <%= f.submit "検索",
+            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 h-10 whitespace-nowrap" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -1,9 +1,12 @@
 <div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-4xl mx-auto px-4">
+  <div class="max-w-7xl mx-auto px-4">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold">応対履歴一覧</h1>
       <%= link_to "新規登録", new_interaction_path,
             class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4 mb-4">
+      <%= render "search_form" %>
     </div>
     <div class="bg-white rounded-lg shadow">
       <% if @interactions.any? %>

--- a/spec/requests/interactions_search_spec.rb
+++ b/spec/requests/interactions_search_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe "Interactions search", type: :request do
+  let(:customer) { create(:customer, name: "鈴木太郎", phone: "090-1111-2222") }
+  let(:other_customer) { create(:customer, name: "佐藤花子", phone: "080-3333-4444") }
+  let(:user) { create(:user, name: "田中") }
+  let(:other_user) { create(:user, name: "山田") }
+
+  before do
+    sign_in(user)
+
+    create(:interaction, customer: customer, user: user,
+          channel: "phone", completed: false, occurred_at: "2026-06-01 10:00")
+    create(:interaction, customer: other_customer, user: other_user,
+          channel: "email", completed: true, occurred_at: "2026-06-10 10:00")
+  end
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /interactions" do
+    it "returns all records when no search params are given" do
+      get interactions_path
+
+      expect(response.body).to include(customer.name, other_customer.name)
+    end
+
+    it "filters by customer name" do
+      get interactions_path, params: { q: { customer_name_cont: "鈴木" } }
+
+      expect(response.body).to include(customer.name)
+      expect(response.body).not_to include(other_customer.name)
+    end
+
+    it "filters by customer phone" do
+      get interactions_path, params: { q: { customer_phone_cont: "090" } }
+
+      expect(response.body).to include(customer.name)
+      expect(response.body).not_to include(other_customer.name)
+    end
+
+    it "filters by assignee name" do
+      get interactions_path, params: { q: { user_name_cont: "田中" } }
+
+      expect(response.body).to include(customer.name)
+      expect(response.body).not_to include(other_customer.name)
+    end
+
+    it "filters by channel" do
+      get interactions_path, params: { q: { channel_eq: "email" } }
+
+      expect(response.body).to include(other_customer.name)
+      expect(response.body).not_to include(customer.name)
+    end
+
+    it "filters by completion status" do
+      get interactions_path, params: { q: { completed_eq: "true" } }
+
+      expect(response.body).to include(other_customer.name)
+      expect(response.body).not_to include(customer.name)
+    end
+
+    it "filters by occurred_at range" do
+      get interactions_path, params: { q: { occurred_at_gteq: "2026-06-05" } }
+      expect(response.body).to include(other_customer.name)
+      expect(response.body).not_to include(customer.name)
+    end
+
+    it "filters by multiple conditions combined" do
+      get interactions_path, params: {
+        q: { channel_eq: "phone", completed_eq: "false", occurred_at_lteq: "2026-06-05" }
+      }
+      expect(response.body).to include(customer.name)
+      expect(response.body).not_to include(other_customer.name)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

応対履歴一覧画面に検索機能を追加。

検索機能には `ransack` を使用。
顧客名・電話番号・担当者名・問い合わせ種別・対応状況・応対日の範囲で絞り込みが可能。

## 変更内容

- `ransack` gemを追加
- `Interaction` モデルに検索対象を追加
  - `ransackable_attributes`
    - `channel`
    - `completed`
    - `occurred_at`
  - `ransackable_associations`
    - `customer`
    - `user`

- `Customer` モデルに検索対象を追加
  - `ransackable_attributes`
    - `name`
    - `phone`

- `User` モデルに検索対象を追加
  - `ransackable_attributes`
    - `name`

- `InteractionsController#index` で検索クエリ（`@q`）を処理するように変更

- 検索フォームを追加
  - `_search_form.html.erb` として分割

- `spec/requests/interactions_search_spec.rb` を新規追加

## 確認済み

- [x] 各検索条件で正しく絞り込まれることを確認
- [x] クリアボタンで検索条件がリセットされることを確認
- [x] 検索条件なしで全件表示されることを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過

## 補足

- お知らせ・タスク・顧客・従業員一覧への検索機能追加は別Issueで対応予定

Closes #116 