### PR TITLE
Implement Notice Search with Ransack

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -5,7 +5,10 @@ class NoticesController < ApplicationController
 
 
   def index
-    @notices = visible_notices.preload(:user).order(start_at: :desc)
+    @q = visible_notices.ransack(params[:q], auth_object: :admin)
+    @notices = @q.result
+               .preload(:user)
+               .order(start_at: :desc)
   end
 
   def new

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -46,4 +46,26 @@ class Notice < ApplicationRecord
   def assign_self_as_root
     update_column(:root_id, id) if root_id.nil?
   end
+
+  scope :status, ->(value) {
+    now = Time.current
+    case value
+    when "active" then where("start_at <= ? AND end_at >= ?", now, now)
+    when "expired" then where("end_at < ?", now)
+    else all
+    end
+  }
+
+  def self.ransackable_attributes(auth_object = nil)
+    base = %w[title content level start_at end_at]
+    auth_object == :admin ? base + %w[restricted] : base
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[user]
+  end
+
+  def self.ransackable_scopes(auth_object = nil)
+    %w[status]
+  end
 end

--- a/app/views/notices/_search_form.html.erb
+++ b/app/views/notices/_search_form.html.erb
@@ -1,0 +1,50 @@
+<h2 class="text-sm font-semibold mb-3">検索</h2>
+<%= search_form_for @q, url: notices_path, method: :get, html: { class: "text-sm w-full" } do |f| %>
+  <div class="flex flex-nowrap items-end gap-3 w-full">
+    <div class="w-64 shrink-0">
+      <%= f.label :title_or_content_cont, "キーワード", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :title_or_content_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "タイトル・内容" %>
+    </div>
+    <div class="w-44 shrink-0">
+      <%= f.label :user_name_cont, "作成者名", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.search_field :user_name_cont,
+            class: "w-full border rounded px-3 py-2 h-10",
+            placeholder: "例）田中" %>
+    </div>
+    <div class="w-36 shrink-0">
+      <%= f.label :level_eq, "重要度", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.select :level_eq,
+            [["指定なし", ""], ["高", "important"], ["低", "normal"]],
+            {},
+            class: "w-full border rounded px-3 py-2 h-10" %>
+    </div>
+    <% if Current.user.admin? %>
+      <div class="w-36 shrink-0">
+        <%= f.label :restricted_eq, "公開範囲", class: "block text-xs text-gray-600 mb-1" %>
+        <%= f.select :restricted_eq,
+              [["指定なし", ""], ["全員", false], ["管理者のみ", true]],
+              {},
+              class: "w-full border rounded px-3 py-2 h-10" %>
+      </div>
+    <% end %>
+    <div class="w-36 shrink-0">
+      <%= f.label :due_within, "公開日時", class: "block text-xs text-gray-600 mb-1" %>
+      <%= f.select :status,
+        [
+          ["指定なし", ""],
+          ["公開中", "active"],
+          ["終了済", "expired"]
+        ],
+        {},
+        class: "w-full border rounded px-3 py-2 h-10" %>
+    </div>
+    <div class="flex items-end gap-2 ml-auto shrink-0">
+      <%= link_to "クリア", notices_path,
+            class: "px-3 py-2 border rounded text-gray-600 h-10 inline-flex items-center whitespace-nowrap" %>
+      <%= f.submit "検索",
+            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 h-10 whitespace-nowrap" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,9 +1,12 @@
 <div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-4xl mx-auto px-4">
+  <div class="max-w-7xl mx-auto px-4">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold">お知らせ一覧</h1>
       <%= link_to "新規登録", new_notice_path,
             class: "px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 text-sm" %>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4 mb-4">
+      <%= render "search_form" %>
     </div>
     <div class="bg-white rounded-lg shadow">
       <% if @notices.any? %>

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -196,4 +196,71 @@ RSpec.describe Notice, type: :model do
       expect { notice.destroy }.to change(ActiveStorage::Attachment, :count).by(-1)
     end
   end
