### PR TITLE
Improve Notice UI responsiveness and add thread-wide related notices

### DIFF
--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,5 +1,6 @@
 class InteractionsController < ApplicationController
-  before_action :set_interaction, only: [ :show, :edit, :update ]
+  before_action :set_interaction, only: [ :edit, :update ]
+  before_action :set_interaction_with_comments, only: :show
   before_action :authorize_edit!, only: [ :edit, :update ]
 
   def index
@@ -52,11 +53,11 @@ class InteractionsController < ApplicationController
   private
 
   def set_interaction
-    @interaction = Interaction.preload(
-      :customer,
-      :user,
-      comments: [ :user ]
-    ).find(params[:id])
+    @interaction = Interaction.preload(:customer, :user).find(params[:id])
+  end
+
+  def set_interaction_with_comments
+    @interaction = Interaction.preload(:customer, :user, comments: [ :user ]).find(params[:id])
   end
 
   def interaction_params

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,5 +1,6 @@
 class NoticesController < ApplicationController
-  before_action :set_notice, only: %i[show edit update]
+  before_action :set_notice, only: %i[edit update]
+  before_action :set_notice_with_comments, only: :show
   before_action :authorize_view!, only: %i[show edit update]
   before_action :authorize_edit!, only: %i[edit update]
 
@@ -7,7 +8,12 @@ class NoticesController < ApplicationController
   def index
     @q = visible_notices.ransack(params[:q], auth_object: :admin)
     @notices = @q.result
-               .preload(:user)
+               .preload(
+                 :user,
+                 root: {
+                   thread_notices: [ :user ]
+                 }
+               )
                .order(start_at: :desc)
   end
 
@@ -29,7 +35,7 @@ class NoticesController < ApplicationController
 
       redirect_to @notice, notice: "お知らせを更新しました"
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -44,17 +50,18 @@ class NoticesController < ApplicationController
     if @notice.update(notice_params)
       redirect_to @notice, notice: "お知らせを更新しました"
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
   private
 
   def set_notice
-    @notice = Notice.preload(
-      :user,
-      comments: [ :user ]
-    ).find(params[:id])
+    @notice = Notice.preload(:user).find(params[:id])
+  end
+
+  def set_notice_with_comments
+    @notice = Notice.preload(:user, comments: [ :user ]).find(params[:id])
   end
 
   def visible_notices

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,6 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: [ :show, :edit, :update ]
+  before_action :set_task, only: [ :edit, :update ]
+  before_action :set_task_with_associations, only: :show
   before_action :authorize_view!, only: [ :show, :edit, :update ]
   before_action :authorize_edit!, only: [ :edit, :update ]
 
@@ -61,11 +62,11 @@ class TasksController < ApplicationController
   private
 
   def set_task
-    @task = Task.preload(
-      :user,
-      task_assignments: [ :user ],
-      comments: [ :user ]
-    ).find(params[:id])
+    @task = Task.preload(:user).find(params[:id])
+  end
+
+  def set_task_with_associations
+    @task = Task.preload(:user, task_assignments: [ :user ], comments: [ :user ]).find(params[:id])
   end
 
   def visible_tasks

--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -2,4 +2,11 @@ module NoticesHelper
   def notice_level_label(notice)
     I18n.t("enums.notice.level.#{notice.level}", default: notice.level)
   end
+
+  def notice_level_badge_class(notice)
+    base = "inline-flex items-center justify-center rounded text-xs border"
+    color = notice.important? ? "bg-amber-100 text-amber-700 border-amber-200" : "bg-gray-100 text-gray-600 border-gray-200"
+
+    "#{base} #{color}"
+  end
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -5,7 +5,10 @@ class Notice < ApplicationRecord
   belongs_to :user
 
   belongs_to :parent, class_name: "Notice", optional: true
-  has_many :children, class_name: "Notice", foreign_key: "parent_id"
+  has_many :children,
+           -> { order(created_at: :desc) },
+           class_name: "Notice",
+           foreign_key: "parent_id"
 
   belongs_to :root, class_name: "Notice", optional: true
   has_many :thread_notices, class_name: "Notice", foreign_key: :root_id, dependent: :nullify
@@ -34,6 +37,11 @@ class Notice < ApplicationRecord
   validates :images,
     content_type: %w[image/jpeg image/png image/gif],
     size: { less_than_or_equal_to: 10.megabytes }
+
+  def related_notices
+    thread_notices_all = root.thread_notices
+    thread_notices_all.reject { |notice| notice.id == id }.sort_by(&:created_at)
+  end
 
   private
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,21 +37,21 @@
       </nav>
 
       <% if notice %>
-        <div class="max-w-7xl mx-auto px-4 py-2 bg-green-100 text-green-800 rounded"><%= notice %></div>
+        <div class="max-w-7xl mx-auto px-4 py-2 bg-green-100 text-green-800 rounded text-xs sm:text-sm"><%= notice %></div>
       <% end %>
 
       <% if alert %>
-        <div class="max-w-7xl mx-auto px-4 py-2 bg-red-100 text-red-800 rounded"><%= alert %></div>
+        <div class="max-w-7xl mx-auto px-4 py-2 bg-red-100 text-red-800 rounded text-xs sm:text-sm"><%= alert %></div>
       <% end %>
 
       <%= yield %>
     <% else %>
       <% if notice %>
-        <div class="max-w-7xl mx-auto px-4 py-2 bg-green-100 text-green-800 rounded"><%= notice %></div>
+        <div class="max-w-7xl mx-auto px-4 py-2 bg-green-100 text-green-800 rounded text-xs sm:text-sm"><%= notice %></div>
       <% end %>
 
       <% if alert %>
