### PR TITLE
Improve Task UI responsiveness and add thread-wide related tasks

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -25,6 +25,8 @@ class NoticesController < ApplicationController
         @notice.interactions << Interaction.find(params[:interaction_id])
       end
 
+      @notice.tasks << Task.find(params[:task_id]) if params[:task_id].present?
+
       redirect_to @notice, notice: "お知らせを更新しました"
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,7 +6,13 @@ class TasksController < ApplicationController
   def index
     @q = visible_tasks.ransack(params[:q], auth_object: :admin)
     @tasks = @q.result
-               .preload(:user)
+               .preload(
+                 :user,
+                 task_assignments: [ :user ],
+                 root: {
+                   thread_tasks: [ :user, task_assignments: [ :user ] ]
+                 }
+               )
                .order(due_at: :asc)
   end
 
@@ -30,7 +36,7 @@ class TasksController < ApplicationController
     if @form.save
       redirect_to @task, notice: "タスクを登録しました"
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -48,7 +54,7 @@ class TasksController < ApplicationController
     else
       @form = TaskForm.new(task: @task)
       @form.valid? # task.errors を form.errors に取り込む
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/helpers/interactions_helper.rb
+++ b/app/helpers/interactions_helper.rb
@@ -9,12 +9,8 @@ module InteractionsHelper
 
   def interaction_status_badge_class(interaction)
     base = "inline-flex items-center justify-center rounded text-xs border"
-    color = interaction.completed? ? "bg-gray-100 text-gray-600 border-gray-200" : "bg-blue-100 text-blue-600 border-blue-200"
+    color = interaction.completed? ? "bg-green-100 text-green-600 border-green-200" : "bg-blue-100 text-blue-600 border-blue-200"
 
     "#{base} #{color}"
-  end
-
-  def interaction_status_text_class(interaction)
-    interaction.completed? ? "text-gray-600" : "text-blue-600"
   end
 end

--- a/app/helpers/task_assignments_helper.rb
+++ b/app/helpers/task_assignments_helper.rb
@@ -2,4 +2,16 @@ module TaskAssignmentsHelper
   def task_status_label(assignment)
     I18n.t("enums.task_assignment.status.#{assignment.status}")
   end
+
+  def task_status_badge_class(assignment)
+    base = "inline-flex items-center justify-center rounded text-xs border"
+
+    color = case assignment.status
+    when "todo" then "bg-gray-100 text-gray-600 border-gray-200"
+    when "in_progress" then "bg-blue-100 text-blue-600 border-blue-200"
+    when "done" then "bg-green-100 text-green-600 border-green-200"
+    end
+
+    "#{base} #{color}"
+  end
 end

--- a/app/javascript/controllers/related_toggle_list_controller.js
+++ b/app/javascript/controllers/related_toggle_list_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
 
     const button = event.currentTarget
     const icon = button.querySelector(".toggle-icon")
-    const parentRow = button.closest("tr")
+    const parentRow = button.closest("tr, .related-list-trigger")
 
     // 親行の直後に連続する関連行だけを集める
     const rows = []

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,7 +5,10 @@ class Task < ApplicationRecord
   belongs_to :user
 
   belongs_to :parent, class_name: "Task", optional: true
-  has_many :children, class_name: "Task", foreign_key: "parent_id"
+  has_many :children,
+           -> { order(created_at: :desc) },
+           class_name: "Task",
+           foreign_key: "parent_id"
 
   belongs_to :root, class_name: "Task", optional: true
   has_many :thread_tasks, class_name: "Task", foreign_key: :root_id, dependent: :nullify
@@ -28,6 +31,11 @@ class Task < ApplicationRecord
   validates :images,
     content_type: %w[image/jpeg image/png image/gif],
     size: { less_than_or_equal_to: 10.megabytes }
+
+  def related_tasks
+    thread_tasks_all = root.thread_tasks
+    thread_tasks_all.reject { |task| task.id == id }.sort_by(&:created_at)
+  end
 
   private
 

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -10,5 +10,5 @@
                   required: true %>
 
   <%= f.submit "コメントを投稿",
-             class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs lg:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
+             class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
 <% end %>

--- a/app/views/interactions/_list_desktop.html.erb
+++ b/app/views/interactions/_list_desktop.html.erb
@@ -2,7 +2,7 @@
   <table class="w-full text-xs sm:text-sm border-collapse table-fixed">
     <thead class="bg-gray-50 text-gray-600">
       <tr>
-        <th class="w-36 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">応対日時</th>
+        <th class="w-36 px-4 py-3 text-center whitespace-nowrap align-middle leading-none tabular-nums">応対日時</th>
         <th class="w-28 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">顧客名</th>
         <th class="w-28 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">問合せ種別</th>
         <th class="w-28 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">担当者名</th>
@@ -21,7 +21,7 @@
             data-clickable-url-value="<%= interaction_path(interaction) %>"
             data-action="click->clickable#open">
 
-          <td class="w-36 px-4 py-3 text-center whitespace-nowrap align-middle leading-none text-gray-600">
+          <td class="w-36 px-4 py-3 text-center whitespace-nowrap align-middle leading-none tabular-nums text-gray-600">
             <%= l interaction.occurred_at %>
           </td>
 
@@ -45,7 +45,7 @@
           </td>
 
           <td class="px-2 md:px-4 xl:px-8 py-3 text-left align-middle leading-none text-gray-600">
-            <div class="w-0 min-w-full truncate">
+            <div class="w-0 min-w-full h-4 overflow-hidden truncate">
               <%= interaction.request_content %>
             </div>
           </td>
@@ -84,7 +84,7 @@
               data-controller="clickable"
               data-clickable-url-value="<%= interaction_path(related_interaction) %>"
               data-action="click->clickable#open">
-              <td class="w-36 px-4 py-3 text-center whitespace-nowrap align-middle leading-none text-gray-600">
+              <td class="w-36 px-4 py-3 text-center whitespace-nowrap align-middle leading-none tabular-nums text-gray-600">
                 <%= l related_interaction.occurred_at %>
               </td>
 
@@ -108,7 +108,7 @@
               </td>
 
               <td class="px-2 md:px-4 xl:px-8 py-3 text-left align-middle leading-none text-gray-600">
-                <div class="w-0 min-w-full truncate">
+                <div class="w-0 min-w-full h-4 overflow-hidden truncate">
                   <%= link_to truncate(related_interaction.request_content, length: 60),
                               interaction_path(related_interaction),
                               class: "block truncate hover:text-blue-600",

--- a/app/views/interactions/_list_mobile.html.erb
+++ b/app/views/interactions/_list_mobile.html.erb
@@ -1,23 +1,34 @@
-<div class="block md:hidden space-y-2 mb-4">
-  <% interactions.each do |interaction| %>
-    <% related_interactions = interaction.related_interactions %>
+<div class="block md:hidden mb-4">
+  <div class="sticky top-20 z-10 flex items-center bg-gray-50 border border-gray-200 rounded shadow-sm px-3 py-2 mb-2 text-xs font-bold text-gray-600">
+    <div class="w-12 flex-none text-left">応対日時</div>
+    <div class="flex-1 min-w-0 text-center mx-1 whitespace-nowrap truncate overflow-hidden">顧客名</div>
+    <div class="flex-1 min-w-0 text-center mx-1 whitespace-nowrap truncate overflow-hidden">問合せ種別</div>
+    <div class="flex-1 min-w-0 text-center mx-1 whitespace-nowrap truncate overflow-hidden">担当者名</div>
+    <div class="flex-1 min-w-0 text-center mx-1 whitespace-nowrap truncate overflow-hidden">対応状況</div>
+    <div class="w-10 flex-none"></div>
+  </div>
 