+
+  describe "ransackable_attributes" do
+    it "permits restricted in addition to base attributes when auth_object is :admin" do
+      expect(described_class.ransackable_attributes(:admin)).to match_array(%w[title content level start_at end_at restricted])
+    end
+
+    it "does not permit restricted when auth_object is nil" do
+      expect(described_class.ransackable_attributes(nil)).to match_array(%w[title content level start_at end_at])
+    end
+
+    it "falls back to the base list without restricted for unexpected auth_object values" do
+      expect(described_class.ransackable_attributes(:something_else)).to match_array(%w[title content level start_at end_at])
+    end
+  end
+
+  describe "ransackable_associations" do
+    it "permits user" do
+      expect(described_class.ransackable_associations).to include("user")
+    end
+  end
+
+  describe "ransackable_scopes" do
+    it "permits status" do
+      expect(described_class.ransackable_scopes).to include("status")
+    end
+  end
+
+  describe "status" do
+    # Fixed date: Wednesday, June 11, 2025 12:00
+    around do |example|
+      travel_to(Time.zone.local(2025, 6, 11, 12, 0, 0), &example)
+    end
+
+    let(:notices) do
+      {
+        active:         create(:notice, start_at: 1.hour.ago,   end_at: 1.week.from_now),
+        upcoming:        create(:notice, start_at: 1.hour.from_now, end_at: 2.hours.from_now),
+        expired:        create(:notice, start_at: 2.weeks.ago,  end_at: 1.hour.ago),
+        ends_now_edge:  create(:notice, start_at: 1.day.ago,    end_at: Time.current)
+      }
+    end
+
+    it "returns only notices where start_at is past and end_at is future when 'active'" do
+      result = described_class.status("active")
+
+      expect(result).to include(notices[:active], notices[:ends_now_edge])
+      expect(result).not_to include(notices[:upcoming], notices[:expired])
+    end
+
+    it "returns only notices where end_at is past when 'expired'" do
+      result = described_class.status("expired")
+
+      expect(result).to include(notices[:expired])
+      expect(result).not_to include(notices[:active], notices[:upcoming])
+    end
+
+    it "returns all notices when the value is an unknown string" do
+      result = described_class.status("unknown")
+
+      expect(result).to include(
+        notices[:active],
+        notices[:upcoming],
+        notices[:expired],
+        notices[:ends_now_edge]
+      )
+    end
+  end
 end

--- a/spec/requests/notices_search_spec.rb
+++ b/spec/requests/notices_search_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe "Notices search", type: :request do
+  let(:admin)        { create(:user, name: "管理者", admin: true) }
+  let(:regular_user) { create(:user, name: "一般ユーザー", admin: false) }
+
+  let!(:public_notice) do
+    create(:notice, title: "公開お知らせ", content: "誰でも閲覧可能なお知らせ", user: admin)
+  end
+  let!(:restricted_notice) do
+    create(:notice, title: "限定お知らせ", content: "管理者専用コンテンツ", restricted: true, user: admin)
+  end
+  let!(:user_notice) do
+    create(:notice, title: "ユーザーお知らせ", content: "一般ユーザーの作業", user: regular_user)
+  end
+
+  def sign_in(user)
+    post session_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /notices" do
+    context "when signed in as admin" do
+      before { sign_in(admin) }
+
+      it "returns all records including restricted ones when no search params are given" do
+        get notices_path
+
+        expect(response.body).to include(public_notice.title, restricted_notice.title, user_notice.title)
+      end
+
+      it "filters by title keyword" do
+        get notices_path, params: { q: { title_cont: "公開" } }
+
+        expect(response.body).to include(public_notice.title)
+        expect(response.body).not_to include(restricted_notice.title, user_notice.title)
+      end
+
+      it "filters by content keyword via title_or_content_cont" do
+        get notices_path, params: { q: { title_or_content_cont: "管理者専用" } }
+
+        expect(response.body).to include(restricted_notice.title)
+        expect(response.body).not_to include(public_notice.title, user_notice.title)
+      end
+
+      it "filters by creator name" do
+        get notices_path, params: { q: { user_name_cont: "一般" } }
+
+        expect(response.body).to include(user_notice.title)
+        expect(response.body).not_to include(public_notice.title, restricted_notice.title)
+      end
+
+      it "filters by restricted status" do
+        get notices_path, params: { q: { restricted_eq: true } }
+
+        expect(response.body).to include(restricted_notice.title)
+        expect(response.body).not_to include(public_notice.title, user_notice.title)
+      end
+
+      it "filters by multiple conditions combined" do
+        get notices_path, params: { q: { user_name_cont: "管理者", restricted_eq: true } }
+
+        expect(response.body).to include(restricted_notice.title)
+        expect(response.body).not_to include(public_notice.title, user_notice.title)
+      end
+
+      it "filters by level" do
+        normal_notice = create(:notice, title: "通常お知らせ", level: "normal", user: admin)
+
+        get notices_path, params: { q: { level_eq: "important" } }
+
+        expect(response.body).to include(public_notice.title, restricted_notice.title)
+        expect(response.body).not_to include(normal_notice.title)
+      end
+    end
+
+    context "when signed in as regular user" do
+      before { sign_in(regular_user) }
+
+      it "returns only non-restricted notices when no search params are given" do
+        get notices_path
+
+        expect(response.body).to include(public_notice.title, user_notice.title)
+        expect(response.body).not_to include(restricted_notice.title)
+      end
+
+      it "filters by title keyword among visible notices only" do
+        get notices_path, params: { q: { title_cont: "公開" } }
+
+        expect(response.body).to include(public_notice.title)
+        expect(response.body).not_to include(user_notice.title, restricted_notice.title)
+      end
+
+      it "filters by creator name among visible notices only" do
+        get notices_path, params: { q: { user_name_cont: "一般" } }
+
+        expect(response.body).to include(user_notice.title)
+        expect(response.body).not_to include(public_notice.title)
+      end
+
+      it "cannot see restricted notices even when passing restricted_eq: true" do
+        get notices_path, params: { q: { restricted_eq: true } }
+
+        expect(response.body).not_to include(restricted_notice.title)
+      end
+    end
+  end
+end

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe "Notices", type: :request do
 
         expect(response.body).not_to include(restricted_notice.title)
       end
