### PR TITLE
Implement Customer Search with Ransack

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -2,7 +2,8 @@ class CustomersController < ApplicationController
   before_action :set_customer, only: [ :show, :edit, :update ]
 
   def index
-    @customers = Customer.order(:name)
+    @q = Customer.ransack(params[:q], auth_object: :customer_list)
+    @customers = @q.result.order(:name)
   end
 
   def new

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -12,6 +12,11 @@ class Customer < ApplicationRecord
   private
 
   def self.ransackable_attributes(auth_object = nil)
-    %w[name phone]
+    base = %w[name phone]
+    auth_object == :customer_list ? base + %w[email] : base
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
   end
 end

--- a/app/views/customers/_search_form.html.erb
+++ b/app/views/customers/_search_form.html.erb
@@ -1,0 +1,29 @@
+<h2 class="text-sm font-semibold mb-3">検索</h2>
+<%= search_form_for @q, url: customers_path, method: :get, html: { class: "text-sm w-full" } do |f| %>
+  <div class="flex flex-nowrap items-end gap-3 w-full overflow-x-auto">
+    <div class="w-64 shrink-0">
+      <%= f.label :name_cont, "名前", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :name_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "例）鈴木" %>
+    </div>
+    <div class="w-64 shrink-0">
+      <%= f.label :phone_cont, "電話番号", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :phone_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "部分一致可" %>
+    </div>
+    <div class="w-80 shrink-0">
+      <%= f.label :email_cont, "メールアドレス", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :email_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "部分一致可" %>
+    </div>
+    <div class="flex items-end gap-2 ml-auto shrink-0">
+      <%= link_to "クリア", customers_path,
+class: "px-3 py-2 border rounded text-gray-600 h-10 inline-flex items-center whitespace-nowrap" %>
+      <%= f.submit "検索",
+            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 h-10 whitespace-nowrap" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/customers/index.html.erb
+++ b/app/views/customers/index.html.erb
@@ -1,9 +1,12 @@
 <div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-4xl mx-auto px-4">
+  <div class="max-w-7xl mx-auto px-4">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold">顧客一覧</h1>
       <%= link_to "新規登録", new_customer_path,
             class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4 mb-4">
+      <%= render "search_form" %>
     </div>
     <div class="bg-white rounded-lg shadow">
       <% if @customers.any? %>

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -94,4 +94,25 @@ RSpec.describe Customer, type: :model do
       end
     end
   end
+
+  describe 'ransackable_attributes' do
+    context "when auth_object is :customer_list" do
+      it "permits email in addition to name and phone" do
+        expect(described_class.ransackable_attributes(:customer_list)).to include("name", "phone", "email")
+      end
+    end
+
+    context "when auth_object is nil" do
+      it "does not permit email" do
+        expect(described_class.ransackable_attributes(nil)).to include("name", "phone")
+        expect(described_class.ransackable_attributes(nil)).not_to include("email")
+      end
+    end
+
+    context "when auth_object is some other unexpected value" do
+      it "falls back to the restricted list" do
+        expect(described_class.ransackable_attributes(:something_else)).not_to include("email")
+      end
+    end
+  end
 end

--- a/spec/requests/customers_search_spec.rb
+++ b/spec/requests/customers_search_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Customers search", type: :request do
+  let(:user) { create(:user, name: "田中") }
+  let(:customer) { create(:customer, name: "鈴木太郎", phone: "090-1111-2222", email: "suzuki@example.com") }
+  let(:other_customer) { create(:customer, name: "佐藤花子", phone: "080-3333-4444", email: "sato@example.com") }
+
+  before do
+    sign_in(user)
+    customer
+    other_customer
+  end
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /customers" do
+    it "returns all records when no search params are given" do
+      get customers_path
+
+      expect(response.body).to include(customer.name, other_customer.name)
+    end
+
+    it "filters by name" do
+      get customers_path, params: { q: { name_cont: "鈴木" } }
+
+      expect(response.body).to include(customer.name)
+      expect(response.body).not_to include(other_customer.name)
+    end
+
+    it "filters by phone" do
+      get customers_path, params: { q: { phone_cont: "090" } }
+
+      expect(response.body).to include(customer.name)
+      expect(response.body).not_to include(other_customer.name)
+    end
+
+    it "filters by email" do
+      get customers_path, params: { q: { email_cont: "suzuki" } }
+
+      expect(response.body).to include(customer.name)
+      expect(response.body).not_to include(other_customer.name)
+    end
+
+    it "filters by multiple conditions combined" do
+      get customers_path, params: { q: { name_cont: "鈴木", phone_cont: "090" } }
+
+      expect(response.body).to include(customer.name)
+      expect(response.body).not_to include(other_customer.name)
+    end
+  end
+end

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe "Interactions", type: :request do
   include InteractionsHelper
 
   let(:user) { create(:user) }
+  let(:customer) { create(:customer, name: "鈴木太郎", phone: "090-1111-2222", email: "suzuki@example.com") }
+  let(:other_customer) { create(:customer, name: "佐藤花子", phone: "080-3333-4444", email: "sato@example.com") }
+
 
   def sign_in(user)
     post session_path, params: { email_address: user.email_address, password: "password55" }
@@ -32,6 +35,16 @@ RSpec.describe "Interactions", type: :request do
         get interactions_path
         expect(response.body).to include("完了")
         expect(response.body).to include("対応中")
+      end
+
+      it "ignores unauthorized customer email filter and returns unfiltered results" do
+        create(:interaction, customer: customer, user: user)
+        create(:interaction, customer: other_customer, user: user)
+
+        get interactions_path, params: { q: { customer_email_cont: customer.email } }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(customer.name, other_customer.name)
       end
     end
 


### PR DESCRIPTION
## 概要
顧客一覧画面に検索機能を追加。
顧客名・電話番号・メールアドレスで絞り込みが可能。
検索機能には既存導入済みの `ransack` を使用。

## 変更内容
- `Customer` モデルに検索対象を追加
  - `ransackable_attributes`
    - `name`
    - `phone`
    - `email`(顧客一覧画面からの検索時のみ許可)
  - `ransackable_associations`
    - 追加なし(空配列を定義)
  - `auth_object` の値に応じて許可する検索項目を切り替えるよう変更
    - 応対履歴一覧画面（`Interaction` 経由の検索）からは引き続き `name` `phone` のみ許可され、`email` では検索できないようにしています
- `CustomersController#index` で検索クエリ（`@q`）を `auth_object` 付きで処理するように変更
- 検索フォームを追加
  - `_search_form.html.erb` として分割
- `spec/requests/customers_search_spec.rb` を新規追加
- `Customer` モデルの `ransackable_attributes` の `auth_object` による切り替えに対するテストを追加

## 確認済み
- [x] 各検索条件で正しく絞り込まれることを確認
- [x] クリアボタンで検索条件がリセットされることを確認
- [x] 検索条件なしで全件表示されることを確認
- [x] 応対履歴一覧画面から顧客のメールアドレスでは検索できない(無視され全件表示される)ことを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過

## 補足
- お知らせ・タスク・従業員一覧への検索機能追加は別Issueで対応予定

Closes #118 