-    <div class="w-full" data-controller="related-toggle">
+  <div class="space-y-2">
+    <% interactions.each do |interaction| %>
+      <% related_interactions = interaction.related_interactions %>
 
-      <%= render "mobile_card",
-                  interaction: interaction,
-                  show_related_button: related_interactions.any? %>
+      <div class="w-full" data-controller="related-toggle">
 
-      <% if related_interactions.any? %>
-        <div class="hidden" data-related-toggle-target="list">
-          <% related_interactions.each do |related_interaction| %>
-            <%= render "mobile_card",
-                        interaction: related_interaction,
-                        show_related_button: false %>
-          <% end %>
-        </div>
-      <% end %>
+        <%= render "mobile_card",
+                    interaction: interaction,
+                    show_related_button: related_interactions.any? %>
 
-    </div>
-  <% end %>
+        <% if related_interactions.any? %>
+          <div class="hidden" data-related-toggle-target="list">
+            <% related_interactions.each do |related_interaction| %>
+              <%= render "mobile_card",
+                          interaction: related_interaction,
+                          show_related_button: false %>
+            <% end %>
+          </div>
+        <% end %>
+
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/interactions/_mobile_card.html.erb
+++ b/app/views/interactions/_mobile_card.html.erb
@@ -6,7 +6,7 @@
 
   <div class="text-xs w-full leading-none">
     <div class="flex items-center justify-between w-full h-5">
-      <div class="w-12 flex-none text-gray-600 whitespace-nowrap text-left leading-none">
+      <div class="w-12 flex-none text-gray-600 whitespace-nowrap text-left leading-none tabular-nums">
         <%= l interaction.occurred_at.to_date, format: :short %>
       </div>
 
@@ -18,7 +18,7 @@
                     data: { turbo_frame: "_top" } %>
       </div>
 
-      <div class="flex-1 min-w-0 text-gray-600 text-center mx-1">
+      <div class="flex-1 min-w-0 text-gray-600 text-center mx-1 whitespace-nowrap truncate overflow-hidden">
         <%= interaction_channel_label(interaction) %>
       </div>
 
@@ -30,8 +30,8 @@
                     data: { turbo_frame: "_top" } %>
       </div>
 
-      <div class="flex-1 flex justify-center items-center mx-1">
-        <span class="<%= interaction_status_badge_class(interaction) %> px-1 py-1 inline-flex items-center justify-center rounded-sm sm:px-2">
+      <div class="flex-1 min-w-0 flex justify-center items-center mx-1 overflow-hidden">
+        <span class="<%= interaction_status_badge_class(interaction) %> px-1 py-1 inline-flex items-center justify-center whitespace-nowrap rounded-sm sm:px-2">
           <%= interaction_status_label(interaction) %>
         </span>
       </div>

--- a/app/views/notices/_form.html.erb
+++ b/app/views/notices/_form.html.erb
@@ -13,6 +13,7 @@
   <% end %>
   <%= f.hidden_field :parent_id %>
   <%= hidden_field_tag :interaction_id, params[:interaction_id] if params[:interaction_id].present? %>
+  <%= hidden_field_tag :task_id, params[:task_id] if params[:task_id].present? %>
   <div>
     <%= f.label :title, "件名", class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_field :title,

--- a/app/views/tasks/_assignees.html.erb
+++ b/app/views/tasks/_assignees.html.erb
@@ -1,32 +1,5 @@
-<div class="mb-6 border-t-4 border-blue-500 pt-6">
-  <h2 class="text-lg font-semibold mb-3">割り当て者と進捗状況</h2>
-  <% if task.task_assignments.any? %>
-    <div class="bg-gray-50 rounded overflow-hidden">
-      <table class="w-full text-sm">
-        <thead class="bg-gray-100 text-gray-600">
-          <tr>
-            <th class="px-16 py-3 text-left font-medium w-1/2">担当者</th>
-            <th class="px-16 py-3 text-left font-medium w-1/2">進捗状況</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-gray-200">
-          <% task.task_assignments.each do |assignment| %>
-            <tr class="hover:bg-gray-100">
-              <td class="px-16 py-3">
-                <%= link_to assignment.user.name, user_path(assignment.user),
-                      class: "text-blue-600 hover:text-blue-800" %>
-              </td>
-              <td class="px-16 py-3 text-gray-600">
-                <%= task_status_label(assignment) %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  <% else %>
-    <p class="text-sm text-gray-500 bg-gray-50 p-4 rounded">
-      まだ誰にも割り当てられていません。
-    </p>
-  <% end %>
+<div class="mb-6 border-t-4 border-gray-300 pt-6">
+  <h2 class="text-base sm:text-lg font-semibold mb-3">割り当て者と進捗状況</h2>
+
+  <%= render "tasks/assignment_table", task: task %>
 </div>

--- a/app/views/tasks/_assignment_popup.html.erb
+++ b/app/views/tasks/_assignment_popup.html.erb
@@ -1,0 +1,6 @@
+<div class="absolute z-50 hidden group-hover:block inset-x-0 mx-auto top-full mt-1 w-48 sm:w-64"
+     onclick="event.stopPropagation();">
+  <div class="rounded-lg border border-gray-200 bg-white shadow-lg overflow-hidden max-h-72 overflow-y-auto">
+    <%= render "tasks/assignment_table", task: task, compact: true %>
+  </div>
+</div>

--- a/app/views/tasks/_assignment_table.html.erb
+++ b/app/views/tasks/_assignment_table.html.erb
@@ -1,0 +1,33 @@
+<% compact = local_assigns.fetch(:compact, false) %>
+<% row_height = compact ? "h-9" : "py-3" %>
+
+<% if task.task_assignments.any? %>
+  <div class="bg-gray-50 rounded overflow-hidden text-xs sm:text-sm">
+    <div class="grid grid-cols-2 items-center bg-gray-100 text-xs sm:text-sm font-bold text-center text-gray-600 <%= row_height %>">
+      <div class="px-4">担当者</div>
+      <div class="px-4">進捗状況</div>
+    </div>
+
+    <% task.task_assignments.each do |assignment| %>
+      <div class="grid grid-cols-2 items-center border-t border-gray-200 hover:bg-gray-100 <%= row_height %>">
+        <div class="flex items-center justify-center px-4 break-words">
+          <%= link_to assignment.user.name,
+                user_path(assignment.user),
+                class: "text-blue-600 hover:text-blue-800",
+                onclick: "event.stopPropagation();",
+                data: { turbo_frame: "_top" } %>
+        </div>
+
+        <div class="flex items-center justify-center px-4 break-words">
+          <span class="<%= task_status_badge_class(assignment) %> px-2 py-1">
+            <%= task_status_label(assignment) %>
+          </span>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <p class="text-xs sm:text-sm text-gray-500 bg-gray-50 p-4 rounded">
+    まだ誰にも割り当てられていません。
+  </p>
+<% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,9 +1,8 @@
 <%= form_with model: task, class: "space-y-4" do |f| %>
   <% if form.errors.any? %>
     <div class="bg-red-50 border border-red-300 rounded p-4">
