### PR TITLE
Implement User Search with Ransack

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,8 @@ class UsersController < ApplicationController
   before_action :require_admin, only: %i[new create edit update]
 
   def index
-    @users = User.order(:name)
+    @q = User.ransack(params[:q], auth_object: :user_list)
+    @users = @q.result.order(:name)
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,11 @@ class User < ApplicationRecord
   private
 
   def self.ransackable_attributes(auth_object = nil)
-    %w[name]
+    base = %w[name]
+    auth_object == :user_list ? base + %w[email_address admin] : base
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
   end
 end

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,0 +1,30 @@
+<h2 class="text-sm font-semibold mb-3">検索</h2>
+<%= search_form_for @q, url: users_path, method: :get, html: { class: "text-sm w-full" } do |f| %>
+  <div class="flex flex-nowrap items-end gap-3 w-full overflow-x-auto">
+    <div class="w-64 shrink-0">
+      <%= f.label :name_cont, "氏名", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :name_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "例）鈴木" %>
+    </div>
+    <div class="w-80 shrink-0">
+      <%= f.label :email_address_cont, "メールアドレス", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :email_address_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "部分一致可" %>
+    </div>
+    <div class="w-64 shrink-0">
+      <%= f.label :admin_eq, "権限", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.select :admin_eq,
+            [["指定なし", ""], ["一般", false], ["管理者", true]],
+            {},
+            class: "w-full border rounded px-3 py-2 h-10" %>
+    </div>
+    <div class="flex items-end gap-2 ml-auto shrink-0">
+      <%= link_to "クリア", users_path,
+            class: "px-3 py-2 border rounded text-gray-600 h-10 inline-flex items-center whitespace-nowrap" %>
+      <%= f.submit "検索",
+            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 h-10 whitespace-nowrap" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,10 +1,13 @@
 <div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-6xl mx-auto px-4">
+  <div class="max-w-7xl mx-auto px-4">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold">従業員一覧</h1>
       <% if Current.user&.admin? %>
         <%= link_to "新規登録", new_user_path, class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm" %>
       <% end %>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4 mb-4">
+      <%= render "search_form" %>
     </div>
     <div class="bg-white rounded-lg shadow">
       <% if @users.any? %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -101,4 +101,25 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe 'ransackable_attributes' do
+    context "when auth_object is :user_list" do
+      it "permits email_address and admin_status in addition to name" do
+        expect(described_class.ransackable_attributes(:user_list)).to include("name", "email_address", "admin")
+      end
+    end
+
+    context "when auth_object is nil" do
+      it "does not permit email or admin" do
+        expect(described_class.ransackable_attributes(nil)).to include("name")
+        expect(described_class.ransackable_attributes(nil)).not_to include("email_address", "admin")
+      end
+    end
+
+    context "when auth_object is some other unexpected value" do
+      it "falls back to the restricted list" do
+        expect(described_class.ransackable_attributes(:something_else)).not_to include("email_address", "admin")
+      end
+    end
+  end
 end

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe "Interactions", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(customer.name, other_customer.name)
       end
+
+      it "ignores unauthorized user email_address, admin filter and returns unfiltered results" do
+        admin = create(:user, admin: true)
+        create(:interaction, customer: customer, user: user)
+        create(:interaction, customer: other_customer, user: admin)
+
+        get interactions_path, params: {
+          q: { email_address_cont: admin.email_address, admin_eq: true }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(customer.name, other_customer.name)
+      end
     end
 
     context "when the user is not logged in" do

--- a/spec/requests/users_search_spec.rb
+++ b/spec/requests/users_search_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Users search", type: :request do
+  let(:user)       { create(:user, name: "田中", admin: true) }
+  let(:other_user) { create(:user, name: "山田", admin: false) }
+
+  before do
+    other_user
+    sign_in(user)
+  end
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /users" do
+    it "returns all records when no search params are given" do
+      get users_path
+
+      expect(response.body).to include(user.name, other_user.name)
+    end
+
+    it "filters by name" do
+      get users_path, params: { q: { name_cont: "田中" } }
+
+      expect(response.body).to include(user.name)
+      expect(response.body).not_to include(other_user.name)
+    end
+
+    it "filters by email_address" do
+      get users_path, params: { q: { email_address_cont: user.email_address } }
+
+      expect(response.body).to include(user.name)
+      expect(response.body).not_to include(other_user.name)
+    end
+
+    it "filters by admin status" do
+      get users_path, params: { q: { admin_eq: true } }
+
+      expect(response.body).to include(user.name)
+      expect(response.body).not_to include(other_user.name)
+    end
+
+    it "filters by multiple conditions combined" do
+      get users_path, params: { q: { name_cont: "田中", email_address_cont: user.email_address } }
+
+      expect(response.body).to include(user.name)
+      expect(response.body).not_to include(other_user.name)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
従業員一覧画面に検索機能を追加。
氏名・メールアドレス・権限で絞り込みが可能。
検索機能には既存導入済みの `ransack` を使用。

## 変更内容
- `User(Employee)` モデルに検索対象を追加
  - `ransackable_attributes`
    - `name`
    - `email_address`(従業員一覧画面からの検索時のみ許可)
    - `adminl`(従業員一覧画面からの検索時のみ許可)
  - `ransackable_associations`
    - 追加なし(空配列を定義)
  - `auth_object` の値に応じて許可する検索項目を切り替えるよう変更
    - 応対履歴一覧画面（`Interaction` 経由の検索）からは引き続き `name` のみ許可され、`email_address` や `admin` では検索できないようにしています
- `UsersController#index` で検索クエリ（`@q`）を `auth_object` 付きで処理するように変更
- 検索フォームを追加
  - `_search_form.html.erb` として分割
- `spec/requests/users_search_spec.rb` を新規追加
- `User` モデルの `ransackable_attributes` の `auth_object` による切り替えに対するテストを追加

## 確認済み
- [x] 各検索条件で正しく絞り込まれることを確認
- [x] クリアボタンで検索条件がリセットされることを確認
- [x] 検索条件なしで全件表示されることを確認
- [x] 応対履歴一覧画面から従業員のメールアドレスや権限では検索できない(無視され全件表示される)ことを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過

## 補足
- お知らせ・タスク一覧への検索機能追加は別Issueで対応予定

Closes #123