### PR TITLE
Implement Task Search with Ransack

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,10 @@ class TasksController < ApplicationController
   before_action :authorize_edit!, only: [ :edit, :update ]
 
   def index
-    @tasks = visible_tasks.preload(:user).order(due_at: :asc)
+    @q = visible_tasks.ransack(params[:q], auth_object: :admin)
+    @tasks = @q.result
+               .preload(:user)
+               .order(due_at: :asc)
   end
 
   def new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -40,4 +40,29 @@ class Task < ApplicationRecord
   def assign_self_as_root
     update_column(:root_id, id) if root_id.nil?
   end
+
+  scope :due_within, ->(period) {
+    from = Time.current.beginning_of_day
+    case period
+    when "unset" then where(due_at: nil)
+    when "overdue" then where(due_at: ...Time.current.beginning_of_day)
+    when "today" then where(due_at: from..Time.current.end_of_day)
+    when "week"  then where(due_at: from..Time.current.end_of_week.end_of_day)
+    when "month" then where(due_at: from..Time.current.end_of_month.end_of_day)
+    else all
+    end
+  }
+
+  def self.ransackable_attributes(auth_object = nil)
+    base = %w[title description due_at]
+    auth_object == :admin ? base + %w[restricted] : base
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[task_assignments user]
+  end
+
+  def self.ransackable_scopes(auth_object = nil)
+    %w[due_within]
+  end
 end

--- a/app/models/task_assignment.rb
+++ b/app/models/task_assignment.rb
@@ -9,4 +9,14 @@ class TaskAssignment < ApplicationRecord
   }, default: :todo
 
   validates :task_id, uniqueness: { scope: :user_id }
+
+  private
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[status user_id]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[user]
+  end
 end

--- a/app/views/tasks/_search_form.html.erb
+++ b/app/views/tasks/_search_form.html.erb
@@ -1,0 +1,59 @@
+<h2 class="text-sm font-semibold mb-3">検索</h2>
+<%= search_form_for @q, url: tasks_path, method: :get, html: { class: "text-sm w-full" } do |f| %>
+  <div class="flex flex-nowrap items-end gap-3 w-full">
+    <div class="w-64 shrink-0">
+      <%= f.label :title_or_description_cont, "キーワード", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :title_or_description_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "タイトル・本文" %>
+    </div>
+    <div class="w-44 shrink-0">
+      <%= f.label :user_name_cont, "作成者名", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :user_name_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "例）田中" %>
+    </div>
+    <div class="w-44 shrink-0">
+      <%= f.label :task_assignments_user_name_cont, "担当者名", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :task_assignments_user_name_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "例）佐藤" %>
+    </div>
+    <div class="w-32 shrink-0">
+      <%= f.label :task_assignments_status_eq, "進捗状況", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.select :task_assignments_status_eq,
+            [["指定なし", ""], ["未着手", "todo"], ["進行中", "in_progress"], ["完了", "done"]],
+            {},
+            class: "w-full border rounded px-3 py-2 h-10" %>
+    </div>
+    <div class="w-32 shrink-0">
+      <%= f.label :due_within, "期限", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.select :due_within,
+            [
+              ["指定なし",   ""],
+              ["期限未設定", "unset"],
+              ["期限超過", "overdue"],
+              ["今日まで",   "today"],
+              ["今週末まで",   "week"],
+              ["今月末まで",   "month"]
+            ],
+            {},
+            class: "w-full border rounded px-3 py-2 h-10" %>
+    </div>
+    <% if Current.user.admin? %>
+      <div class="w-32 shrink-0">
+        <%= f.label :restricted_eq, "公開範囲", class: "block text-xs text-gray-600 mb-1" %>
+        <%= f.select :restricted_eq,
+              [["指定なし", ""], ["全員", false], ["管理者のみ", true]],
+              {},
+              class: "w-full border rounded px-3 py-2 h-10" %>
+      </div>
+    <% end %>
+    <div class="flex items-end gap-2 ml-auto shrink-0">
+      <%= link_to "クリア", tasks_path,
+            class: "px-3 py-2 border rounded text-gray-600 h-10 inline-flex items-center whitespace-nowrap" %>
+      <%= f.submit "検索",
+            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 h-10 whitespace-nowrap" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,9 +1,12 @@
 <div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-4xl mx-auto px-4">