-      <p class="text-red-700 font-semibold text-sm mb-2">
-        <%= form.errors.count %>件のエラーがあります
-      </p>
+      <p class="text-red-700 font-semibold text-sm mb-2">入力内容にエラーがあります。</p>
+
       <ul class="list-disc list-inside text-red-600 text-sm space-y-1">
         <% form.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
@@ -11,55 +10,80 @@
       </ul>
     </div>
   <% end %>
+
   <%= f.hidden_field :parent_id %>
   <%= hidden_field_tag :interaction_id, params[:interaction_id] if params[:interaction_id].present? %>
   <%= hidden_field_tag :notice_id, params[:notice_id] if params[:notice_id].present? %>
-  <div>
-    <%= f.label :title, "件名", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_field :title,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+    <div>
+      <%= f.label :title, "件名", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= f.text_field :title,
+                       class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" %>
+    </div>
+
+    <div>
+      <%= f.label :due_at, "期限", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= f.datetime_local_field :due_at,
+                                 class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm xl:text-sm" %>
+    </div>
+
+    <div>
+      <%= label_tag :assignee_ids, "担当者", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= select_tag "assignee_ids[]",
+                     options_from_collection_for_select(User.order(:name), :id, :name, params[:assignee_ids]),
+                     multiple: true,
+                     class: "w-full border border-gray-300 rounded px-3 py-2 text-xs sm:text-sm" %>
+
+      <p class="mt-1 text-xs text-gray-400">
+        複数選択可。Windows: Ctrl+クリック / Mac: Command+クリックで複数選択
+      </p>
+    </div>
+
+    <% if Current.user.admin? %>
+      <div>
+        <span class="block text-sm text-gray-700 mb-1">公開範囲</span>
+
+        <label class="flex items-center h-8 sm:h-9">
+          <%= f.check_box :restricted, class: "rounded" %>
+          <span class="ml-2 text-xs sm:text-sm text-gray-700">管理者のみ</span>
+        </label>
+      </div>
+    <% end %>
   </div>
+
   <div>
-    <%= f.label :description, "内容", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_area :description, rows: 4,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+    <%= f.label :description, "内容", class: "block text-sm text-gray-700 mb-1" %>
+
+    <%= f.text_area :description,
+                    rows: 4,
+                    class: "w-full border border-gray-300 rounded px-3 py-2 text-xs sm:text-sm" %>
   </div>
+
   <div>
-    <%= f.label :due_at, "期限", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.datetime_local_field :due_at,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
-  </div>
-  <div>
-    <%= label_tag :assignee_ids, "担当者", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= select_tag "assignee_ids[]",
-          options_from_collection_for_select(User.order(:name), :id, :name, params[:assignee_ids]),
-          multiple: true,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+    <%= f.label :images, "画像", class: "block text-sm text-gray-700 mb-1" %>
+
+    <div class="w-full border border-gray-300 rounded px-3 py-2 text-xs sm:text-sm bg-white">
+      <%= f.file_field :images,
+                       multiple: true,
+                       accept: "image/jpeg,image/png,image/gif",
+                       class: "w-full text-xs sm:text-sm text-gray-600
+                               file:mr-3 file:py-1 file:px-3
+                               file:rounded file:border file:border-gray-300
+                               file:text-sm file:text-gray-600 file:bg-gray-50
+                               hover:file:bg-gray-100 file:cursor-pointer cursor-pointer" %>
+    </div>
+
     <p class="mt-1 text-xs text-gray-400">
-      複数選択可。Windows: Ctrl+クリック / Mac: Command+クリックで複数選択
+      JPEG / PNG / GIF・最大 10MB・複数可
     </p>
-  </div>
-  <% if Current.user.admin? %>
-    <div class="flex items-center gap-2">
-      <%= f.check_box :restricted, class: "rounded" %>
-      <%= f.label :restricted, "管理者のみ", class: "text-sm text-gray-700" %>
-    </div>
-  <% end %>
-  <div>
-    <%= f.label :images, "画像", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <div class="w-full border border-gray-300 rounded px-3 py-2 text-sm bg-white">
-      <%= f.file_field :images, multiple: true, accept: "image/jpeg,image/png,image/gif",
-            class: "w-full text-sm text-gray-600
-                    file:mr-3 file:py-1 file:px-3
-                    file:rounded file:border file:border-gray-300
-                    file:text-sm file:text-gray-600 file:bg-gray-50
-                    hover:file:bg-gray-100 file:cursor-pointer cursor-pointer" %>
-    </div>
-    <p class="mt-1 text-xs text-gray-400">JPEG / PNG / GIF・最大 10MB・複数可</p>
   </div>
 
   <div class="flex justify-end pt-2">
-    <%= f.submit task.new_record? ? "登録する" : "更新する",
-          class: "px-6 py-2 bg-purple-500 text-white rounded hover:bg-purple-600 text-sm cursor-pointer" %>
+    <%= f.submit task.new_record? ? "登録" : "更新",
+                 class: "px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
   </div>
 <% end %>

--- a/app/views/tasks/_list.html.erb
+++ b/app/views/tasks/_list.html.erb
@@ -1,0 +1,6 @@
+<% if @tasks.any? %>
+  <%= render "list_mobile", tasks: @tasks %>
+  <%= render "list_desktop", tasks: @tasks %>
+<% else %>
+  <%= render "list_empty" %>
+<% end %>

