### PR TITLE
Implement public landing page and authentication flow

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -31,7 +31,7 @@ module Authentication
 
     def request_authentication
       session[:return_to_after_authenticating] = request.url
-      redirect_to new_session_path
+      redirect_to login_path
     end
 
     def after_authentication_url

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,6 @@
+class PagesController < ApplicationController
+  allow_unauthenticated_access
+
+  def home
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,14 +8,14 @@ class SessionsController < ApplicationController
   def create
     if user = User.authenticate_by(params.permit(:email_address, :password))
       start_new_session_for user
-      redirect_to after_authentication_url
+      redirect_to interactions_path
     else
-      redirect_to new_session_path, alert: "Try another email address or password."
+      redirect_to login_path, alert: "Try another email address or password."
     end
   end
 
   def destroy
     terminate_session
-    redirect_to new_session_path, status: :see_other
+    redirect_to login_path, status: :see_other
   end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,0 +1,2 @@
+module PagesHelper
+end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,0 +1,62 @@
+<div class="min-h-screen bg-white">
+  <header class="flex items-center justify-between px-12 py-6">
+    <div class="flex items-center gap-3">
+      <div class="flex h-8 w-8 items-center justify-center rounded bg-blue-600 text-white">🏪</div>
+      <span class="font-bold text-gray-900">店舗業務管理システム</span>
+    </div>
+    <nav class="flex items-center gap-8 text-sm text-gray-600">
+      <a href="#" class="hover:text-blue-600">機能紹介</a>
+      <a href="#" class="hover:text-blue-600">導入メリット</a>
+      <%= link_to "ログイン", login_path, class: "hover:text-blue-600" %>
+      <%= link_to "デモを体験する", login_path, class: "rounded-lg bg-blue-600 px-5 py-2 text-white hover:bg-blue-700" %>
+    </nav>
+  </header>
+  <main class="px-12 pt-16">
+    <section class="mx-auto max-w-6xl text-center">
+      <h1 class="text-5xl font-bold leading-tight text-gray-900">
+        店舗業務を、<br>
+        もっとスマートに。
+      </h1>
+      <p class="mt-8 text-gray-600 leading-relaxed">
+        応対履歴、タスク、周知事項の共有まで。<br>
+        日々の業務を一元管理し、生産性を向上させます。
+      </p>
+      <div class="mt-16 grid grid-cols-3 gap-16">
+        <div>
+          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 text-3xl">💬</div>
+          <h3 class="mt-5 font-bold">応対履歴を一元管理</h3>
+          <p class="mt-3 text-sm text-gray-500">
+            顧客とのやり取りを<br>
+            簡単に確認できます。
+          </p>
+        </div>
+        <div>
+          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 text-3xl">📋</div>
+          <h3 class="mt-5 font-bold">タスクで業務を見える化</h3>
+          <p class="mt-3 text-sm text-gray-500">
+            タスクを整理し<br>
+            チームで共有できます。
+          </p>
+        </div>
+        <div>
+          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 text-3xl">📢</div>
+          <h3 class="mt-5 font-bold">お知らせで情報を共有</h3>
+          <p class="mt-3 text-sm text-gray-500">
+            従業員への周知事項を<br>
+            確実に共有できます。
+          </p>
+        </div>
+      </div>
+      <div class="mt-20 h-64 rounded-t-3xl bg-blue-50 flex items-end justify-center overflow-hidden">
+        <div class="mb-8 text-center">
+          <div class="text-8xl">🏬</div>
+          <p class="mt-3 text-sm text-gray-400">店舗運営を支える管理システム</p>
+        </div>
+      </div>
+      <div class="mt-8 flex justify-center gap-5">
+        <%= link_to "デモを体験する", login_path, class: "rounded-lg bg-blue-600 px-10 py-3 font-semibold text-white hover:bg-blue-700" %>
+        <%= link_to "ログインはこちら", login_path, class: "rounded-lg border border-blue-600 px-10 py-3 font-semibold text-blue-600 hover:bg-blue-50" %>
+      </div>
+    </section>
+  </main>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,11 +1,72 @@
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
-<%= tag.div(flash[:notice], style: "color:green") if flash[:notice] %>
-
-<%= form_with url: session_path do |form| %>
-  <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
-  <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %><br>
-  <%= form.submit "Sign in" %>
-<% end %>
-<br>
-
-<%= link_to "Forgot password?", new_password_path %>
+<div class="min-h-screen bg-white flex">
+  <div class="flex-1 bg-blue-50 flex flex-col">
+    <header class="px-12 py-6">
+      <%= link_to root_path, class: "inline-flex items-center gap-3 hover:opacity-80" do %>
+        <div class="flex h-8 w-8 items-center justify-center rounded bg-blue-600 text-white">🏪</div>
+        <span class="font-bold text-gray-900">店舗業務管理システム</span>
+      <% end %>
+    </header>
+    <div class="flex flex-1 items-start justify-center px-12 pt-24">
+      <div class="max-w-lg">
+        <h1 class="text-4xl font-bold leading-relaxed text-gray-900">店舗業務管理システムへようこそ</h1>
+        <p class="mt-6 text-lg text-gray-600">ログインして、日々の業務を効率化しましょう。</p>
+        <div class="mt-9 rounded-xl border border-blue-100 bg-white p-8 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900">デモアカウント（お試し用）</h3>
+          <div class="mt-8 flex gap-8">
+            <div class="flex-1 flex flex-col justify-between">
+              <div>
+                <span class="block text-sm font-bold text-blue-600 mb-3">管理者権限</span>
+                <div class="space-y-2 text-base">
+                  <div>
+                    <span class="block text-sm text-gray-500">メールアドレス</span>
+                    <span class="text-gray-900 font-medium">manager@example.com</span>
+                  </div>
+                  <div>
+                    <span class="block text-sm text-gray-500">パスワード</span>
+                    <span class="text-gray-900 font-medium">Admin2026!</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="flex-1 border-l border-gray-100 pl-8 flex flex-col justify-between">
+              <div>
+                <span class="block text-sm font-bold text-emerald-600 mb-3">一般ユーザー</span>
+                <div class="space-y-2 text-base">
+                  <div>
+                    <span class="block text-sm text-gray-500">メールアドレス</span>
+                    <span class="text-gray-900 font-medium">member@example.com</span>
+                  </div>
+                  <div>
+                    <span class="block text-sm text-gray-500">パスワード</span>
+                    <span class="text-gray-900 font-medium">User2026!</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p class="mt-8 text-sm text-gray-500">※ デモ環境のため、データは予告なくリセットされる場合があります。</p>
+      </div>
+    </div>
+  </div>
+  <div class="flex-1 flex items-center justify-center">
+    <div class="w-full max-w-md rounded-2xl border border-gray-100 bg-white p-10 shadow-sm">
+      <h2 class="text-3xl font-bold text-gray-900">ログイン</h2>
+      <p class="mt-3 text-sm text-gray-500">アカウント情報を入力してください</p>
+      <%= form_with url: login_path, class: "mt-8 space-y-5" do |f| %>
+        <div>
+          <%= f.label :email_address, "メールアドレス", class: "block mb-2 text-sm font-medium text-gray-700" %>
+          <%= f.email_field :email_address, placeholder: "メールアドレスを入力", class: "w-full rounded-lg border border-gray-200 px-4 py-3 text-sm focus:border-blue-500" %>
+        </div>
+        <div>
+          <%= f.label :password, "パスワード", class: "block mb-2 text-sm font-medium text-gray-700" %>
+          <%= f.password_field :password, placeholder: "パスワードを入力", class: "w-full rounded-lg border border-gray-200 px-4 py-3 text-sm" %>
+        </div>
+        <div class="flex justify-between text-sm">
+          <%= link_to "パスワードを忘れた方", new_password_path, class: "text-blue-600 hover:underline" %>
+        </div>
+        <%= f.submit "ログイン", class: "w-full rounded-lg bg-blue-600 py-3 font-semibold text-white hover:bg-blue-700" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_user_menu.html.erb
+++ b/app/views/shared/_user_menu.html.erb
@@ -24,7 +24,7 @@
             class: "block px-4 py-2 hover:bg-gray-50" %>
     </div>
     <div class="border-t py-1">