-        <div class="max-w-7xl mx-auto px-4 py-2 bg-red-100 text-red-800 rounded"><%= alert %></div>
+        <div class="max-w-7xl mx-auto px-4 py-2 bg-red-100 text-red-800 rounded text-xs sm:text-sm"><%= alert %></div>
       <% end %>
 
       <%= yield %>

--- a/app/views/notices/_form.html.erb
+++ b/app/views/notices/_form.html.erb
@@ -1,9 +1,8 @@
 <%= form_with model: notice, class: "space-y-4" do |f| %>
   <% if notice.errors.any? %>
     <div class="bg-red-50 border border-red-300 rounded p-4">
-      <p class="text-red-700 font-semibold text-sm mb-2">
-        <%= notice.errors.count %>件のエラーがあります
-      </p>
+      <p class="text-red-700 font-semibold text-sm mb-2">入力内容にエラーがあります。</p>
+
       <ul class="list-disc list-inside text-red-600 text-sm space-y-1">
         <% notice.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
@@ -11,56 +10,83 @@
       </ul>
     </div>
   <% end %>
+
   <%= f.hidden_field :parent_id %>
   <%= hidden_field_tag :interaction_id, params[:interaction_id] if params[:interaction_id].present? %>
   <%= hidden_field_tag :task_id, params[:task_id] if params[:task_id].present? %>