--- a/app/views/tasks/_list_desktop.html.erb
+++ b/app/views/tasks/_list_desktop.html.erb
@@ -1,0 +1,93 @@
+<div class="hidden md:block bg-white rounded-lg shadow text-xs sm:text-sm">
+  <div class="flex rounded-t-lg bg-gray-50 text-xs sm:text-sm font-bold text-gray-600">
+    <div class="flex-1 min-w-0 px-2 md:px-4 xl:px-8 py-3 text-left whitespace-nowrap align-middle leading-none">件名</div>
+    <div class="flex-1 min-w-0 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">作成者</div>
+    <div class="flex-1 min-w-0 px-4 py-3 text-center whitespace-nowrap align-middle leading-none tabular-nums">期限</div>
+    <div class="w-24 flex-none px-4 py-3 text-center whitespace-nowrap align-middle leading-none"></div>
+  </div>
+
+  <div data-controller="related-toggle-list">
+    <% tasks.each do |task| %>
+      <% related_tasks = task.related_tasks %>
+      <div class="group related-list-trigger relative flex items-center hover:bg-gray-100 cursor-pointer"
+          data-task-id="<%= task.id %>"
+          data-controller="clickable"
+          data-clickable-url-value="<%= task_path(task) %>"
+          data-action="click->clickable#open">
+
+        <div class="flex-1 min-w-0 px-2 md:px-4 xl:px-8 py-3 text-left align-middle leading-none text-gray-600 truncate">
+          <%= task.title %>
+        </div>
+
+        <div class="flex-1 min-w-0 px-4 py-3 text-center whitespace-nowrap truncate align-middle leading-none">
+          <%= link_to task.user.name,
+                      user_path(task.user),
+                      class: "text-blue-600 hover:text-blue-800",
+                      onclick: "event.stopPropagation();",
+                      data: { turbo_frame: "_top" } %>
+        </div>
+
+        <div class="flex-1 min-w-0 px-4 py-3 text-center whitespace-nowrap align-middle leading-none tabular-nums text-gray-600">
+          <%= task.due_at ? l(task.due_at) : "未設定" %>
+        </div>
+
+        <div class="w-24 flex-none px-4 py-3 text-center whitespace-nowrap align-middle leading-none text-gray-600">
+          <% if related_tasks.any? %>
+            <button
+              type="button"
+              class="related-toggle-button inline-flex items-center gap-1 text-blue-600"
+              data-task-id="<%= task.id %>"
+              data-action="click->related-toggle-list#toggle"
+              data-related-toggle-list-target="button"
+              aria-expanded="false">
+
+              <span>関連</span>
+
+              <span class="toggle-icon text-xs" data-related-toggle-list-target="icon">▼</span>
+
+            </button>
+          <% else %>
+            <span class="text-gray-400">-</span>
+          <% end %>
+        </div>
+
+        <%= render "tasks/assignment_popup", task: task %>
+      </div>
+
+      <% if related_tasks.any? %>
+        <% related_tasks.each do |related_task| %>
+          <div
+            class="group related-list-row relative hidden flex items-center hover:bg-gray-100"
+            data-controller="clickable"
+            data-clickable-url-value="<%= task_path(related_task) %>"
+            data-action="click->clickable#open">
+            <div class="flex-1 min-w-0 px-2 md:px-4 xl:px-8 py-3 text-left align-middle leading-none text-gray-600 truncate">
+              <%= link_to truncate(related_task.title, length: 60),
+                          task_path(related_task),
+                          class: "block truncate hover:text-blue-600",
+                          data: { turbo_frame: "_top" } %>
+            </div>
+
+            <div class="flex-1 min-w-0 px-4 py-3 text-center whitespace-nowrap truncate align-middle leading-none">
+              <%= link_to related_task.user.name,
+                          user_path(related_task.user),
+                          class: "text-blue-600 hover:text-blue-800",
+                          onclick: "event.stopPropagation();",
+                          data: { turbo_frame: "_top" } %>
+            </div>
+
+            <div class="flex-1 min-w-0 px-4 py-3 text-center whitespace-nowrap align-middle leading-none tabular-nums text-gray-600">
+              <%= related_task.due_at ? l(related_task.due_at) : "未設定" %>
+            </div>
+
+            <div class="w-24 flex-none px-4 py-3 text-center whitespace-nowrap align-middle leading-none text-gray-400">
+              -
+            </div>
+
+            <%= render "tasks/assignment_popup", task: related_task %>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/tasks/_list_empty.html.erb
+++ b/app/views/tasks/_list_empty.html.erb
@@ -1,0 +1,3 @@
+<div class="bg-white rounded-lg shadow p-8 text-center text-gray-600 text-sm">
+  まだタスクは登録されていません。
+</div>

--- a/app/views/tasks/_list_mobile.html.erb
+++ b/app/views/tasks/_list_mobile.html.erb
@@ -1,0 +1,32 @@
+<div class="block md:hidden mb-4">
+  <div class="sticky top-20 z-10 flex items-center bg-gray-50 border border-gray-200 rounded shadow-sm px-3 py-2 mb-2 text-xs font-bold text-gray-600">
+    <div class="flex-1 min-w-0 text-left mx-1 whitespace-nowrap truncate overflow-hidden">件名</div>
+    <div class="flex-1 min-w-0 text-center mx-1 whitespace-nowrap truncate overflow-hidden">作成者</div>
+    <div class="flex-1 min-w-0 text-center mx-1 whitespace-nowrap truncate overflow-hidden">期限</div>
+    <div class="w-10 flex-none"></div>
+  </div>
+
+  <div class="space-y-2">
+    <% tasks.each do |task| %>
+      <% related_tasks = task.related_tasks %>
+
+      <div class="w-full" data-controller="related-toggle">
+
+        <%= render "mobile_card",
+                    task: task,
+                    show_related_button: related_tasks.any? %>
+
+        <% if related_tasks.any? %>
+          <div class="hidden" data-related-toggle-target="list">
+            <% related_tasks.each do |related_task| %>
+              <%= render "mobile_card",
+                          task: related_task,
+                          show_related_button: false %>
+            <% end %>
+          </div>
+        <% end %>
+
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/tasks/_mobile_card.html.erb
+++ b/app/views/tasks/_mobile_card.html.erb
@@ -1,0 +1,51 @@
+<div class="group relative bg-white rounded shadow-sm px-3 py-2 w-full hover:bg-gray-50 cursor-pointer"
+     data-controller="clickable"
+     data-related-toggle-target="card"
+     data-clickable-url-value="<%= task_path(task) %>"
+     data-action="click->clickable#open">
+
+  <div class="text-xs w-full leading-none">
+    <div class="flex items-center justify-between w-full h-5">
+      <div class="flex-1 min-w-0 text-gray-700 text-left mx-1 overflow-hidden">
+        <%= link_to task.title,
+                    task_path(task),
+                    class: "block truncate text-gray-700 hover:text-blue-600",
+                    onclick: "event.stopPropagation();",
+                    data: { turbo_frame: "_top" } %>
+      </div>
+
+      <div class="flex-1 min-w-0 text-blue-600 text-center mx-1 overflow-hidden">
+        <%= link_to task.user.name,
+                    user_path(task.user),
+                    class: "block truncate text-blue-600 hover:text-blue-800",
+                    onclick: "event.stopPropagation();",
+                    data: { turbo_frame: "_top" } %>
+      </div>
+
+      <div class="flex-1 min-w-0 text-gray-600 text-center mx-1 overflow-hidden whitespace-nowrap tabular-nums">
+        <%= task.due_at ? l(task.due_at.to_date, format: :short) : "未設定" %>
+      </div>
+
+      <div class="w-10 flex-none flex justify-end">
+        <% if show_related_button %>
+          <button
+            type="button"
+            class="related-toggle-button inline-flex items-center gap-1 text-blue-600"
+            data-action="click->related-toggle#toggle"
+            data-related-toggle-target="button"
+            aria-expanded="false">
+
+            <span>関連</span>
+
+            <span class="toggle-icon text-xs" data-related-toggle-target="icon">▼</span>
+          </button>
+
+        <% else %>
+          <span class="text-gray-400">-</span>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <%= render "tasks/assignment_popup", task: task %>
+</div>

--- a/app/views/tasks/_related_interactions.html.erb
+++ b/app/views/tasks/_related_interactions.html.erb
@@ -1,20 +1,25 @@
-<div class="mb-6 border-t-4 border-purple-500 pt-6">
-  <h2 class="text-lg font-semibold mb-3">関連応対履歴</h2>
+<div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
+  <h2 class="text-base sm:text-lg font-semibold mb-3">関連応対履歴</h2>
+
   <% interactions = task.interactions %>
+
   <% if interactions.any? %>
     <ul class="space-y-2">
       <% interactions.each do |interaction| %>
-        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
-          <span class="text-gray-600">応対履歴</span>
-          <%= link_to interaction.request_content, interaction_path(interaction), class: "flex-1 hover:text-blue-600" %>
-          <span class="text-xs text-gray-500">
-            <%= l interaction.occurred_at %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded group">
+          <%= link_to interaction.request_content,
+                      interaction_path(interaction),
+                      class: "flex-1 min-w-0 truncate text-gray-700 group-hover:text-blue-600" %>
+
+          <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right text-gray-500 group-hover:text-blue-600">
+            <span class="sm:hidden"><%= interaction.occurred_at.strftime("%-m/%-d") %></span>
+            <span class="hidden sm:inline"><%= l interaction.occurred_at %></span>
           </span>
         </li>
       <% end %>
     </ul>
   <% else %>