+  <div class="max-w-7xl mx-auto px-4">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold">タスク一覧</h1>
       <%= link_to "新規登録", new_task_path,
             class: "px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600 text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4 mb-4">
+      <%= render "search_form" %>
     </div>
     <div class="bg-white rounded-lg shadow">
       <% if @tasks.any? %>

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Task, type: :model do
   end
 
   describe 'associations' do
-    it 'belongs to user)' do
+    it 'belongs to user' do
       association = described_class.reflect_on_association(:user)
       expect(association.macro).to eq(:belongs_to)
     end
@@ -42,7 +42,7 @@ RSpec.describe Task, type: :model do
       association = described_class.reflect_on_association(:assigned_users)
       expect(association.macro).to eq(:has_many)
       expect(association.options[:through]).to eq(:task_assignments)
-      expect(association.options[:source]).to eq (:user)
+      expect(association.options[:source]).to eq(:user)
     end
   end
 
@@ -131,6 +131,103 @@ RSpec.describe Task, type: :model do
 
         expect { task.destroy }.to change(ActiveStorage::Attachment, :count).by(-1)
       end
+    end
+  end
+
+  describe "ransackable_attributes" do
+    it "permits restricted in addition to base attributes when auth_object is :admin" do
+      expect(described_class.ransackable_attributes(:admin)).to include("title", "description", "due_at", "restricted")
+    end
+
+    it "does not permit restricted when auth_object is nil" do
+      expect(described_class.ransackable_attributes(nil)).to include("title", "description", "due_at")
+      expect(described_class.ransackable_attributes(nil)).not_to include("restricted")
+    end
+
+    it "falls back to the base list without restricted for unexpected auth_object values" do
+      expect(described_class.ransackable_attributes(:something_else)).not_to include("restricted")
+    end
+  end
+
+  describe "ransackable_associations" do
+    it "permits task_assignments and user" do
+      expect(described_class.ransackable_associations).to include("task_assignments", "user")
+    end
+  end
+
+  describe "ransackable_scopes" do
+    it "permits due_within" do
+      expect(described_class.ransackable_scopes).to include("due_within")
+    end
+  end
+
+  describe "due_within" do
+    # Fixed date: Tuesday, June 11, 2024
+    # end_of_week = Sunday, June 16, 2024
+    # end_of_month = June 30, 2024
+    around do |example|
+      travel_to(Time.zone.local(2024, 6, 11, 12, 0, 0), &example)
+    end
+
+    let(:tasks) do
+      {
+        no_due: create(:task, due_at: nil),
+        overdue: create(:task, due_at: Time.zone.local(2024, 6, 10, 9, 0, 0)),
+        today: create(:task, due_at: Time.zone.local(2024, 6, 11, 15, 0, 0)),
+        this_week: create(:task, due_at: Time.zone.local(2024, 6, 14, 12, 0, 0)),
+        next_week: create(:task, due_at: Time.zone.local(2024, 6, 17, 12, 0, 0)),
+        this_month: create(:task, due_at: Time.zone.local(2024, 6, 28, 12, 0, 0)),
+        next_month: create(:task, due_at: Time.zone.local(2024, 7, 15, 12, 0, 0))
+      }
+    end
+
+    it "returns only tasks with no due date when 'unset'" do
+      result = described_class.due_within("unset")
+
+      expect(result).to include(tasks[:no_due])
+      expect(result).not_to include(tasks[:today])
+    end
+
+    it "returns only tasks past the start of today when 'overdue'" do
+      result = described_class.due_within("overdue")
+
+      expect(result).to include(tasks[:overdue])
+      expect(result).not_to include(tasks[:today])
+    end
+
+    it "returns only tasks due within today when 'today'" do
+      result = described_class.due_within("today")
+
+      expect(result).to include(tasks[:today])
+      expect(result).not_to include(tasks[:overdue], tasks[:this_week])
+    end
+
+    it "returns tasks due from today through end of this week when 'week'" do
+      result = described_class.due_within("week")
+
+      expect(result).to include(tasks[:today], tasks[:this_week])
+      expect(result).not_to include(tasks[:overdue], tasks[:next_week])
+    end
+
+    it "returns tasks due from today through end of this month when 'month'" do
+      result = described_class.due_within("month")
+
+      expect(result).to include(tasks[:today], tasks[:next_week], tasks[:this_month])
+      expect(result).not_to include(tasks[:overdue], tasks[:next_month])
+    end
+
+    it "returns all tasks when the period is an unknown value" do
+      result = described_class.due_within("unknown")
+
+      expect(result).to include(
+        tasks[:no_due],
+        tasks[:overdue],
+        tasks[:today],
+        tasks[:this_week],
+        tasks[:next_week],
+        tasks[:this_month],
+        tasks[:next_month]
+      )
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include ImageHelpers
+  config.include ActiveSupport::Testing::TimeHelpers
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')