-      <%= button_to "ログアウト", session_path,
+      <%= button_to "ログアウト", logout_path,
             method: :delete,
             form_class: "block",
             data: { turbo_confirm: "ログアウトしますか？" },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root "interactions#index"
+  root "pages#home"
   resource :session
   resources :passwords, param: :token
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   root "pages#home"
-  resource :session
+
+  get "/login", to: "sessions#new"
+  post "/login", to: "sessions#create"
+  delete "/logout", to: "sessions#destroy"
+
   resources :passwords, param: :token
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :users, except: :destroy

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,6 @@
 # This file should ensure the existence of records required to run the application in every environment (production,
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-
 # ==============================================================================
 # パスワードの読み込み
 # 本番環境では環境変数を必ず設定すること。
@@ -422,5 +421,35 @@ task_assignments_data.each do |attrs|
     puts "タスク: #{assignment.task.title}"
     puts "担当: #{assignment.user.name}"
     puts "状態: #{task_status_label(assignment.status)}"
+  end
+end
+
+# ==============================================================================
+# デモ用ユーザーの作成
+# ==============================================================================
+demo_users_data = [
+  {
+    name: "Taro Manager",
+    email_address: "manager@example.com",
+    password: "Admin2026!",
+    admin: true
+  },
+  {
+    name: "Hanako Member",
+    email_address: "member@example.com",
+    password: "User2026!",
+    admin: false
+  }
+]
+
+demo_users_data.each do |attrs|
+  user = User.find_or_create_by!(email_address: attrs[:email_address]) do |u|
+    u.assign_attributes(attrs)
+  end
+
+  if user.previously_new_record?
+    puts "デモユーザーを作成しました！"
+    puts "名前: #{user.name}"
+    puts "メールアドレス: #{user.email_address}"
   end
 end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PagesHelper. For example:
+#
+# describe PagesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PagesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Authentication", type: :request do
+  let(:user) { create(:user) }
+
+  def sign_in(user)
+    post login_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  describe "GET /login" do
+    it "allows users to access login page" do
+      get login_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /interactions" do
+    it "redirects unauthenticated users to login page" do
+      get interactions_path
+
+      expect(response).to redirect_to(login_path)
+    end
+  end
+
+  describe "POST /login" do
+    it "logs in successfully" do
+      sign_in(user)
+
+      expect(response).to redirect_to(interactions_path)
+    end
+  end
+
+  describe "DELETE /logout" do
+    it "logs out successfully" do
+      sign_in(user)
+
+      delete logout_path
+
+      expect(response).to redirect_to(login_path)
+    end
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Comments", type: :request do
   let(:other_user) { create(:other_user) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   before { sign_in(user) }

--- a/spec/requests/customers_search_spec.rb
+++ b/spec/requests/customers_search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Customers search", type: :request do
   end
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /customers" do

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Customers", type: :request do
   let(:user) { create(:user) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /customers" do
@@ -29,7 +29,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get customers_path
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -47,7 +47,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get new_customer_path
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -93,7 +93,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         post customers_path, params: {}
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -121,7 +121,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get customer_path(customer)
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -141,7 +141,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get edit_customer_path(customer)
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -174,7 +174,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         patch customer_path(customer), params: {}
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end

--- a/spec/requests/interactions_parent_child_spec.rb
+++ b/spec/requests/interactions_parent_child_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Interactions parent-child", type: :request do
   let(:admin) { create(:user, admin: true) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /interactions/:id - back link" do

--- a/spec/requests/interactions_search_spec.rb
+++ b/spec/requests/interactions_search_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Interactions search", type: :request do
   end
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /interactions" do

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Interactions", type: :request do
 
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /interactions" do
@@ -64,7 +64,7 @@ RSpec.describe "Interactions", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get interactions_path
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -88,7 +88,7 @@ RSpec.describe "Interactions", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get interactions_path
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -142,7 +142,7 @@ RSpec.describe "Interactions", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         post interactions_path, params: {}
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -241,7 +241,7 @@ RSpec.describe "Interactions", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get interaction_path(interaction)
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -271,7 +271,7 @@ RSpec.describe "Interactions", type: :request do
       it "redirects to the login page" do
         interaction = create(:interaction, user: user)
         get edit_interaction_path(interaction)
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -319,7 +319,7 @@ RSpec.describe "Interactions", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         patch interaction_path(interaction), params: {}
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end

--- a/spec/requests/notice_interactions_spec.rb
+++ b/spec/requests/notice_interactions_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Notice Interactions", type: :request do
   let(:interaction) { create(:interaction) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   before { sign_in(user) }

--- a/spec/requests/notices_parent_child_spec.rb
+++ b/spec/requests/notices_parent_child_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Notices parent-child", type: :request do
   let(:admin) { create(:user, admin: true) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /notices/:id - back link" do

--- a/spec/requests/notices_search_spec.rb
+++ b/spec/requests/notices_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Notices search", type: :request do
   end
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /notices" do

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Notices", type: :request do
   let!(:restricted_notice) { create(:notice, user: admin, restricted: true) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   def valid_params
@@ -89,7 +89,7 @@ RSpec.describe "Notices", type: :request do
       it "redirects to the login page" do
         get notices_path
 
-        expect(response).to redirect_to new_session_path
+        expect(response).to redirect_to login_path
       end
     end
   end
@@ -179,7 +179,7 @@ RSpec.describe "Notices", type: :request do
       it "redirects to the login page" do
         get notice_path(notice)
 
-        expect(response).to redirect_to new_session_path
+        expect(response).to redirect_to login_path
       end
     end
   end
@@ -215,7 +215,7 @@ RSpec.describe "Notices", type: :request do
       it "redirects to the login page" do
         get new_notice_path
 
-        expect(response).to redirect_to new_session_path
+        expect(response).to redirect_to login_path
       end
     end
   end
@@ -275,7 +275,7 @@ RSpec.describe "Notices", type: :request do
       it "redirects to the login page" do
         post notices_path, params: {}
 
-        expect(response).to redirect_to new_session_path
+        expect(response).to redirect_to login_path
       end
     end
   end
@@ -380,7 +380,7 @@ RSpec.describe "Notices", type: :request do
       it "redirects to the login page" do
         get edit_notice_path(notice)
 
-        expect(response).to redirect_to new_session_path
+        expect(response).to redirect_to login_path
       end
     end
   end
@@ -450,7 +450,7 @@ RSpec.describe "Notices", type: :request do
       it "redirects to the login page" do
         patch notice_path(notice), params: {}
 
-        expect(response).to redirect_to new_session_path
+        expect(response).to redirect_to login_path
       end
     end
   end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Pages", type: :request do
+  describe "GET /home" do
+    it "returns http success" do
+      get "/pages/home"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,10 +1,9 @@
-require 'rails_helper'
-
 RSpec.describe "Pages", type: :request do
-  describe "GET /home" do
-    it "returns http success" do
-      get "/pages/home"
-      expect(response).to have_http_status(:success)
+  describe "GET /" do
+    it "allows users to access landing page" do
+      get root_path
+
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/task_assignments_spec.rb
+++ b/spec/requests/task_assignments_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Task Assignments", type: :request do
   end
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   before { sign_in(task_creator) }

--- a/spec/requests/task_interactions_spec.rb
+++ b/spec/requests/task_interactions_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Task Interactions", type: :request do
   let(:interaction) { create(:interaction) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   before { sign_in(user) }

--- a/spec/requests/task_notices_spec.rb
+++ b/spec/requests/task_notices_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Task Notices", type: :request do
   let(:notice) { create(:notice) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   before { sign_in(user) }

--- a/spec/requests/tasks_parent_child_spec.rb
+++ b/spec/requests/tasks_parent_child_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Tasks parent-child", type: :request do
   let(:admin) { create(:user, admin: true) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /tasks/:id - back link" do

--- a/spec/requests/tasks_search_spec.rb
+++ b/spec/requests/tasks_search_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Tasks search", type: :request do
   let!(:user_task)       { create(:task, title: "ユーザータスク", description: "一般ユーザーの作業", user: regular_user) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /tasks" do

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Tasks", type: :request do
   let(:restricted_task) { create(:task, user: admin, restricted: true) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /tasks" do
@@ -86,7 +86,7 @@ RSpec.describe "Tasks", type: :request do
       it "redirects to the login page" do
         get tasks_path
 
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -131,7 +131,7 @@ RSpec.describe "Tasks", type: :request do
       it "redirects to the login page" do
         get task_path(task)
 
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -167,7 +167,7 @@ RSpec.describe "Tasks", type: :request do
       it "redirects to the login page" do
         get new_task_path
 
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -245,7 +245,7 @@ RSpec.describe "Tasks", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         post tasks_path, params: {}
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -349,7 +349,7 @@ RSpec.describe "Tasks", type: :request do
       it "redirects to the login page" do
         get edit_task_path(task)
 
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -424,7 +424,7 @@ RSpec.describe "Tasks", type: :request do
       it "redirects to the login page" do
         patch task_path(task), params: {}
 
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end

--- a/spec/requests/users_search_spec.rb
+++ b/spec/requests/users_search_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Users search", type: :request do
   end
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /users" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Users", type: :request do
   let!(:admin) { create(:user, admin: true) }
 
   def sign_in(user)
-    post session_path, params: { email_address: user.email_address, password: "password55" }
+    post login_path, params: { email_address: user.email_address, password: "password55" }
   end
 
   describe "GET /users" do
@@ -31,7 +31,7 @@ RSpec.describe "Users", type: :request do
       it "redirects to the login page" do
         get users_path
 
-        expect(response).to redirect_to new_session_path
+        expect(response).to redirect_to login_path
       end
     end
   end
@@ -110,7 +110,7 @@ RSpec.describe "Users", type: :request do
       it "redirects to the login page" do
         get user_path(user)
 
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end
@@ -155,7 +155,7 @@ RSpec.describe "Users", type: :request do
       it "redirects to the login page" do
         get new_user_path
 
-        expect(response).to redirect_to new_session_path
+        expect(response).to redirect_to login_path
       end
     end
   end
@@ -235,7 +235,7 @@ RSpec.describe "Users", type: :request do
       it "redirects to the login page" do
         post users_path, params: {}
 
-        expect(response).to redirect_to(new_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
   end

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe "Header", type: :system do
   let(:user) { create(:user, password: "password55") }
 
   def sign_in(user)
-    visit new_session_path
+    visit login_path
 
     fill_in "email_address", with: user.email_address
     fill_in "password", with: "password55"
-    click_button "Sign in"
+    click_button "ログイン"
 
-    expect(page).to have_current_path(root_path)
+    expect(page).to have_current_path(interactions_path)
   end
 
   describe "navigation tabs" do

--- a/spec/views/pages/home.html.tailwindcss_spec.rb
+++ b/spec/views/pages/home.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "pages/home.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要

サービス紹介ページ（LP）を追加し、公開ページとログイン後のアプリ画面を分離。
Rails 8 authentication の仕組みを利用して、ログイン・ログアウト、パスワード再設定への導線を整備。
併せて、デプロイ環境で動作確認できるようデモ用アカウントを追加。

## 変更内容

### 公開ページ追加

- LP用ページを追加
- root path (`/`) をアプリ内部画面から公開ページへ変更
- 未認証ユーザーでもアクセス可能なページとして設定

### 認証ルーティング整理

- ログイン用ルーティングを追加
- ログアウト用ルーティングを整理
- ログイン画面への導線を追加

### ログイン処理

- Rails 8 authentication を利用したログインフローを整備
- ログイン成功後は応対履歴一覧画面へ遷移
- 認証失敗時はログイン画面へ戻すように変更

### パスワード再設定導線

- ログイン画面からパスワード再設定ページへ遷移できるように対応

### 認証制御

- 未認証アクセス可能なページを整理

対象:
- LP
- ログイン画面
- パスワード再設定関連ページ

その他のアプリ内部ページは認証必須になるよう設定。（Rails 8 authentication の既存設定を活用）

### デモアカウント追加

- デプロイ環境の動作確認用としてデモユーザーを追加
- 管理者ユーザー・一般ユーザーの2種類を用意

### テスト

Request Specを追加・修正。

追加:
- LPが表示されることを確認
- ログインページへアクセスできることを確認
- 未認証ユーザーが認証必須ページへアクセスした場合、ログイン画面へリダイレクトされることを確認
- ログイン成功後の遷移を確認
- ログアウト後の状態を確認

修正:
- ログインルーティング変更に伴う既存specの更新

## 確認済み

- [x] `/` へアクセスするとLPが表示されることを確認
- [x] `/login` からログインできることを確認
- [x] 正しい認証情報でログイン後、応対履歴一覧画面へ遷移することを確認
- [x] 未ログイン状態で認証必須ページへアクセスするとログイン画面へ遷移することを確認
- [x] ログアウト後にログイン画面へリダイレクトされることを確認
- [x] パスワード再設定ページへの導線を確認
- [x] デモアカウントでログインできることを確認
- [x] 管理者・一般ユーザーそれぞれの権限で動作確認
- [x] bundle exec rubocop エラーなし
- [x] bundle exec rspec が正常に通過

## 補足

- LPおよび認証関連ページのデザイン改善は別Issueで対応予定
- ログイン後のDashboard画面追加は今後の実装を検討中
- デモアカウントはポートフォリオ確認用として利用

Closes #130