-    <div class="text-sm text-gray-500">
+    <div class="text-gray-500">
       まだ関連応対履歴は登録されていません。
     </div>
   <% end %>

--- a/app/views/tasks/_related_notices.html.erb
+++ b/app/views/tasks/_related_notices.html.erb
@@ -1,21 +1,32 @@
-<div class="mb-6 border-t-4 border-yellow-500 pt-6">
-  <h2 class="text-lg font-semibold mb-3">関連お知らせ</h2>
+<div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
+  <h2 class="text-base sm:text-lg font-semibold mb-3">関連お知らせ</h2>
+
   <% notices = task.notices %>
+
   <% if notices.any? %>
     <ul class="space-y-2">
       <% notices.each do |notice| %>
-        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
-          <span class="text-gray-600">お知らせ</span>
-          <%= link_to notice.content, notice_path(notice), class: "flex-1 hover:text-blue-600" %>
-          <span class="text-xs text-gray-500">
-            <%= l notice.start_at %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded group">
+          <%= link_to notice.content,
+                      notice_path(notice),
+                      class: "flex-1 min-w-0 truncate text-gray-700 group-hover:text-blue-600" %>
+
+          <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right text-gray-500 group-hover:text-blue-600">
+            <span class="sm:hidden"><%= notice.start_at.strftime("%-m/%-d") %></span>
+            <span class="hidden sm:inline"><%= l notice.start_at %></span>
           </span>
         </li>
       <% end %>
     </ul>
   <% else %>
-    <div class="text-sm text-gray-500">
+    <div class="text-gray-500">
       まだ関連お知らせは登録されていません。
     </div>
   <% end %>
+
+  <div class="mt-4">
+    <%= link_to "関連お知らせを作成",
+                new_notice_path(task_id: task.id),
+                class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
+  </div>
 </div>

--- a/app/views/tasks/_search_form.html.erb
+++ b/app/views/tasks/_search_form.html.erb
@@ -1,59 +1,82 @@
-<h2 class="text-sm font-semibold mb-3">検索</h2>
-<%= search_form_for @q, url: tasks_path, method: :get, html: { class: "text-sm w-full" } do |f| %>
-  <div class="flex flex-nowrap items-end gap-3 w-full">
-    <div class="w-64 shrink-0">
-      <%= f.label :title_or_description_cont, "キーワード", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.search_field :title_or_description_cont,
-            class: "w-full border rounded px-3 py-2 h-10",
-            placeholder: "タイトル・本文" %>
-    </div>
-    <div class="w-44 shrink-0">
-      <%= f.label :user_name_cont, "作成者名", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.search_field :user_name_cont,
-            class: "w-full border rounded px-3 py-2 h-10",
-            placeholder: "例）田中" %>
-    </div>
-    <div class="w-44 shrink-0">
-      <%= f.label :task_assignments_user_name_cont, "担当者名", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.search_field :task_assignments_user_name_cont,
-            class: "w-full border rounded px-3 py-2 h-10",
-            placeholder: "例）佐藤" %>
-    </div>
-    <div class="w-32 shrink-0">
-      <%= f.label :task_assignments_status_eq, "進捗状況", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.select :task_assignments_status_eq,
-            [["指定なし", ""], ["未着手", "todo"], ["進行中", "in_progress"], ["完了", "done"]],
-            {},
-            class: "w-full border rounded px-3 py-2 h-10" %>
-    </div>
-    <div class="w-32 shrink-0">
-      <%= f.label :due_within, "期限", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.select :due_within,
-            [
-              ["指定なし",   ""],
-              ["期限未設定", "unset"],
-              ["期限超過", "overdue"],
-              ["今日まで",   "today"],
-              ["今週末まで",   "week"],
-              ["今月末まで",   "month"]
-            ],
-            {},
-            class: "w-full border rounded px-3 py-2 h-10" %>
-    </div>
-    <% if Current.user.admin? %>
-      <div class="w-32 shrink-0">
-        <%= f.label :restricted_eq, "公開範囲", class: "block text-xs text-gray-600 mb-1" %>
-        <%= f.select :restricted_eq,
-              [["指定なし", ""], ["全員", false], ["管理者のみ", true]],
-              {},
-              class: "w-full border rounded px-3 py-2 h-10" %>
+<div class="flex items-center justify-between w-full">
+  <h2 class="text-sm font-semibold">検索</h2>
+
+  <svg data-disclosure-target="icon"
+       class="w-4 h-4 text-gray-500 transition-transform duration-200"
+       fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+  </svg>
+</div>
+
+<div data-disclosure-target="panel"
+     data-action="click->disclosure#stop"
+     class="hidden mt-3">
+  <%= search_form_for q, url: tasks_path, method: :get,
+                      html: { class: "text-sm w-full", data: { turbo_frame: "tasks_list" } } do |f| %>
+    <div class="grid grid-cols-2 md:grid-cols-4 xl:flex xl:flex-nowrap xl:items-end gap-2 xl:gap-3 w-full">
+
+      <div class="w-full xl:w-64 shrink-0 order-1">
+        <%= f.label :title_or_description_cont, "キーワード", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.search_field :title_or_description_cont,
+                           class: "w-full border border-gray-300 rounded px-3 h-8 sm:h-9 text-xs sm:text-sm text-gray-600",
+                           placeholder: "タイトル・本文" %>
       </div>
-    <% end %>
-    <div class="flex items-end gap-2 ml-auto shrink-0">
-      <%= link_to "クリア", tasks_path,
-            class: "px-3 py-2 border rounded text-gray-600 h-10 inline-flex items-center whitespace-nowrap" %>
-      <%= f.submit "検索",
-            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 h-10 whitespace-nowrap" %>
+
+      <div class="w-full xl:w-40 shrink-0 order-2">
+        <%= f.label :user_name_cont, "作成者名", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.search_field :user_name_cont,
+                           class: "w-full border border-gray-300 rounded px-3 h-8 sm:h-9 text-xs sm:text-sm text-gray-600",
+                           placeholder: "例）田中" %>
+      </div>
+
+      <div class="w-full xl:w-40 shrink-0 order-3">
+        <%= f.label :task_assignments_user_name_cont, "担当者名", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.search_field :task_assignments_user_name_cont,
+                           class: "w-full border border-gray-300 rounded px-3 h-8 sm:h-9 text-xs sm:text-sm text-gray-600",
+                           placeholder: "例）佐藤" %>
+      </div>
+
+      <div class="w-full xl:w-28 shrink-0 order-4">
+        <%= f.label :task_assignments_status_eq, "進捗状況", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.select :task_assignments_status_eq,
+                     [["指定なし", ""], ["未着手", "todo"], ["進行中", "in_progress"], ["完了", "done"]],
+                     {},
+                     class: "w-full border border-gray-300 rounded px-2 h-8 sm:h-9 text-xs sm:text-sm text-gray-600" %>
+      </div>
+
+      <div class="w-full xl:w-28 shrink-0 order-5">
+        <%= f.label :due_within, "期限", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.select :due_within,
+                     [
+                       ["指定なし",   ""],
+                       ["期限未設定", "unset"],
+                       ["期限超過", "overdue"],
+                       ["今日まで",   "today"],
+                       ["今週末まで",   "week"],
+                       ["今月末まで",   "month"]
+                     ],
+                     {},
+                     class: "w-full border border-gray-300 rounded px-2 h-8 sm:h-9 text-xs sm:text-sm text-gray-600" %>
+      </div>
+
+      <% if Current.user.admin? %>
+        <div class="w-full xl:w-28 shrink-0 order-6">
+          <%= f.label :restricted_eq, "公開範囲", class: "block text-xs text-gray-500 mb-1" %>
+          <%= f.select :restricted_eq,
+                       [["指定なし", ""], ["全員", false], ["管理者のみ", true]],
+                       {},
+                       class: "w-full border border-gray-300 rounded px-2 h-8 sm:h-9 text-xs sm:text-sm text-gray-600" %>
+        </div>
+      <% end %>
+
+      <div class="flex items-end justify-end justify-self-end gap-2 w-full order-7 col-start-2 md:col-start-4 xl:w-auto xl:ml-auto xl:mt-0 shrink-0 pt-1 xl:pt-0">
+        <%= link_to "クリア",
+                    tasks_path,
+                    class: "w-auto px-3 h-8 sm:h-9 border border-gray-300 rounded text-gray-500 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap bg-white hover:bg-gray-50" %>
+
+        <%= f.submit "検索",
+                     class: "w-auto px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap cursor-pointer" %>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/tasks/_timeline.html.erb
+++ b/app/views/tasks/_timeline.html.erb
@@ -1,25 +1,36 @@
-<div class="mb-6 border-t-4 border-blue-500 pt-6">
-  <h2 class="text-lg font-semibold mb-3">この案件の流れ</h2>
-  <div class="space-y-2 text-sm">
+<div class="mb-6 border-t-4 border-gray-300 pt-6">
+  <h2 class="text-base sm:text-lg font-semibold mb-3">この案件の流れ</h2>
+
+  <div class="space-y-2 text-xs sm:text-sm">
     <% timeline.each do |item| %>
       <div class="pl-4 border-l-2 <%= item == current_item ? 'border-blue-500' : 'border-gray-300' %>">
         <% if item == current_item %>