--- a/spec/requests/tasks_search_spec.rb
+++ b/spec/requests/tasks_search_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe "Tasks search", type: :request do
+  let(:admin)        { create(:user, name: "管理者", admin: true) }
+  let(:regular_user) { create(:user, name: "一般ユーザー", admin: false) }
+
+  let!(:public_task) { create(:task, title: "公開タスク", description: "誰でも閲覧可能なタスク", user: admin) }
+  let!(:restricted_task) { create(:task, title: "限定タスク", description: "管理者専用コンテンツ", restricted: true, user: admin) }
+  let!(:user_task)       { create(:task, title: "ユーザータスク", description: "一般ユーザーの作業", user: regular_user) }
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /tasks" do
+    context "when signed in as admin" do
+      before { sign_in(admin) }
+
+      it "returns all records including restricted ones when no search params are given" do
+        get tasks_path
+
+        expect(response.body).to include(public_task.title, restricted_task.title, user_task.title)
+      end
+
+      it "filters by title keyword" do
+        get tasks_path, params: { q: { title_cont: "公開" } }
+
+        expect(response.body).to include(public_task.title)
+        expect(response.body).not_to include(restricted_task.title, user_task.title)
+      end
+
+      it "filters by description keyword via title_or_description_cont" do
+        get tasks_path, params: { q: { title_or_description_cont: "管理者専用" } }
+
+        expect(response.body).to include(restricted_task.title)
+        expect(response.body).not_to include(public_task.title, user_task.title)
+      end
+
+      it "filters by creator name" do
+        get tasks_path, params: { q: { user_name_cont: "一般" } }
+
+        expect(response.body).to include(user_task.title)
+        expect(response.body).not_to include(public_task.title, restricted_task.title)
+      end
+
+      it "filters by restricted status" do
+        get tasks_path, params: { q: { restricted_eq: true } }
+
+        expect(response.body).to include(restricted_task.title)
+        expect(response.body).not_to include(public_task.title, user_task.title)
+      end
+
+      it "filters by multiple conditions combined" do
+        get tasks_path, params: { q: { user_name_cont: "管理者", restricted_eq: true } }
+
+        expect(response.body).to include(restricted_task.title)
+        expect(response.body).not_to include(public_task.title, user_task.title)
+      end
+
+      it "filters by assignee name" do
+        assignee = create(:user, name: "担当者A")
+        create(:task_assignment, task: public_task, user: assignee)
+
+        get tasks_path, params: { q: { task_assignments_user_name_cont: "担当者A" } }
+
+        expect(response.body).to include(public_task.title)
+        expect(response.body).not_to include(user_task.title)
+      end
+
+      it "filters by assignee status" do
+        assignee = create(:user, name: "担当者A")
+        create(:task_assignment, task: user_task, user: assignee, status: :in_progress)
+
+        get tasks_path, params: { q: { task_assignments_status_eq: "in_progress" } }
+
+        expect(response.body).to include(user_task.title)
+        expect(response.body).not_to include(public_task.title)
+      end
+    end
+
+    context "when signed in as regular user" do
+      before { sign_in(regular_user) }
+
+      it "returns only non-restricted tasks when no search params are given" do
+        get tasks_path
+
+        expect(response.body).to include(public_task.title, user_task.title)
+        expect(response.body).not_to include(restricted_task.title)
+      end
+
+      it "filters by title keyword among visible tasks only" do
+        get tasks_path, params: { q: { title_cont: "公開" } }
+
+        expect(response.body).to include(public_task.title)
+        expect(response.body).not_to include(user_task.title, restricted_task.title)
+      end
+
+      it "filters by creator name among visible tasks only" do
+        get tasks_path, params: { q: { user_name_cont: "一般" } }
+
+        expect(response.body).to include(user_task.title)
+        expect(response.body).not_to include(public_task.title)
+      end
+
+      it "cannot see restricted tasks even when passing restricted_eq: true" do
+        get tasks_path, params: { q: { restricted_eq: true } }
+
+        expect(response.body).not_to include(restricted_task.title)
+      end
+    end
+  end
+end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -38,6 +38,34 @@ RSpec.describe "Tasks", type: :request do
 
         expect(response.body).not_to include(restricted_task.title)
       end