+
+      it "ignores unauthorized creator user filters and returns unfiltered results" do
+        other_notice = create(:notice, user: admin, restricted: false)
+
+        get notices_path, params: {
+          q: {
+            user_email_address_cont: admin.email_address,
+            user_admin_eq: true
+          }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(notice.title, other_notice.title)
+      end
     end
 
     context "when the user is admin" do


### PR DESCRIPTION
## 概要

お知らせ一覧画面に検索機能を追加。
キーワード・作成者名・重要度・公開範囲・公開日時で絞り込みが可能。
検索機能には既存導入済みの `ransack` を使用。

## 変更内容

### `Notice` モデル

- `ransackable_attributes` を追加
  - `title` / `content` / `level` / `start_at` / `end_at`（全ユーザー共通）
  - `restricted`（管理者のみ。`auth_object == :admin` のときのみ許可）
- `ransackable_associations` を追加
  - `user`
- `ransackable_scopes` を追加
  - `status`（公開日時フィルタ用スコープ）

### `User` モデル（関連）

- `auth_object` の値に応じて許可する検索項目を切り替え
  - 管理者以外のログインユーザーは `name` のみ許可。`email_address` や `admin` での検索は不可

### `NoticesController#index`

- 検索クエリ `@q` を `auth_object: :admin` 付きで処理するように変更

### ビュー

- 検索フォームを `app/views/notices/_search_form.html.erb` として切り出し
  - キーワード（タイトル・本文）/ 作成者名 / 重要度 / 公開範囲 / 公開日時 の各フィールドを追加
  - 管理者のみ「公開範囲」フィルタを表示（`Current.user.admin?` で条件分岐）
  - クリアボタンで検索条件をリセット
- `app/views/notices/index.html.erb` に検索フォームを埋め込み

### テスト

- `spec/requests/notices_search_spec.rb` を新規追加
  - 管理者・一般ユーザーそれぞれの検索動作を網羅
- `spec/models/notice_spec.rb` に `ransackable_attributes` の `auth_object` 切り替えに対するテストを追加
  - `status` スコープの境界値テスト（`travel_to` で固定日時を使用）
- `spec/requests/notices_spec.rb` に未許可フィールドが無視されることを検証するテストを追加
  - `user_email_address_cont` / `user_admin_eq` などが渡された場合、全件表示されることを確認

## 確認済み

- [x] 各検索条件で正しく絞り込まれることを確認
- [x] クリアボタンで検索条件がリセットされることを確認
- [x] 検索条件なしで全件表示されることを確認
- [x] 従業員（お知らせの作成者）のメールアドレスや権限では検索できない（無視され全件表示される）ことを確認
- [x] `bundle exec rubocop` エラーなし
- [x] `bundle exec rspec` が正常に通過

## 補足

- ページネーションは別 Issue で対応予定

Closes #128 