-          <span class="font-medium">
-            <%= l item.created_at %>
-            <%= truncate(item.description, length: 30) %>
-            <span class="text-blue-600">★ 現在</span>
-          </span>
+          <div class="flex items-center gap-1 py-1 px-2 bg-gray-50 rounded">
+            <span class="flex-1 min-w-0 truncate"><%= item.description %></span>
+            <span class="w-16 shrink-0 whitespace-nowrap text-blue-600">★ 現在</span>
+            <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right">
+              <span class="sm:hidden"><%= item.created_at.strftime("%-m/%-d") %></span>
+              <span class="hidden sm:inline"><%= l item.created_at %></span>
+            </span>
+          </div>
         <% else %>
-          <%= link_to task_path(item), class: "text-gray-700 hover:text-blue-600" do %>
-            <%= l item.created_at %> <%= truncate(item.description, length: 40) %>
+          <%= link_to task_path(item),
+                      class: "flex items-center gap-1 py-1 px-2 rounded hover:bg-gray-50 text-gray-700 hover:text-blue-600" do %>
+            <span class="flex-1 min-w-0 truncate"><%= item.description %></span>
+            <span class="w-16 shrink-0"></span>
+            <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right">
+              <span class="sm:hidden"><%= item.created_at.strftime("%-m/%-d") %></span>
+              <span class="hidden sm:inline"><%= l item.created_at %></span>
+            </span>
           <% end %>
         <% end %>
       </div>
     <% end %>
   </div>
+
   <div class="mt-4">
     <%= link_to "関連タスクを作成",
-          new_task_path(parent_id: current_item.id),
-          class: "text-sm px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+                new_task_path(parent_id: current_item.id),
+                class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
   </div>
 </div>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,14 +1,15 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-2xl mx-auto px-4">
-    <div class="mb-4">
-      <%= link_to "← 詳細に戻る", task_path(@task),
-            class: "text-blue-600 hover:underline text-sm" %>
+<div class="max-w-4xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <%= link_to "← 詳細に戻る",
+                task_path(@task),
+                class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-lg p-6">
+    <div class="border-b-4 border-blue-500 pb-4 mb-6">
+      <h1 class="text-xl font-bold">タスクの編集</h1>
     </div>
-    <div class="bg-white rounded-lg shadow-lg p-6">
-      <div class="border-b-4 border-purple-500 pb-4 mb-6">
-        <h1 class="text-2xl font-bold">タスクを編集</h1>
-      </div>
-      <%= render "form", task: @task, form: @form %>
-    </div>
+
+    <%= render "form", task: @task, form: @form %>
   </div>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,43 +1,19 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-7xl mx-auto px-4">
-    <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold">タスク一覧</h1>
-      <%= link_to "新規登録", new_task_path,
-            class: "px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600 text-sm" %>
-    </div>
-    <div class="bg-white rounded-lg shadow p-4 mb-4">
-      <%= render "search_form" %>
-    </div>
-    <div class="bg-white rounded-lg shadow">
-      <% if @tasks.any? %>
-        <table class="w-full text-sm">
-          <thead class="bg-gray-50 border-b">
-            <tr>
-              <th class="text-left p-3 text-gray-600">タイトル</th>
-              <th class="text-left p-3 text-gray-600">担当者</th>
-              <th class="text-left p-3 text-gray-600">期限</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y">
-            <% @tasks.each do |task| %>
-              <tr class="hover:bg-gray-50">
-                <td class="p-3">
-                  <%= link_to task.title, task_path(task),
-                        class: "text-blue-600 hover:underline" %>
-                </td>
-                <td class="p-3"><%= task.user.name %></td>
-                <td class="p-3">
-                  <%= task.due_at ? l(task.due_at) : "未設定" %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      <% else %>
-        <div class="p-8 text-center text-gray-500 text-sm">
-          まだタスクは登録されていません。
-        </div>
-      <% end %>
-    </div>
+<div class="max-w-7xl mx-auto px-4 py-4">
+  <div class="flex justify-between items-center mb-4">
+    <h1 class="text-base sm:text-xl font-bold">タスク一覧</h1>
+
+    <%= link_to "新規登録",
+            new_task_path,
+            class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center" %>
   </div>
+
+  <div data-controller="disclosure"
+       data-action="click->disclosure#toggle"
+       class="bg-white rounded-lg shadow overflow-hidden p-3 mb-4 cursor-pointer">
+    <%= render "search_form", q: @q %>
+  </div>
+
+  <%= turbo_frame_tag "tasks_list" do %>
+    <%= render "list" %>
+  <% end %>
 </div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,21 +1,23 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-2xl mx-auto px-4">
-    <div class="mb-4">
-      <% if @task.parent %>
-        <%= link_to "← 元のタスクに戻る", task_path(@parent_task),
-              class: "text-blue-600 hover:underline text-sm" %>
-      <% else %>
-        <%= link_to "← 一覧に戻る", tasks_path,
-              class: "text-blue-600 hover:underline text-sm" %>
-      <% end %>
+<div class="max-w-4xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <% if @task.parent %>
+      <%= link_to "← 元のタスクに戻る",
+                  task_path(@parent_task),
+                  class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+    <% else %>
+      <%= link_to "← 一覧に戻る",
+                  tasks_path,
+                  class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+    <% end %>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-lg p-6">
+    <div class="border-b-4 border-blue-500 pb-4 mb-6">
+      <h1 class="text-xl font-bold">
+        <%= @parent_task ? "関連タスクの登録" : "タスクの新規登録" %>
+      </h1>
     </div>