+
+      it "ignores unauthorized creator user filters and returns unfiltered results" do
+        other_task = create(:task, user: admin, restricted: false)
+
+        get tasks_path, params: {
+          q: {
+            user_email_address_cont: admin.email_address,
+            user_admin_eq: true
+          }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(task.title, other_task.title)
+      end
+
+      it "ignores unauthorized assignee user filters and returns unfiltered results" do
+        other_task = create(:task, user: admin, restricted: false)
+
+        get tasks_path, params: {
+          q: {
+            task_assignments_user_email_address_cont: admin.email_address,
+            task_assignments_user_admin_eq: true
+          }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(task.title, other_task.title)
+      end
     end
 
     context "when the user is an admin" do


### PR DESCRIPTION
## 概要

タスク一覧画面に検索機能を追加。
キーワード・作成者名・担当者名・進捗状況・期限で絞り込みが可能。
検索機能には既存導入済みの `ransack` を使用。

## 変更内容

### `Task` モデル

- `ransackable_attributes` を追加
  - `title` / `description` / `due_at`（全ユーザー共通）
  - `restricted`（管理者のみ。`auth_object == :admin` のときのみ許可）
- `ransackable_associations` を追加
  - `task_assignments` / `user`
- `ransackable_scopes` を追加
  - `due_within`（期限フィルタ用スコープ）

### `TaskAssignment` モデル

- `ransackable_attributes` を追加（`status` / `user_id`）
- `ransackable_associations` を追加（`user`）

### `User` モデル（関連）

- `auth_object` の値に応じて許可する検索項目を切り替え
  - 管理者以外のログインユーザーは `name` のみ許可。`email_address` や `admin` での検索は不可

### `TasksController#index`

- 検索クエリ `@q` を `auth_object: :admin` 付きで処理するように変更

### ビュー

- 検索フォームを `app/views/tasks/_search_form.html.erb` として切り出し
  - キーワード（タイトル・本文）/ 作成者名 / 担当者名 / 進捗状況 / 期限 の各フィールドを追加
  - 管理者のみ「公開範囲」フィルタを表示（`Current.user.admin?` で条件分岐）
  - クリアボタンで検索条件をリセット
- `app/views/tasks/index.html.erb` に検索フォームを埋め込み

### テスト

- `spec/requests/tasks_search_spec.rb` を新規追加
  - 管理者・一般ユーザーそれぞれの検索動作を網羅
  - 担当者名・進捗状況での絞り込みも検証
- `spec/models/task_spec.rb` に `ransackable_attributes` の `auth_object` 切り替えに対するテストを追加
  - `due_within` スコープの境界値テスト（`travel_to` で固定日時を使用）
- `spec/requests/tasks_spec.rb` に未許可フィールドが無視されることを検証するテストを追加
  - `user_email_address_cont` / `user_admin_eq` などが渡された場合、全件表示されることを確認
- `spec/rails_helper.rb` に `ActiveSupport::Testing::TimeHelpers` を追加

## 確認済み

- [x] 各検索条件で正しく絞り込まれることを確認
- [x] クリアボタンで検索条件がリセットされることを確認
- [x] 検索条件なしで全件表示されることを確認
- [x] 従業員（タスクの作成者・担当者）のメールアドレスや権限では検索できない（無視され全件表示される）ことを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過

## 補足

- お知らせ一覧への検索機能追加は別 Issue で対応予定

Closes #125