-  <div>
-    <%= f.label :title, "件名", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_field :title,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
-  </div>
-  <div>
-    <%= f.label :level, "重要度", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.select :level,
-          [["高", "important"], ["低", "normal"]],
-          { prompt: "選択してください" },
-          { class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" } %>
-  </div>
-  <div>
-    <%= f.label :start_at, "開始日時", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.datetime_local_field :start_at,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
-  </div>
-  <div>
-    <%= f.label :end_at, "終了日時", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.datetime_local_field :end_at,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
-  </div>
-  <div>
-    <%= f.label :content, "内容", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_area :content, rows: 4,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
-  </div>
-  <% if Current.user.admin? %>
-    <div class="flex items-center gap-2">
-      <%= f.check_box :restricted, class: "rounded" %>
-      <%= f.label :restricted, "管理者のみ", class: "text-sm text-gray-700" %>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+    <div>
+      <%= f.label :title, "件名", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= f.text_field :title,
+                       class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" %>
     </div>
-  <% end %>
-  <div>
-    <%= f.label :images, "画像", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <div class="w-full border border-gray-300 rounded px-3 py-2 text-sm bg-white">
-      <%= f.file_field :images, multiple: true, accept: "image/jpeg,image/png,image/gif",
-            class: "w-full text-sm text-gray-600
-                    file:mr-3 file:py-1 file:px-3
-                    file:rounded file:border file:border-gray-300
-                    file:text-sm file:text-gray-600 file:bg-gray-50
-                    hover:file:bg-gray-100 file:cursor-pointer cursor-pointer" %>
+
+    <div>
+      <%= f.label :level, "重要度", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= f.select :level,
+                   [["高", "important"], ["低", "normal"]],
+                   { prompt: "選択してください" },
+                   { class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" } %>
     </div>
-    <p class="mt-1 text-xs text-gray-400">JPEG / PNG / GIF・最大 10MB・複数可</p>
+
+    <div>
+      <%= f.label :start_at, "開始日時", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= f.datetime_local_field :start_at,
+                                 class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm xl:text-sm" %>
+    </div>
+
+    <div>
+      <%= f.label :end_at, "終了日時", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= f.datetime_local_field :end_at,
+                                 class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm xl:text-sm" %>
+    </div>
+
+    <% if Current.user.admin? %>
+      <div>
+        <span class="block text-sm text-gray-700 mb-1">公開範囲</span>
+
+        <label class="flex items-center h-8 sm:h-9">
+          <%= f.check_box :restricted, class: "rounded" %>
+          <span class="ml-2 text-xs sm:text-sm text-gray-700">管理者のみ</span>
+        </label>
+      </div>
+    <% end %>
   </div>
+
+  <div>
+    <%= f.label :content, "内容", class: "block text-sm text-gray-700 mb-1" %>
+
+    <%= f.text_area :content,
+                    rows: 4,
+                    class: "w-full border border-gray-300 rounded px-3 py-2 text-xs sm:text-sm" %>
+  </div>
+
+  <div>
+    <%= f.label :images, "画像", class: "block text-sm text-gray-700 mb-1" %>
+
+    <div class="w-full border border-gray-300 rounded px-3 py-2 text-xs sm:text-sm bg-white">
+      <%= f.file_field :images,
+                       multiple: true,
+                       accept: "image/jpeg,image/png,image/gif",
+                       class: "w-full text-xs sm:text-sm text-gray-600
+                               file:mr-3 file:py-1 file:px-3
+                               file:rounded file:border file:border-gray-300
+                               file:text-sm file:text-gray-600 file:bg-gray-50
+                               hover:file:bg-gray-100 file:cursor-pointer cursor-pointer" %>
+    </div>
+
+    <p class="mt-1 text-xs text-gray-400">
+      JPEG / PNG / GIF・最大 10MB・複数可
+    </p>
+  </div>
+
   <div class="flex justify-end pt-2">
-    <%= f.submit notice.new_record? ? "登録する" : "更新する",
-          class: "px-6 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 text-sm cursor-pointer" %>
+    <%= f.submit notice.new_record? ? "登録" : "更新",
+                 class: "px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
   </div>
 <% end %>

--- a/app/views/notices/_list.html.erb
+++ b/app/views/notices/_list.html.erb
@@ -1,0 +1,6 @@
+<% if @notices.any? %>
+  <%= render "list_mobile", notices: @notices %>
+  <%= render "list_desktop", notices: @notices %>
+<% else %>
+  <%= render "list_empty" %>
+<% end %>

--- a/app/views/notices/_list_desktop.html.erb
+++ b/app/views/notices/_list_desktop.html.erb
@@ -1,0 +1,106 @@
+<div class="hidden md:block overflow-x-auto bg-white rounded-lg shadow">
+  <table class="w-full text-xs sm:text-sm border-collapse table-fixed">
+    <thead class="bg-gray-50 text-gray-600">
+      <tr>
+        <th class="w-5/12 px-2 md:px-4 xl:px-8 py-3 text-left whitespace-nowrap align-middle leading-none">件名</th>
+        <th class="w-2/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">重要度</th>
+        <th class="w-2/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">作成者</th>
+        <th class="w-2/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none tabular-nums">公開日時</th>
+        <th class="w-1/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none"></th>
+      </tr>
+    </thead>
+
+    <tbody data-controller="related-toggle-list">
+      <% notices.each do |notice| %>
+        <% related_notices = notice.related_notices %>
+        <tr class="hover:bg-gray-100 cursor-pointer"
+            data-notice-id="<%= notice.id %>"
+            data-controller="clickable"
+            data-clickable-url-value="<%= notice_path(notice) %>"
+            data-action="click->clickable#open">
+
+          <td class="w-5/12 px-2 md:px-4 xl:px-8 py-3 text-left align-middle leading-none text-gray-600 truncate">
+            <%= notice.title %>
+          </td>
+
+          <td class="w-2/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">
+            <span class="<%= notice_level_badge_class(notice) %> px-2 py-1 inline-block leading-none">
+              <%= notice_level_label(notice) %>
+            </span>
+          </td>
+
+          <td class="w-2/12 px-4 py-3 text-center whitespace-nowrap truncate align-middle leading-none">
+            <%= link_to notice.user.name,
+                        user_path(notice.user),
+                        class: "text-blue-600 hover:text-blue-800",
+                        onclick: "event.stopPropagation();",
+                        data: { turbo_frame: "_top" } %>
+          </td>
+
+          <td class="w-2/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none tabular-nums text-gray-600">
+            <%= l notice.start_at %>
+          </td>
+
+          <td class="w-1/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none text-gray-600">
+            <% if related_notices.any? %>
+              <button
+                type="button"
+                class="related-toggle-button inline-flex items-center gap-1 text-blue-600"
+                data-notice-id="<%= notice.id %>"
+                data-action="click->related-toggle-list#toggle"
+                data-related-toggle-list-target="button"
+                aria-expanded="false">
+
+                <span>関連</span>
+
+                <span class="toggle-icon text-xs" data-related-toggle-list-target="icon">▼</span>
+
+              </button>
+            <% else %>
+              <span class="text-gray-400">-</span>
+            <% end %>
+          </td>
+        </tr>
+
+        <% if related_notices.any? %>
+          <% related_notices.each do |related_notice| %>
+            <tr
+              class="related-list-row hidden hover:bg-gray-100"
+              data-controller="clickable"
+              data-clickable-url-value="<%= notice_path(related_notice) %>"
+              data-action="click->clickable#open">
+              <td class="w-5/12 px-2 md:px-4 xl:px-8 py-3 text-left align-middle leading-none text-gray-600 truncate">
+                <%= link_to truncate(related_notice.title, length: 60),
+                            notice_path(related_notice),
+                            class: "block truncate hover:text-blue-600",
+                            data: { turbo_frame: "_top" } %>
+              </td>
+
+              <td class="w-2/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">
+                <span class="<%= notice_level_badge_class(related_notice) %> px-2 py-1 inline-block leading-none">
+                  <%= notice_level_label(related_notice) %>
+                </span>
+              </td>
+
+              <td class="w-2/12 px-4 py-3 text-center whitespace-nowrap truncate align-middle leading-none">
+                <%= link_to related_notice.user.name,
+                            user_path(related_notice.user),
+                            class: "text-blue-600 hover:text-blue-800",
+                            onclick: "event.stopPropagation();",
+                            data: { turbo_frame: "_top" } %>
+              </td>
+
+              <td class="w-2/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none tabular-nums text-gray-600">
+                <%= l related_notice.start_at %>
+              </td>
+
+              <td class="w-1/12 px-4 py-3 text-center whitespace-nowrap align-middle leading-none text-gray-400">
+                -
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/notices/_list_empty.html.erb
+++ b/app/views/notices/_list_empty.html.erb
@@ -1,0 +1,3 @@
+<div class="bg-white rounded-lg shadow p-8 text-center text-gray-600 text-sm">
+  まだお知らせはありません。
+</div>

--- a/app/views/notices/_list_mobile.html.erb
+++ b/app/views/notices/_list_mobile.html.erb
@@ -1,0 +1,32 @@
+<div class="block md:hidden mb-4">
+  <div class="sticky top-20 z-10 flex items-center bg-gray-50 border border-gray-200 rounded shadow-sm px-3 py-2 mb-2 text-xs font-bold text-gray-600">
+    <div class="flex-1 min-w-0 text-left mx-1 whitespace-nowrap truncate overflow-hidden">件名</div>
+    <div class="w-12 flex-none text-center mx-1 whitespace-nowrap truncate overflow-hidden">重要度</div>
+    <div class="flex-1 min-w-0 text-center mx-1 whitespace-nowrap truncate overflow-hidden">作成者</div>
+    <div class="w-10 flex-none"></div>
+  </div>
+
+  <div class="space-y-2">
+    <% notices.each do |notice| %>
+      <% related_notices = notice.related_notices %>
+
+      <div class="w-full" data-controller="related-toggle">
+
+        <%= render "mobile_card",
+                    notice: notice,
+                    show_related_button: related_notices.any? %>
+
+        <% if related_notices.any? %>
+          <div class="hidden" data-related-toggle-target="list">
+            <% related_notices.each do |related_notice| %>
+              <%= render "mobile_card",
+                          notice: related_notice,
+                          show_related_button: false %>
+            <% end %>
+          </div>
+        <% end %>
+
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notices/_mobile_card.html.erb
+++ b/app/views/notices/_mobile_card.html.erb
@@ -1,0 +1,57 @@
+<div class="bg-white rounded shadow-sm px-3 py-2 w-full hover:bg-gray-50 cursor-pointer"
+     data-controller="clickable"
+     data-related-toggle-target="card"
+     data-clickable-url-value="<%= notice_path(notice) %>"
+     data-action="click->clickable#open">
+
+  <div class="text-xs w-full leading-none">
+    <div class="flex items-center justify-between w-full h-5">
+      <div class="flex-1 min-w-0 text-gray-700 text-left mx-1 overflow-hidden">
+        <%= link_to notice.title,
+                    notice_path(notice),
+                    class: "block truncate text-gray-700 hover:text-blue-600",
+                    onclick: "event.stopPropagation();",
+                    data: { turbo_frame: "_top" } %>
+      </div>
+
+      <div class="w-12 flex-none flex justify-center items-center mx-1 overflow-hidden">
+        <span class="<%= notice_level_badge_class(notice) %> px-1 py-1 inline-flex items-center justify-center whitespace-nowrap rounded-sm sm:px-2">
+          <%= notice_level_label(notice) %>
+        </span>
+      </div>
+
+      <div class="flex-1 min-w-0 text-blue-600 text-center mx-1 overflow-hidden">
+        <%= link_to notice.user.name,
+                    user_path(notice.user),
+                    class: "block truncate text-blue-600 hover:text-blue-800",
+                    onclick: "event.stopPropagation();",
+                    data: { turbo_frame: "_top" } %>
+      </div>
+
+      <div class="w-10 flex justify-end">
+        <% if show_related_button %>
+          <button
+            type="button"
+            class="related-toggle-button inline-flex items-center gap-1 text-blue-600"
+            data-action="click->related-toggle#toggle"
+            data-related-toggle-target="button"
+            aria-expanded="false">
+
+            <span>関連</span>
+
+            <span class="toggle-icon text-xs" data-related-toggle-target="icon">▼</span>
+          </button>
+
+        <% else %>
+          <span class="text-gray-400">-</span>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="pt-2 ml-1">
+      <div class="text-gray-600 truncate">
+        <%= notice.content %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/notices/_related_interactions.html.erb
+++ b/app/views/notices/_related_interactions.html.erb
@@ -1,20 +1,25 @@
-<div class="mb-6 border-t-4 border-blue-500 pt-6">
-  <h2 class="text-lg font-semibold mb-3">関連応対履歴</h2>
+<div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
+  <h2 class="text-base sm:text-lg font-semibold mb-3">関連応対履歴</h2>
+
   <% interactions = notice.interactions %>
+
   <% if interactions.any? %>
     <ul class="space-y-2">
       <% interactions.each do |interaction| %>
-        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
-          <span class="text-gray-600">応対履歴</span>
-          <%= link_to interaction.request_content, interaction_path(interaction), class: "flex-1 hover:text-blue-600" %>
-          <span class="text-xs text-gray-500">
-            <%= l interaction.occurred_at %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded group">
+          <%= link_to interaction.request_content,
+                      interaction_path(interaction),
+                      class: "flex-1 min-w-0 truncate text-gray-700 group-hover:text-blue-600" %>
+
+          <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right text-gray-500 group-hover:text-blue-600">
+            <span class="sm:hidden"><%= interaction.occurred_at.strftime("%-m/%-d") %></span>
+            <span class="hidden sm:inline"><%= l interaction.occurred_at %></span>
           </span>
         </li>
       <% end %>
     </ul>
   <% else %>
-    <div class="text-sm text-gray-500">
+    <div class="text-gray-500">
       まだ関連応対履歴は登録されていません。
     </div>
   <% end %>

--- a/app/views/notices/_related_tasks.html.erb
+++ b/app/views/notices/_related_tasks.html.erb
@@ -1,26 +1,32 @@
-<div class="mb-6 border-t-4 border-purple-500 pt-6">
-  <h2 class="text-lg font-semibold mb-3">関連タスク</h2>
+<div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
+  <h2 class="text-base sm:text-lg font-semibold mb-3">関連タスク</h2>
+
   <% tasks = notice.tasks %>
+
   <% if tasks.any? %>
     <ul class="space-y-2">
       <% tasks.each do |task| %>
-        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded">
-          <span class="text-gray-600">タスク</span>
-          <%= link_to task.title, task_path(task), class: "flex-1 hover:text-blue-600" %>
-          <span class="text-xs text-gray-500">
-            <%= l task.due_at %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded group">
+          <%= link_to task.title,
+                      task_path(task),
+                      class: "flex-1 min-w-0 truncate text-gray-700 group-hover:text-blue-600" %>
+
+          <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right text-gray-500 group-hover:text-blue-600">
+            <span class="sm:hidden"><%= task.due_at.strftime("%-m/%-d") %></span>
+            <span class="hidden sm:inline"><%= l task.due_at %></span>
           </span>
         </li>
       <% end %>
     </ul>
   <% else %>
-    <div class="text-sm text-gray-500">
+    <div class="text-gray-500">
       まだ関連するタスクは登録されていません。
     </div>
   <% end %>
+
   <div class="mt-4">
     <%= link_to "関連タスクを作成",
-        new_task_path(notice_id: notice.id),
-        class: "text-sm px-4 py-2 bg-purple-500 text-white rounded hover:bg-yellow-600" %>
+                new_task_path(notice_id: notice.id),
+                class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
   </div>
 </div>

--- a/app/views/notices/_search_form.html.erb
+++ b/app/views/notices/_search_form.html.erb
@@ -1,50 +1,68 @@
-<h2 class="text-sm font-semibold mb-3">検索</h2>
-<%= search_form_for @q, url: notices_path, method: :get, html: { class: "text-sm w-full" } do |f| %>
-  <div class="flex flex-nowrap items-end gap-3 w-full">
-    <div class="w-64 shrink-0">
-      <%= f.label :title_or_content_cont, "キーワード", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.search_field :title_or_content_cont,
-            class: "w-full border rounded px-3 py-2 h-10",
-            placeholder: "タイトル・内容" %>
-    </div>
-    <div class="w-44 shrink-0">
-      <%= f.label :user_name_cont, "作成者名", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.search_field :user_name_cont,
-            class: "w-full border rounded px-3 py-2 h-10",
-            placeholder: "例）田中" %>
-    </div>
-    <div class="w-36 shrink-0">
-      <%= f.label :level_eq, "重要度", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.select :level_eq,
-            [["指定なし", ""], ["高", "important"], ["低", "normal"]],
-            {},
-            class: "w-full border rounded px-3 py-2 h-10" %>
-    </div>
-    <% if Current.user.admin? %>
-      <div class="w-36 shrink-0">
-        <%= f.label :restricted_eq, "公開範囲", class: "block text-xs text-gray-600 mb-1" %>
-        <%= f.select :restricted_eq,
-              [["指定なし", ""], ["全員", false], ["管理者のみ", true]],
-              {},
-              class: "w-full border rounded px-3 py-2 h-10" %>
+<div class="flex items-center justify-between w-full">
+  <h2 class="text-sm font-semibold">検索</h2>
+
+  <svg data-disclosure-target="icon"
+       class="w-4 h-4 text-gray-500 transition-transform duration-200"
+       fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+  </svg>
+</div>
+
+<div data-disclosure-target="panel"
+     data-action="click->disclosure#stop"
+     class="hidden mt-3">
+  <%= search_form_for q, url: notices_path, method: :get,
+                      html: { class: "text-sm w-full", data: { turbo_frame: "notices_list" } } do |f| %>
+    <div class="grid grid-cols-2 md:grid-cols-4 xl:flex xl:flex-nowrap xl:items-end gap-2 xl:gap-3 w-full">
+
+      <div class="w-full xl:w-64 shrink-0 order-1">
+        <%= f.label :title_or_content_cont, "キーワード", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.search_field :title_or_content_cont,
+                           class: "w-full border border-gray-300 rounded px-3 h-8 sm:h-9 text-xs sm:text-sm text-gray-600",
+                           placeholder: "タイトル・内容" %>
       </div>
-    <% end %>
-    <div class="w-36 shrink-0">
-      <%= f.label :due_within, "公開日時", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.select :status,
-        [
-          ["指定なし", ""],
-          ["公開中", "active"],
-          ["終了済", "expired"]
-        ],
-        {},
-        class: "w-full border rounded px-3 py-2 h-10" %>
+
+      <div class="w-full xl:w-40 shrink-0 order-2">
+        <%= f.label :user_name_cont, "作成者名", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.search_field :user_name_cont,
+                           class: "w-full border border-gray-300 rounded px-3 h-8 sm:h-9 text-xs sm:text-sm text-gray-600",
+                           placeholder: "例）田中" %>
+      </div>
+
+      <div class="w-full xl:w-32 shrink-0 order-3">
+        <%= f.label :level_eq, "重要度", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.select :level_eq,
+                     [["指定なし", ""], ["高", "important"], ["低", "normal"]],
+                     {},
+                     class: "w-full border border-gray-300 rounded px-2 h-8 sm:h-9 text-xs sm:text-sm text-gray-600" %>
+      </div>
+
+      <% if Current.user.admin? %>
+        <div class="w-full xl:w-32 shrink-0 order-4">
+          <%= f.label :restricted_eq, "公開範囲", class: "block text-xs text-gray-500 mb-1" %>
+          <%= f.select :restricted_eq,
+                       [["指定なし", ""], ["全員", false], ["管理者のみ", true]],
+                       {},
+                       class: "w-full border border-gray-300 rounded px-2 h-8 sm:h-9 text-xs sm:text-sm text-gray-600" %>
+        </div>
+      <% end %>
+
+      <div class="w-full xl:w-32 shrink-0 order-5">
+        <%= f.label :status, "公開状況", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.select :status,
+                     [["指定なし", ""], ["公開中", "active"], ["終了済", "expired"]],
+                     {},
+                     class: "w-full border border-gray-300 rounded px-2 h-8 sm:h-9 text-xs sm:text-sm text-gray-600" %>
+      </div>
+
+      <div class="flex items-end justify-end justify-self-end gap-2 w-full order-6 md:col-start-4 xl:w-auto xl:ml-auto xl:mt-0 shrink-0 pt-1 xl:pt-0">
+        <%= link_to "クリア",
+                    notices_path,
+                    class: "w-auto px-3 h-8 sm:h-9 border border-gray-300 rounded text-gray-500 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap bg-white hover:bg-gray-50" %>
+
+        <%= f.submit "検索",
+                     class: "w-auto px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap cursor-pointer" %>
+      </div>
     </div>
-    <div class="flex items-end gap-2 ml-auto shrink-0">
-      <%= link_to "クリア", notices_path,
-            class: "px-3 py-2 border rounded text-gray-600 h-10 inline-flex items-center whitespace-nowrap" %>
-      <%= f.submit "検索",
-            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 h-10 whitespace-nowrap" %>
-    </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/notices/_timeline.html.erb
+++ b/app/views/notices/_timeline.html.erb
@@ -1,25 +1,36 @@
-<div class="mb-6 border-t-4 border-blue-500 pt-6">
-  <h2 class="text-lg font-semibold mb-3">この案件の流れ</h2>
-  <div class="space-y-2 text-sm">
+<div class="mb-6 border-t-4 border-gray-300 pt-6">
+  <h2 class="text-base sm:text-lg font-semibold mb-3">この案件の流れ</h2>
+
+  <div class="space-y-2 text-xs sm:text-sm">
     <% timeline.each do |item| %>
       <div class="pl-4 border-l-2 <%= item == current_item ? 'border-blue-500' : 'border-gray-300' %>">
         <% if item == current_item %>
-          <span class="font-medium">
-            <%= l item.created_at %>
-            <%= truncate(item.content, length: 30) %>
-            <span class="text-blue-600">★ 現在</span>
-          </span>
+          <div class="flex items-center gap-1 py-1 px-2 bg-gray-50 rounded">
+            <span class="flex-1 min-w-0 truncate"><%= item.content %></span>
+            <span class="w-16 shrink-0 whitespace-nowrap text-blue-600">★ 現在</span>
+            <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right">
+              <span class="sm:hidden"><%= item.created_at.strftime("%-m/%-d") %></span>
+              <span class="hidden sm:inline"><%= l item.created_at %></span>
+            </span>
+          </div>
         <% else %>
-          <%= link_to notice_path(item), class: "text-gray-700 hover:text-blue-600" do %>
-            <%= l item.created_at %> <%= truncate(item.content, length: 40) %>
+          <%= link_to notice_path(item),
+                      class: "flex items-center gap-1 py-1 px-2 rounded hover:bg-gray-50 text-gray-700 hover:text-blue-600" do %>
+            <span class="flex-1 min-w-0 truncate"><%= item.content %></span>
+            <span class="w-16 shrink-0"></span>
+            <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right">
+              <span class="sm:hidden"><%= item.created_at.strftime("%-m/%-d") %></span>
+              <span class="hidden sm:inline"><%= l item.created_at %></span>
+            </span>
           <% end %>
         <% end %>
       </div>
     <% end %>
   </div>
+
   <div class="mt-4">
-    <%= link_to "続きのお知らせを作成",
-          new_notice_path(parent_id: current_item.id),
-          class: "text-sm px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+    <%= link_to "関連お知らせを作成",
+                new_notice_path(parent_id: current_item.id),
+                class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
   </div>
 </div>

--- a/app/views/notices/edit.html.erb
+++ b/app/views/notices/edit.html.erb
@@ -1,14 +1,15 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-2xl mx-auto px-4">
-    <div class="mb-4">
-      <%= link_to "← 詳細に戻る", notice_path(@notice),
-            class: "text-blue-600 hover:underline text-sm" %>
+<div class="max-w-4xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <%= link_to "← 詳細に戻る",
+                notice_path(@notice),
+                class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-lg p-6">
+    <div class="border-b-4 border-blue-500 pb-4 mb-6">
+      <h1 class="text-xl font-bold">お知らせの編集</h1>
     </div>
-    <div class="bg-white rounded-lg shadow-lg p-6">
-      <div class="border-b-4 border-yellow-500 pb-4 mb-6">
-        <h1 class="text-2xl font-bold">お知らせを編集</h1>
-      </div>
-      <%= render "form", notice: @notice %>
-    </div>
+
+    <%= render "form", notice: @notice %>
   </div>
 </div>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,41 +1,19 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-7xl mx-auto px-4">
-    <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold">お知らせ一覧</h1>
-      <%= link_to "新規登録", new_notice_path,
-            class: "px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 text-sm" %>
-    </div>
-    <div class="bg-white rounded-lg shadow p-4 mb-4">
-      <%= render "search_form" %>
-    </div>
-    <div class="bg-white rounded-lg shadow">
-      <% if @notices.any? %>
-        <table class="w-full text-sm">
-          <thead class="bg-gray-50 border-b">
-            <tr>
-              <th class="text-left p-3 text-gray-600 w-1/2">タイトル</th>
-              <th class="text-left p-3 text-gray-600 w-1/4">重要度</th>
-              <th class="text-left p-3 text-gray-600 w-1/4">作成者</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y">
-            <% @notices.each do |notice| %>
-              <tr class="hover:bg-gray-50">
-                <td class="p-3">
-                  <%= link_to notice.title, notice_path(notice),
-                        class: "text-blue-600 hover:underline" %>
-                </td>
-                <td class="p-3"><%= notice_level_label(notice) %></td>
-                <td class="p-3"><%= notice.user.name %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      <% else %>
-        <div class="p-8 text-center text-gray-500 text-sm">
-          まだお知らせはありません。
-        </div>
-      <% end %>
-    </div>
+<div class="max-w-7xl mx-auto px-4 py-4">
+  <div class="flex justify-between items-center mb-4">
+    <h1 class="text-base sm:text-xl font-bold">お知らせ一覧</h1>
+
+    <%= link_to "新規登録",
+            new_notice_path,
+            class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center" %>
   </div>
+
+  <div data-controller="disclosure"
+       data-action="click->disclosure#toggle"
+       class="bg-white rounded-lg shadow overflow-hidden p-3 mb-4 cursor-pointer">
+    <%= render "search_form", q: @q %>
+  </div>
+
+  <%= turbo_frame_tag "notices_list" do %>
+    <%= render "list" %>
+  <% end %>
 </div>

--- a/app/views/notices/new.html.erb
+++ b/app/views/notices/new.html.erb
@@ -1,25 +1,23 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-2xl mx-auto px-4">
-    <div class="mb-4">
-      <% if @notice.parent %>
-        <%= link_to "← 元のお知らせに戻る", notice_path(@notice.parent),
-              class: "text-blue-600 hover:underline text-sm" %>
-      <% else %>
-        <%= link_to "← 一覧に戻る", notices_path,
-              class: "text-blue-600 hover:underline text-sm" %>
-      <% end %>
+<div class="max-w-4xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <% if @notice.parent %>
+      <%= link_to "← 元のお知らせに戻る",
+                  notice_path(@notice.parent),
+                  class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+    <% else %>
+      <%= link_to "← 一覧に戻る",
+                  notices_path,
+                  class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+    <% end %>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-lg p-6">
+    <div class="border-b-4 border-blue-500 pb-4 mb-6">
+      <h1 class="text-xl font-bold">
+        <%= @parent_notice ? " 関連お知らせの登録" : "お知らせの新規登録" %>
+      </h1>
     </div>
-    <div class="bg-white rounded-lg shadow-lg p-6">
-      <div class="border-b-4 border-yellow-500 pb-4 mb-6">
-        <h1 class="text-2xl font-bold">
-          <% if @parent_notice %>
-            続きのお知らせを登録
-          <% else %>
-            お知らせを新規登録
-          <% end %>
-        </h1>
-      </div>
-      <%= render "form", notice: @notice %>
-    </div>
+
+    <%= render "form", notice: @notice %>
   </div>
 </div>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -1,66 +1,82 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-4xl mx-auto px-4">
-    <div class="mb-4">
-      <%= link_to "← 一覧に戻る", notices_path, class: "text-blue-600 hover:underline text-sm" %>
-    </div>
-    <div class="bg-white rounded-lg shadow-lg p-6">
-      <div class="border-b-4 border-yellow-500 pb-4 mb-6">
-        <h1 class="text-2xl font-bold">お知らせ詳細</h1>
-      </div>
+<div class="max-w-4xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <%= link_to "← 一覧に戻る",
+                notices_path,
+                class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+  </div>
 
-      <div class="mb-6">
-        <h2 class="text-lg font-semibore mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
-        <div class="mb-3">
-          <h3 class="text-xl font-bold"><%= @notice.title %></h3>
-        </div>
-        <div class="grid grid-cols-2 gap-3 text-sm">
-          <div>
-            <span class="text-gray-600">作成者:</span>
-            <span class="ml-2"><%= @notice.user.name %></span>
+  <div class="bg-white rounded-lg shadow-lg p-6">
+    <div class="border-b-4 border-blue-500 pb-4 mb-6">
+      <h1 class="text-lg sm:text-xl font-bold">お知らせ詳細</h1>
+    </div>
+
+    <div class="mb-6">
+      <h2 class="text-base sm:text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
+
+      <div class="bg-gray-50 p-4 rounded text-xs sm:text-sm">
+        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-6 gap-y-3">
+          <div class="flex items-center md:col-span-2 xl:col-span-3">
+            <span class="w-20 shrink-0 text-gray-600">件名:</span>
+            <span><%= @notice.title %></span>
           </div>
-          <div>
-            <span class="text-gray-600">作成日時:</span>
-            <span class="ml-2"><%= l @notice.created_at %></span>
+
+          <div class="flex items-center">
+            <span class="w-20 shrink-0 text-gray-600">作成者:</span>
+            <span>
+              <%= link_to @notice.user.name,
+                          user_path(@notice.user),
+                          class: "text-blue-600 hover:text-blue-800" %>
+            </span>
           </div>
-          <div>
-            <span class="text-gray-600">重要度:</span>
-            <span class="ml-2 px-2 py-0.5 rounded text-xs bg-gray-200 text-gray-700">
+
+          <div class="flex items-center">
+            <span class="w-20 shrink-0 text-gray-600">作成日時:</span>
+            <span><%= l @notice.created_at %></span>
+          </div>
+
+          <div class="flex items-center">
+            <span class="w-20 shrink-0 text-gray-600">重要度:</span>
+            <span class="<%= notice_level_badge_class(@notice) %> px-2 py-1 inline-block leading-none">
               <%= notice_level_label(@notice) %>
             </span>
           </div>
-          <div>
-            <span class="text-gray-600">対象:</span>
-            <span class="ml-2"><%= @notice.restricted? ? "管理者のみ" : "全員" %></span>
+
+          <div class="flex items-center">
+            <span class="w-20 shrink-0 text-gray-600">対象:</span>
+            <span><%= @notice.restricted? ? "管理者のみ" : "全員" %></span>
           </div>
-          <div>
-            <span class="text-gray-600">開始日時:</span>
-            <span class="ml-2"><%= l @notice.start_at %></span>
+
+          <div class="flex items-center">
+            <span class="w-20 shrink-0 text-gray-600">開始日時:</span>
+            <span><%= l @notice.start_at %></span>
           </div>
-          <div>
-            <span class="text-gray-600">終了日時:</span>
-            <span class="ml-2"><%= l @notice.end_at %></span>
+
+          <div class="flex items-center">
+            <span class="w-20 shrink-0 text-gray-600">終了日時:</span>
+            <span><%= l @notice.end_at %></span>
           </div>
         </div>
       </div>
-
-      <div class="mb-6">
-        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">内容</h2>
-        <div class="bg-gray-50 p-4 rounded text-sm whitespace-pre-wrap"><%= @notice.content %></div>
-      </div>
-
-      <%= render "shared/images", record: @notice %>
-
-      <%= render "timeline", timeline: @timeline, current_item: @notice %>
-      <%= render "related_interactions", notice: @notice %>
-      <%= render "related_tasks", notice: @notice %>
-      <%= render "shared/comment_thread", commentable: @notice %>
-
-      <% if @notice.user == Current.user %>
-        <div class="mt-6 flex justify-end border-t pt-4">
-          <%= link_to "編集", edit_notice_path(@notice),
-              class: "px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 text-sm" %>
-        </div>
-      <% end %>
     </div>
+
+    <div class="mb-6">
+      <h2 class="text-base sm:text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">内容</h2>
+
+      <div class="bg-gray-50 p-4 rounded text-xs sm:text-sm whitespace-pre-wrap"><%= @notice.content %></div>
+    </div>
+
+    <%= render "shared/images", record: @notice %>
+    <%= render "timeline", timeline: @timeline, current_item: @notice %>
+    <%= render "related_interactions", notice: @notice %>
+    <%= render "related_tasks", notice: @notice %>
+    <%= render "shared/comment_thread", commentable: @notice %>
+
+    <% if @notice.user == Current.user %>
+      <div class="mt-6 flex justify-end border-t-4 border-gray-300 pt-6">
+        <%= link_to "編集",
+                    edit_notice_path(@notice),
+                    class: "px-3 xl:px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -32,6 +32,47 @@ RSpec.describe Notice, type: :model do
       expect(association.options[:class_name]).to eq("Notice")
       expect(association.options[:foreign_key]).to eq("parent_id")
     end
+
+    it 'belongs to root notice (optional)' do
+      association = described_class.reflect_on_association(:root)
+
+      expect(association.macro).to eq(:belongs_to)
+      expect(association.options[:class_name]).to eq("Notice")
+      expect(association.options[:optional]).to be(true)
+    end
+
+    it 'has many thread_notices' do
+      association = described_class.reflect_on_association(:thread_notices)
+
+      expect(association.macro).to eq(:has_many)
+      expect(association.options[:class_name]).to eq("Notice")
+      expect(association.options[:foreign_key]).to eq(:root_id)
+    end
+  end
+
+  describe '#related_notices' do
+    it 'returns other notices in the same thread ordered by created_at' do
+      parent = create(:notice)
+      earlier_related_notice = create(:notice, parent: parent)
+      later_related_notice = create(:notice, parent: parent)
+
+      expect(parent.related_notices).to eq([ earlier_related_notice, later_related_notice ])
+      expect(earlier_related_notice.related_notices).to eq([ parent, later_related_notice ])
+      expect(later_related_notice.related_notices).to eq([ parent, earlier_related_notice ])
+    end
+
+    it 'returns an empty array when there are no related notices' do
+      notice = create(:notice)
+
+      expect(notice.related_notices).to eq([])
+    end
+
+    it 'does not include itself' do
+      parent = create(:notice)
+      create(:notice, parent: parent)
+
+      expect(parent.related_notices).not_to include(parent)
+    end
   end
 
   describe "root assignment" do

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -72,6 +72,32 @@ RSpec.describe "Notices", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(notice.title, other_notice.title)
       end
+
+      it "uses full-page navigation for user links inside turbo frame" do
+        get notices_path
+
+        expect(response.body).to include('data-turbo-frame="_top"')
+        expect(response.body).to include(user_path(notice.user))
+      end
+
+      it "renders related notices under the parent notice row" do
+        related_notice = create(:notice, user: user, parent: notice, title: "関連お知らせの内容")
+
+        get notices_path
+
+        expect(response.body).to include("関連")
+        expect(response.body).to include(related_notice.title)
+      end
+
+      it "renders sibling notices as related, not just direct children" do
+        first_sibling_notice = create(:notice, user: user, parent: notice, title: "関連お知らせA")
+        second_sibling_notice = create(:notice, user: user, parent: notice, title: "関連お知らせB")
+
+        get notices_path
+
+        expect(response.body).to include(first_sibling_notice.title)
+        expect(response.body).to include(second_sibling_notice.title)
+      end
     end
 
     context "when the user is admin" do
@@ -251,7 +277,7 @@ RSpec.describe "Notices", type: :request do
       it "re-renders the new template with invalid params" do
         post notices_path, params: { notice: { title: nil } }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "ignores restricted parameter" do
@@ -401,7 +427,7 @@ RSpec.describe "Notices", type: :request do
         patch notice_path(notice), params: { notice: { title: nil } }
 
         expect(notice.reload.title).not_to be_nil
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "cannot update a restricted notice and redirects to the index template" do


### PR DESCRIPTION
## 概要
お知らせ機能のレスポンシブ対応と、スレッド内の関連お知らせ表示機能を追加した。
## 変更内容
- Notice モデルに `related_notices` メソッドを追加（同一スレッド内の自分以外のお知らせを作成日時順で取得）
- `children` アソシエーションに作成日時降順の order を追加
- NoticesController の index で `root: { thread_notices: [:user] }` を preload し、一覧にスレッド情報を含める
- NoticesController / InteractionsController / TasksController の `set_*` を分離し、show アクションでのみ comments 等を preload するように変更
- `unprocessable_entity` を `unprocessable_content` に置き換え
- お知らせ一覧をモバイル用（`_list_mobile`）とデスクトップ用（`_list_desktop`）の partial に分割し、`_list` / `_list_empty` / `_mobile_card` を追加
- 検索フォームを disclosure（開閉式）UI に変更し、Turbo Frame 対応
- 詳細・新規登録・編集・タイムライン・関連応対履歴・関連タスク画面のレイアウトとレスポンシブスタイルをタスク・応対履歴と統一
- NoticesHelper に `notice_level_badge_class` を追加
- レイアウトのフラッシュメッセージにレスポンシブなテキストサイズを追加
## 確認済み
- [x] `spec/models/notice_spec.rb` に related_notices のテストを追加
- [x] `spec/requests/notices_spec.rb` に一覧でのユーザーリンクの turbo frame 挙動、関連お知らせ表示のテストを追加
- [x] unprocessable_content へのステータスコード変更に伴うテスト修正
## 補足
Closes #143 