-    <div class="bg-white rounded-lg shadow-lg p-6">
-      <div class="border-b-4 border-purple-500 pb-4 mb-6">
-        <h1 class="text-2xl font-bold">
-          <%= @parent_task ? "関連タスクを登録" : "タスクを新規登録" %>
-        </h1>
-      </div>
-      <%= render "form", task: @task, form: @form %>
-    </div>
+
+    <%= render "form", task: @task, form: @form %>
   </div>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,53 +1,61 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-4xl mx-auto px-4">
-    <div class="mb-4">
-      <%= link_to "← 一覧に戻る", tasks_path,
-            class: "text-blue-600 hover:underline text-sm" %>
+<div class="max-w-4xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <%= link_to "← 一覧に戻る",
+                tasks_path,
+                class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-lg p-6">
+    <div class="border-b-4 border-blue-500 pb-4 mb-6">
+      <h1 class="text-lg sm:text-xl font-bold">タスク詳細</h1>
     </div>
-    <div class="bg-white rounded-lg shadow-lg p-6">
-      <div class="border-b-4 border-purple-500 pb-4 mb-6">
-        <h1 class="text-2xl font-bold">タスク詳細</h1>
-      </div>
-      <div class="mb-6">
-        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
-        <div class="bg-gray-50 p-4 rounded text-sm space-y-2">
-          <div>
-            <span class="text-gray-600">件名</span>
-            <span class="ml-2"><%= @task.title %></span>
+
+    <div class="mb-6">
+      <h2 class="text-base sm:text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
+
+      <div class="bg-gray-50 p-4 rounded text-xs sm:text-sm">
+        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-6 gap-y-3">
+          <div class="flex items-center">
+            <span class="w-16 shrink-0 text-gray-600">件名:</span>
+            <span><%= @task.title %></span>
           </div>
-          <div>
-            <span class="text-gray-600">作成者:</span>
-            <span class="ml-2"><%= @task.user.name %></span>
-          </div>
-          <div>
-            <span class="text-gray-600">期限:</span>
-            <span class="ml-2">
-              <%= @task.due_at ? l(@task.due_at) : "未設定" %>
+
+          <div class="flex items-center">
+            <span class="w-16 shrink-0 text-gray-600">作成者:</span>
+            <span>
+              <%= link_to @task.user.name,
+                          user_path(@task.user),
+                          class: "text-blue-600 hover:text-blue-800" %>
             </span>
           </div>
+
+          <div class="flex items-center">
+            <span class="w-16 shrink-0 text-gray-600">期限:</span>
+            <span><%= @task.due_at ? l(@task.due_at) : "未設定" %></span>
+          </div>
         </div>
       </div>
-      <div class="mb-6">
-        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">内容</h2>
-        <div class="bg-gray-50 p-4 rounded text-sm whitespace-pre-wrap">
-          <%= @task.description %>
-        </div>
-      </div>
-
-      <%= render "shared/images", record: @task %>
-
-      <%= render "assignees", task: @task %>
-      <%= render "timeline", timeline: @timeline, current_item: @task %>
-      <%= render "related_interactions", task: @task %>
-      <%= render "related_notices", task: @task %>
-      <%= render "shared/comment_thread", commentable: @task %>
-
-      <% if @task.user == Current.user %>
-        <div class="mt-6 flex justify-end border-t pt-4">
-          <%= link_to "編集", edit_task_path(@task),
-                class: "px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 text-sm" %>
-        </div>
-      <% end %>
     </div>
+
+    <div class="mb-6">
+      <h2 class="text-base sm:text-base sm:text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">内容</h2>
+
+      <div class="bg-gray-50 p-4 rounded text-xs sm:text-sm whitespace-pre-wrap"><%= @task.description %></div>
+    </div>
+
+    <%= render "shared/images", record: @task %>
+    <%= render "assignees", task: @task %>
+    <%= render "timeline", timeline: @timeline, current_item: @task %>
+    <%= render "related_interactions", task: @task %>
+    <%= render "related_notices", task: @task %>
+    <%= render "shared/comment_thread", commentable: @task %>
+
+    <% if @task.user == Current.user %>
+      <div class="mt-6 flex justify-end border-t-4 border-gray-300 pt-6">
+        <%= link_to "編集",
+                    edit_task_path(@task),
+                    class: "px-3 xl:px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Task, type: :model do
 
     it 'has a valid task with parent' do
       task = create(:task, :with_parent)
+
       expect(task).to be_valid
       expect(task.parent).to be_present
     end
@@ -16,11 +17,13 @@ RSpec.describe Task, type: :model do
   describe 'associations' do
     it 'belongs to user' do
       association = described_class.reflect_on_association(:user)
+
       expect(association.macro).to eq(:belongs_to)
     end
 
     it 'belongs to parent task (optional)' do
       association = described_class.reflect_on_association(:parent)
+
       expect(association.macro).to eq(:belongs_to)
       expect(association.options[:class_name]).to eq("Task")
       expect(association.options[:optional]).to be(true)
@@ -28,6 +31,7 @@ RSpec.describe Task, type: :model do
 
     it 'has many children tasks' do
       association = described_class.reflect_on_association(:children)
+
       expect(association.macro).to eq(:has_many)
       expect(association.options[:class_name]).to eq("Task")
       expect(association.options[:foreign_key]).to eq("parent_id")
@@ -35,14 +39,80 @@ RSpec.describe Task, type: :model do
 
     it 'has many task_assignments' do
       association = described_class.reflect_on_association(:task_assignments)
+
       expect(association.macro).to eq(:has_many)
     end
 
     it 'has_many users through task_assignments' do
       association = described_class.reflect_on_association(:assigned_users)
+
       expect(association.macro).to eq(:has_many)
       expect(association.options[:through]).to eq(:task_assignments)
       expect(association.options[:source]).to eq(:user)
+    end
+
+    it 'belongs to root task (optional)' do
+      association = described_class.reflect_on_association(:root)
+
+      expect(association.macro).to eq(:belongs_to)
+      expect(association.options[:class_name]).to eq("Task")
+      expect(association.options[:optional]).to be(true)
+    end
+
+    it 'has many thread_tasks' do
+      association = described_class.reflect_on_association(:thread_tasks)
+
+      expect(association.macro).to eq(:has_many)
+      expect(association.options[:class_name]).to eq("Task")
+      expect(association.options[:foreign_key]).to eq(:root_id)
+    end
+  end
+
+  describe 'root assignment' do
+    it 'sets root to itself when there is no parent' do
+      task = create(:task)
+
+      expect(task.root).to eq(task)
+    end
+
+    it 'inherits the root from the parent' do
+      parent = create(:task)
+      child = create(:task, parent: parent)
+
+      expect(child.root).to eq(parent)
+    end
+
+    it 'inherits the same root across multiple generations' do
+      root = create(:task)
+      child = create(:task, parent: root)
+      grandchild = create(:task, parent: child)
+
+      expect(grandchild.root).to eq(root)
+    end
+  end
+
+  describe '#related_tasks' do
+    it 'returns other tasks in the same thread ordered by created_at' do
+      parent = create(:task)
+      earlier_related_task = create(:task, parent: parent)
+      later_related_task = create(:task, parent: parent)
+
+      expect(parent.related_tasks).to eq([ earlier_related_task, later_related_task ])
+      expect(earlier_related_task.related_tasks).to eq([ parent, later_related_task ])
+      expect(later_related_task.related_tasks).to eq([ parent, earlier_related_task ])
+    end
+
+    it 'returns an empty array when there are no related tasks' do
+      task = create(:task)
+
+      expect(task.related_tasks).to eq([])
+    end
+
+    it 'does not include itself' do
+      parent = create(:task)
+      create(:task, parent: parent)
+
+      expect(parent.related_tasks).not_to include(parent)
     end
   end
 
@@ -50,16 +120,19 @@ RSpec.describe Task, type: :model do
     describe 'title' do
       it 'is required' do
         task = build(:task, title: "")
+
         expect(task).to be_invalid
       end
 
       it 'accepts title up to 50 characters' do
         task = build(:task, title: 'あ' * 50)
+
         expect(task).to be_valid
       end
 
       it 'rejects title longer than 50 characters' do
         task = build(:task, title: 'あ' * 51)
+
         expect(task).to be_invalid
       end
     end
@@ -67,16 +140,19 @@ RSpec.describe Task, type: :model do
     describe 'description' do
       it 'is required' do
         task = build(:task, description: "")
+
         expect(task).to be_invalid
       end
 
       it 'accepts description up to 2000 characters' do
         task = build(:task, description: 'あ' * 2000)
+
         expect(task).to be_valid
       end
 
       it 'rejects description longer than 2000 characters' do
         task = build(:task, description: 'あ' * 2001)
+
         expect(task).to be_invalid
       end
     end
@@ -84,16 +160,19 @@ RSpec.describe Task, type: :model do
     describe 'restricted' do
       it 'is valid when restricted is true' do
         task = build(:task, restricted: true)
+
         expect(task).to be_valid
       end
 
       it 'is valid when restricted is false' do
         task = build(:task, restricted: false)
+
         expect(task).to be_valid
       end
 
       it 'is invalid when restricted is nil' do
         task = build(:task, restricted: nil)
+
         expect(task).to be_invalid
       end
     end

--- a/spec/requests/interaction_tasks_spec.rb
+++ b/spec/requests/interaction_tasks_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Interaction Tasks", type: :request do
+  let(:user) { create(:user) }
+  let(:task) { create(:task) }
+  let(:customer) { create(:customer) }
+
+  def sign_in(user)
+    post login_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  before { sign_in(user) }
+
+  describe "GET /interactions/:id - related tasks display" do
+    let(:interaction) { create(:interaction, user: user, customer: customer) }
+
+    context "when the interaction has linked tasks" do
+      before { interaction.tasks << task }
+
+      it "displays the linked task" do
+        get interaction_path(interaction)
+
+        expect(response.body).to include(task.title)
+      end
+    end
+
+    context "when the interaction has no linked tasks" do
+      it "displays the empty message" do
+        get interaction_path(interaction)
+
+        expect(response.body).to include("まだ関連するタスクは登録されていません")
+      end
+    end
+  end
+end

--- a/spec/requests/notice_tasks_spec.rb
+++ b/spec/requests/notice_tasks_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Notice Tasks", type: :request do
+  let(:user) { create(:user) }
+  let(:task) { create(:task) }
+
+  def sign_in(user)
+    post login_path, params: { email_address: user.email_address, password: "password55" }
+  end
+
+  before { sign_in(user) }
+
+  describe "GET /notices/new with task_id" do
+    it "passes task_id to the form" do
+      get new_notice_path(task_id: task.id)
+
+      expect(response.body).to include(task.id.to_s)
+    end
+  end
+
+  describe "POST /notices with task_id" do
+    let(:valid_params) do
+      {
+        notice: {
+          title: "テストお知らせ",
+          content: "テストお知らせの詳細",
+          level: "normal",
+          start_at: 1.day.from_now,
+          end_at: 7.days.from_now
+        },
+        task_id: task.id
+      }
+    end
+
+    it "links the notice to the task" do
+      post notices_path, params: valid_params
+
+      expect(Notice.last.tasks).to include(task)
+    end
+
+    it "redirects to the created notice" do
+      post notices_path, params: valid_params
+
+      expect(response).to redirect_to(notice_path(Notice.last))
+    end
+
+    it "does not link when task_id is absent" do
+      post notices_path, params: valid_params.except(:task_id)
+
+      expect(Notice.last.tasks).to be_empty
+    end
+
+    it "does not link when notice save fails" do
+      invalid_params = valid_params.deep_merge(notice: { title: "" })
+
+      expect {
+        post notices_path, params: invalid_params
+      }.not_to change(Notice, :count)
+    end
+  end
+end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -66,6 +66,32 @@ RSpec.describe "Tasks", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(task.title, other_task.title)
       end
+
+      it "uses full-page navigation for user links inside turbo frame" do
+        get tasks_path
+
+        expect(response.body).to include('data-turbo-frame="_top"')
+        expect(response.body).to include(user_path(task.user))
+      end
+
+      it "renders related tasks under the parent task row" do
+        related_task = create(:task, user: user, parent: task, title: "関連タスクの内容")
+
+        get tasks_path
+
+        expect(response.body).to include("関連")
+        expect(response.body).to include(related_task.title)
+      end
+
+      it "renders sibling tasks as related, not just direct children" do
+        first_sibling_task = create(:task, user: user, parent: task, title: "関連タスクA")
+        second_sibling_task = create(:task, user: user, parent: task, title: "関連タスクB")
+
+        get tasks_path
+
+        expect(response.body).to include(first_sibling_task.title)
+        expect(response.body).to include(second_sibling_task.title)
+      end
     end
 
     context "when the user is an admin" do
@@ -208,7 +234,7 @@ RSpec.describe "Tasks", type: :request do
 
       it "re-renders the new template with invalid params" do
         post tasks_path, params: create_task_with_assignees({ task: { title: nil } })
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "ignores restricted parameter" do
@@ -372,7 +398,7 @@ RSpec.describe "Tasks", type: :request do
         patch task_path(task), params: { task: { title: nil } }
 
         expect(task.reload.title).not_to be_nil
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "cannot update a restricted task and redirects to the index template" do


### PR DESCRIPTION
## 概要
タスク一覧・詳細画面のUIを刷新し、レスポンシブ対応と関連情報（お知らせ・応対履歴・関連タスク）の表示/リンクを強化する。
## 変更内容
- タスク一覧をturbo frame化し、デスクトップ/モバイル用partialと関連タスク展開機能を追加
- タスク割り当てテーブル・ポップアップ用partialとステータスバッジ用helperを追加
- お知らせ作成時にtask_idパラメータでタスクと関連付けられるように対応
- Task#related_tasksメソッドとthread_tasks関連のテストを追加
- タスク関連画面（フォーム・詳細・タイムライン・関連応対履歴等）の余白・フォントサイズ・レスポンシブ対応を統一
- 応対履歴一覧のモバイル表示にスティッキーヘッダーとtabular-nums、はみ出し対応を追加
- `unprocessable_entity` を `unprocessable_content` に変更（Rails側のステータスコード対応）
## 確認済み
- [x] spec/models/task_spec.rb にrelated_tasks・thread_tasks関連のテストを追加
- [x] spec/requests/tasks_spec.rb にturbo frame内リンクとstatusコード変更のテストを追加
- [x] spec/requests/interaction_tasks_spec.rb, spec/requests/notice_tasks_spec.rb を追加
## 補足
Closes #141 