### PR TITLE
Improve Customer UI responsiveness

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -16,7 +16,7 @@ class CustomersController < ApplicationController
     if @customer.save
       redirect_to @customer, notice: "顧客を登録しました"
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -30,7 +30,7 @@ class CustomersController < ApplicationController
     if @customer.update(customer_params)
       redirect_to @customer, notice: "顧客情報を更新しました"
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -21,6 +21,7 @@ class CustomersController < ApplicationController
   end
 
   def show
+    @interactions = @customer.interactions.order(occurred_at: :desc)
   end
 
   def edit

--- a/app/views/customers/_form.html.erb
+++ b/app/views/customers/_form.html.erb
@@ -1,9 +1,8 @@
 <%= form_with model: customer, class: "space-y-4" do |f| %>
   <% if customer.errors.any? %>
     <div class="bg-red-50 border border-red-300 rounded p-4">
-      <p class="text-red-700 font-semibold text-sm mb-2">
-        <%= customer.errors.count %>件のエラーがあります
-      </p>
+      <p class="text-red-700 font-semibold text-sm mb-2">入力内容にエラーがあります。</p>
+
       <ul class="list-disc list-inside text-red-600 text-sm space-y-1">
         <% customer.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
@@ -11,28 +10,40 @@
       </ul>
     </div>
   <% end %>
-  <div>
-    <%= f.label :name, "顧客名", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_field :name,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+    <div>
+      <%= f.label :name, "顧客名", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= f.text_field :name,
+                       class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" %>
+    </div>
+
+    <div>
+      <%= f.label :phone, "電話番号", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= f.telephone_field :phone,
+                            class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" %>
+    </div>
+
+    <div>
+      <%= f.label :email, "メールアドレス", class: "block text-sm text-gray-700 mb-1" %>
+
+      <%= f.email_field :email,
+                        class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" %>
+    </div>
   </div>
+
   <div>
-    <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.email_field :email,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
+    <%= f.label :key_notes, "重要メモ", class: "block text-sm text-gray-700 mb-1" %>
+
+    <%= f.text_area :key_notes,
+                    rows: 4,
+                    class: "w-full border border-gray-300 rounded px-3 py-2 text-xs sm:text-sm" %>
   </div>
-  <div>
-    <%= f.label :phone, "電話番号", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.telephone_field :phone,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
-  </div>
-  <div>
-    <%= f.label :key_notes, "重要メモ", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_area :key_notes, rows: 4,
-          class: "w-full border border-gray-300 rounded px-3 py-2 text-sm" %>
-  </div>
+
   <div class="flex justify-end pt-2">
-    <%= f.submit customer.new_record? ? "登録する" : "更新する",
-          class: "px-6 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm cursor-pointer" %>
+    <%= f.submit customer.new_record? ? "登録" : "更新",
+                 class: "px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
   </div>
 <% end %>

--- a/app/views/customers/_list.html.erb
+++ b/app/views/customers/_list.html.erb
@@ -1,0 +1,6 @@
+<% if @customers.any? %>
+  <%= render "list_mobile", customers: @customers %>
+  <%= render "list_desktop", customers: @customers %>
+<% else %>
+  <%= render "list_empty" %>
+<% end %>

--- a/app/views/customers/_list_desktop.html.erb
+++ b/app/views/customers/_list_desktop.html.erb
@@ -1,0 +1,43 @@
+<div class="hidden md:block overflow-x-auto bg-white rounded-lg shadow">
+  <table class="w-full text-xs sm:text-sm border-collapse table-fixed">
+    <thead class="bg-gray-50 text-gray-600">
+      <tr>
+        <th class="w-40 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">顧客名</th>
+        <th class="w-56 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">メールアドレス</th>
+        <th class="w-40 px-4 py-3 text-center whitespace-nowrap align-middle leading-none">電話番号</th>
+        <th class="pl-8 md:pl-12 xl:pl-16 pr-4 py-3 text-left whitespace-nowrap align-middle leading-none">重要メモ</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% customers.each do |customer| %>
+        <tr class="h-12 hover:bg-gray-100 cursor-pointer"
+            data-controller="clickable"
+            data-clickable-url-value="<%= customer_path(customer) %>"
+            data-action="click->clickable#open">
+
+          <td class="w-40 px-4 py-3 text-center whitespace-nowrap truncate align-middle leading-none">
+            <%= link_to customer.name,
+                        customer_path(customer),
+                        class: "text-blue-600 hover:text-blue-800",
+                        onclick: "event.stopPropagation();" %>
+          </td>
+
+          <td class="w-56 px-4 py-3 text-center whitespace-nowrap truncate align-middle leading-none text-gray-600">
+            <%= customer.email %>
+          </td>
+
+          <td class="w-40 px-4 py-3 text-center whitespace-nowrap align-middle leading-none text-gray-600">
+            <%= customer.phone %>
+          </td>
+
+          <td class="pl-8 md:pl-12 xl:pl-16 pr-4 py-3 text-left align-middle leading-none text-gray-600">
+            <div class="w-0 min-w-full truncate">
+              <%= customer.key_notes %>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/customers/_list_empty.html.erb
+++ b/app/views/customers/_list_empty.html.erb
@@ -1,0 +1,3 @@
+<div class="bg-white rounded-lg shadow p-8 text-center text-gray-600 text-sm">
+  まだ顧客は登録されていません。
+</div>

--- a/app/views/customers/_list_mobile.html.erb
+++ b/app/views/customers/_list_mobile.html.erb
@@ -1,0 +1,13 @@
+<div class="block md:hidden mb-4">
+  <div class="sticky top-20 z-10 flex items-center bg-gray-50 border border-gray-200 rounded shadow-sm px-3 py-2 mb-2 text-xs font-bold text-gray-600">
+    <div class="flex-1 min-w-0 text-left px-1 whitespace-nowrap truncate overflow-hidden">顧客名</div>
+    <div class="flex-1 min-w-0 text-center px-1 whitespace-nowrap truncate overflow-hidden">電話番号</div>
+    <div class="flex-1 min-w-0 text-center px-1 whitespace-nowrap truncate overflow-hidden">メールアドレス</div>
+  </div>
+
+  <div class="space-y-2">
+    <% customers.each do |customer| %>
+      <%= render "mobile_card", customer: customer %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/customers/_mobile_card.html.erb
+++ b/app/views/customers/_mobile_card.html.erb
@@ -1,0 +1,30 @@
+<div class="bg-white rounded shadow-sm px-3 py-2 w-full hover:bg-gray-50 cursor-pointer"
+     data-controller="clickable"
+     data-clickable-url-value="<%= customer_path(customer) %>"
+     data-action="click->clickable#open">
+
+  <div class="text-xs w-full leading-none">
+    <div class="flex items-center w-full h-5">
+      <div class="flex-1 min-w-0 text-left px-1 overflow-hidden">
+        <%= link_to customer.name,
+                    customer_path(customer),
+                    class: "block truncate text-blue-600 hover:text-blue-800",
+                    onclick: "event.stopPropagation();" %>
+      </div>
+
+      <div class="flex-1 min-w-0 text-center px-1 overflow-hidden text-gray-600 truncate tabular-nums">
+        <%= customer.phone %>
+      </div>
+
+      <div class="flex-1 min-w-0 text-center px-1 overflow-hidden text-gray-600 truncate">
+        <%= customer.email %>
+      </div>
+    </div>
+
+    <% if customer.key_notes.present? %>
+      <div class="pt-2 text-left mx-1 overflow-hidden text-gray-500 truncate">
+        <%= customer.key_notes %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/customers/_related_interactions.html.erb
+++ b/app/views/customers/_related_interactions.html.erb
@@ -1,0 +1,30 @@
+<div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
+  <h2 class="text-base sm:text-lg font-semibold mb-3">応対履歴</h2>
+
+  <% if interactions.any? %>
+    <ul class="space-y-2">
+      <% interactions.each do |interaction| %>
+        <li class="flex items-center gap-3 p-2 bg-gray-50 rounded group">
+          <%= link_to interaction.request_content,
+                      interaction_path(interaction),
+                      class: "flex-1 min-w-0 truncate text-gray-700 group-hover:text-blue-600" %>
+
+          <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right text-gray-500 group-hover:text-blue-600">
+            <span class="sm:hidden"><%= interaction.occurred_at.strftime("%-m/%-d") %></span>
+            <span class="hidden sm:inline"><%= l interaction.occurred_at %></span>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <div class="text-gray-500">
+      まだ応対履歴は登録されていません。
+    </div>
+  <% end %>
+
+  <div class="mt-4">
+    <%= link_to "応対履歴を作成",
+                new_interaction_path,
+                class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
+  </div>
+</div>

--- a/app/views/customers/_search_form.html.erb
+++ b/app/views/customers/_search_form.html.erb
@@ -1,29 +1,49 @@
-<h2 class="text-sm font-semibold mb-3">検索</h2>
-<%= search_form_for @q, url: customers_path, method: :get, html: { class: "text-sm w-full" } do |f| %>
-  <div class="flex flex-nowrap items-end gap-3 w-full overflow-x-auto">
-    <div class="w-64 shrink-0">
-      <%= f.label :name_cont, "名前", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.search_field :name_cont,
-            class: "w-full border rounded px-3 py-2 h-10",
-            placeholder: "例）鈴木" %>
+<div class="flex items-center justify-between w-full">
+  <h2 class="text-sm font-semibold">検索</h2>
+
+  <svg data-disclosure-target="icon"
+       class="w-4 h-4 text-gray-500 transition-transform duration-200"
+       fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+  </svg>
+</div>
+
+<div data-disclosure-target="panel"
+     data-action="click->disclosure#stop"
+     class="hidden mt-3">
+  <%= search_form_for q, url: customers_path, method: :get,
+                      html: { class: "text-sm w-full", data: { turbo_frame: "customers_list" } } do |f| %>
+    <div class="grid grid-cols-2 md:grid-cols-4 xl:flex xl:flex-nowrap xl:items-end gap-2 xl:gap-3 w-full">
+
+      <div class="w-full xl:w-44 shrink-0 order-1">
+        <%= f.label :name_cont, "名前", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.search_field :name_cont,
+                           class: "w-full border border-gray-300 rounded px-3 h-8 sm:h-9 text-xs sm:text-sm text-gray-600",
+                           placeholder: "例）鈴木" %>
+      </div>
+
+      <div class="w-full xl:w-44 shrink-0 order-2">
+        <%= f.label :phone_cont, "電話番号", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.search_field :phone_cont,
+                           class: "w-full border border-gray-300 rounded px-3 h-8 sm:h-9 text-xs sm:text-sm text-gray-600",
+                           placeholder: "部分一致可" %>
+      </div>
+
+      <div class="w-full xl:w-56 shrink-0 order-3">
+        <%= f.label :email_cont, "メールアドレス", class: "block text-xs text-gray-500 mb-1" %>
+        <%= f.search_field :email_cont,
+                           class: "w-full border border-gray-300 rounded px-3 h-8 sm:h-9 text-xs sm:text-sm text-gray-600",
+                           placeholder: "部分一致可" %>
+      </div>
+
+      <div class="flex items-end justify-end justify-self-end gap-2 w-full order-4 md:col-start-4 xl:w-auto xl:ml-auto xl:mt-0 shrink-0 pt-1 xl:pt-0">
+        <%= link_to "クリア",
+                    customers_path,
+                    class: "w-auto px-3 h-8 sm:h-9 border border-gray-300 rounded text-gray-500 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap bg-white hover:bg-gray-50" %>
+
+        <%= f.submit "検索",
+                     class: "w-auto px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap cursor-pointer" %>
+      </div>
     </div>
-    <div class="w-64 shrink-0">
-      <%= f.label :phone_cont, "電話番号", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.search_field :phone_cont,
-            class: "w-full border rounded px-3 py-2 h-10",
-            placeholder: "部分一致可" %>
-    </div>
-    <div class="w-80 shrink-0">
-      <%= f.label :email_cont, "メールアドレス", class: "block text-xs text-gray-600 mb-1" %>
-      <%= f.search_field :email_cont,
-            class: "w-full border rounded px-3 py-2 h-10",
-            placeholder: "部分一致可" %>
-    </div>
-    <div class="flex items-end gap-2 ml-auto shrink-0">
-      <%= link_to "クリア", customers_path,
-class: "px-3 py-2 border rounded text-gray-600 h-10 inline-flex items-center whitespace-nowrap" %>
-      <%= f.submit "検索",
-            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 h-10 whitespace-nowrap" %>
-    </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/customers/edit.html.erb
+++ b/app/views/customers/edit.html.erb
@@ -1,14 +1,15 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-2xl mx-auto px-4">
-    <div class="mb-4">
-      <%= link_to "← 詳細に戻る", customer_path(@customer),
-            class: "text-blue-600 hover:underline text-sm" %>
+<div class="max-w-4xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <%= link_to "← 詳細に戻る",
+                customer_path(@customer),
+                class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-lg p-6">
+    <div class="border-b-4 border-blue-500 pb-4 mb-6">
+      <h1 class="text-xl font-bold">顧客情報の編集</h1>
     </div>
-    <div class="bg-white rounded-lg shadow-lg p-6">
-      <div class="border-b-4 border-blue-500 pb-4 mb-6">
-        <h1 class="text-2xl font-bold">顧客情報を編集</h1>
-      </div>
-      <%= render "form", customer: @customer %>
-    </div>
+
+    <%= render "form", customer: @customer %>
   </div>
 </div>

--- a/app/views/customers/index.html.erb
+++ b/app/views/customers/index.html.erb
@@ -1,45 +1,19 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-7xl mx-auto px-4">
-    <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold">顧客一覧</h1>
-      <%= link_to "新規登録", new_customer_path,
-            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm" %>
-    </div>
-    <div class="bg-white rounded-lg shadow p-4 mb-4">
-      <%= render "search_form" %>
-    </div>
-    <div class="bg-white rounded-lg shadow">
-      <% if @customers.any? %>
-        <table class="w-full text-sm">
-          <thead class="bg-gray-50 border-b">
-            <tr>
-              <th class="text-center p-3 text-gray-600">顧客名</th>
-              <th class="text-center p-3 text-gray-600">メールアドレス</th>
-              <th class="text-center p-3 text-gray-600">電話番号</th>
-              <th class="text-center p-3 text-gray-600">重要メモ</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y">
-            <% @customers.each do |customer| %>
-              <tr class="hover:bg-gray-50">
-                <td class="p-3 text-center">
-                  <%= link_to customer.name, customer_path(customer),
-                        class: "text-blue-600 hover:underline" %>
-                </td>
-                <td class="p-3 text-center"><%= customer.email %></td>
-                <td class="p-3 text-center"><%= customer.phone %></td>
-                <td class="p-3 text-center text-gray-500">
-                  <%= truncate(customer.key_notes, length: 60) %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      <% else %>
-        <div class="p-8 text-center text-gray-500 text-sm">
-          まだ顧客は登録されていません。
-        </div>
-      <% end %>
-    </div>
+<div class="max-w-7xl mx-auto px-4 py-4">
+  <div class="flex justify-between items-center mb-4">
+    <h1 class="text-base sm:text-xl font-bold">顧客一覧</h1>
+
+    <%= link_to "新規登録",
+            new_customer_path,
+            class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center" %>
   </div>
+
+  <div data-controller="disclosure"
+       data-action="click->disclosure#toggle"
+       class="bg-white rounded-lg shadow overflow-hidden p-3 mb-4 cursor-pointer">
+    <%= render "search_form", q: @q %>
+  </div>
+
+  <%= turbo_frame_tag "customers_list" do %>
+    <%= render "list" %>
+  <% end %>
 </div>

--- a/app/views/customers/new.html.erb
+++ b/app/views/customers/new.html.erb
@@ -1,14 +1,15 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-2xl mx-auto px-4">
-    <div class="mb-4">
-      <%= link_to "← 一覧に戻る", customers_path,
-            class: "text-blue-600 hover:underline text-sm" %>
+<div class="max-w-4xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <%= link_to "← 一覧に戻る",
+                customers_path,
+                class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-lg p-6">
+    <div class="border-b-4 border-blue-500 pb-4 mb-6">
+      <h1 class="text-xl font-bold">顧客の新規登録</h1>
     </div>
-    <div class="bg-white rounded-lg shadow-lg p-6">
-      <div class="border-b-4 border-blue-500 pb-4 mb-6">
-        <h1 class="text-2xl font-bold">顧客を新規登録</h1>
-      </div>
-      <%= render "form", customer: @customer %>
-    </div>
+
+    <%= render "form", customer: @customer %>
   </div>
 </div>

--- a/app/views/customers/show.html.erb
+++ b/app/views/customers/show.html.erb
@@ -1,42 +1,54 @@
-<div class="min-h-screen bg-gray-50 py-8">
-  <div class="max-w-4xl mx-auto px-4">
-    <div class="mb-4">
-      <%= link_to "← 一覧に戻る", customers_path,
-            class: "text-blue-600 hover:underline text-sm" %>
+<div class="max-w-4xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <%= link_to "← 一覧に戻る",
+                customers_path,
+                class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-lg p-6">
+    <div class="border-b-4 border-blue-500 pb-4 mb-6">
+      <h1 class="text-lg sm:text-xl font-bold">顧客詳細</h1>
     </div>
-    <div class="bg-white rounded-lg shadow-lg p-6">
-      <div class="border-b-4 border-blue-500 pb-4 mb-6">
-        <h1 class="text-2xl font-bold">顧客詳細</h1>
+
+    <div class="mb-6">
+      <h2 class="text-base sm:text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
+
+      <div class="bg-gray-50 p-4 rounded text-xs sm:text-sm space-y-3">
+        <div class="flex items-center">
+          <span class="w-32 shrink-0 text-gray-600">顧客名:</span>
+          <span>
+            <%= link_to @customer.name,
+                        customer_path(@customer),
+                        class: "text-blue-600 hover:text-blue-800" %>
+          </span>
+        </div>
+
+        <div class="flex items-center">
+          <span class="w-32 shrink-0 text-gray-600">電話番号:</span>
+          <span><%= @customer.phone.presence || "ー" %></span>
+        </div>
+
+        <div class="flex items-center min-w-0">
+          <span class="w-32 shrink-0 text-gray-600">メールアドレス:</span>
+          <span class="truncate"><%= @customer.email.presence || "ー" %></span>
+        </div>
       </div>
+    </div>
+
+    <% if @customer.key_notes.present? %>
       <div class="mb-6">
-        <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">基本情報</h2>
-        <div class="bg-gray-50 p-4 rounded text-sm space-y-2">
-          <div>
-            <span class="text-gray-600">顧客名:</span>
-            <span class="ml-2"><%= @customer.name %></span>
-          </div>
-          <div>
-            <span class="text-gray-600">メールアドレス:</span>
-            <span class="ml-2"><%= @customer.email %></span>
-          </div>
-          <div>
-            <span class="text-gray-600">電話番号:</span>
-            <span class="ml-2"><%= @customer.phone %></span>
-          </div>
-        </div>
+        <h2 class="text-base sm:text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">重要メモ</h2>
+
+        <div class="bg-gray-50 p-4 rounded text-xs sm:text-sm whitespace-pre-wrap"><%= @customer.key_notes %></div>
       </div>
-      <% if @customer.key_notes.present? %>
-        <div class="mb-6">
-          <h2 class="text-lg font-semibold mb-3 border-b-2 border-gray-300 pb-2">重要メモ</h2>
-          <div class="bg-gray-50 p-4 rounded text-sm whitespace-pre-wrap">
-            <%= @customer.key_notes %>
-          </div>
-        </div>
-      <% end %>
-      <div class="mt-6 flex justify-end border-t pt-4">
-        <%= link_to "編集", edit_customer_path(@customer),
-              class: "px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 text-sm" %>
-      </div>
+    <% end %>
+
+    <%= render "related_interactions", interactions: @interactions %>
+
+    <div class="mt-6 flex justify-end border-t-4 border-gray-300 pt-6">
+      <%= link_to "編集",
+                  edit_customer_path(@customer),
+                  class: "px-3 xl:px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
     </div>
   </div>
 </div>

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -13,12 +13,15 @@ RSpec.describe "Customers", type: :request do
 
       it "responds with HTTP 200 OK" do
         get customers_path
+
         expect(response).to have_http_status(:ok)
       end
 
       it "displays the customers list" do
         customer = create(:customer)
+
         get customers_path
+
         expect(response.body).to include(customer.name)
         expect(response.body).to include(customer.email)
         expect(response.body).to include(customer.phone)
@@ -29,6 +32,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get customers_path
+
         expect(response).to redirect_to(login_path)
       end
     end
@@ -40,6 +44,7 @@ RSpec.describe "Customers", type: :request do
 
       it "responds with HTTP 200 OK" do
         get new_customer_path
+
         expect(response).to have_http_status(:ok)
       end
     end
@@ -47,6 +52,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get new_customer_path
+
         expect(response).to redirect_to(login_path)
       end
     end
@@ -75,6 +81,7 @@ RSpec.describe "Customers", type: :request do
 
       it "redirects to the show page with valid params" do
         post customers_path, params: valid_params
+
         expect(response).to redirect_to(customer_path(Customer.last))
       end
 
@@ -86,6 +93,7 @@ RSpec.describe "Customers", type: :request do
 
       it "re-renders the new template with invalid params" do
         post customers_path, params: { customer: { name: nil } }
+
         expect(response).to have_http_status(:unprocessable_content)
       end
     end
@@ -93,6 +101,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         post customers_path, params: {}
+
         expect(response).to redirect_to(login_path)
       end
     end
@@ -106,21 +115,39 @@ RSpec.describe "Customers", type: :request do
 
       it "responds with HTTP 200 OK" do
         get customer_path(customer)
+
         expect(response).to have_http_status(:ok)
       end
 
       it "displays the customer information" do
         get customer_path(customer)
+
         expect(response.body).to include(customer.name)
         expect(response.body).to include(customer.email)
         expect(response.body).to include(customer.phone)
         expect(response.body).to include(customer.key_notes)
+      end
+
+      it "displays related interactions for the customer" do
+        interaction = create(:interaction, customer: customer, request_content: "関連する応対内容")
+
+        get customer_path(customer)
+
+        expect(response.body).to include("応対履歴")
+        expect(response.body).to include(interaction.request_content)
+      end
+
+      it "displays a message when there are no related interactions" do
+        get customer_path(customer)
+
+        expect(response.body).to include("まだ応対履歴は登録されていません。")
       end
     end
 
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get customer_path(customer)
+
         expect(response).to redirect_to(login_path)
       end
     end
@@ -134,6 +161,7 @@ RSpec.describe "Customers", type: :request do
 
       it "returns 200" do
         get edit_customer_path(customer)
+
         expect(response).to have_http_status(:ok)
       end
     end
@@ -141,6 +169,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         get edit_customer_path(customer)
+
         expect(response).to redirect_to(login_path)
       end
     end
@@ -155,18 +184,21 @@ RSpec.describe "Customers", type: :request do
       it "updates the customer with valid parameters" do
         patch customer_path(customer),
           params: { customer: { name: "更新後の顧客名" } }
+
         expect(customer.reload.name).to eq("更新後の顧客名")
       end
 
       it "redirects to the show page with valid parameters" do
         patch customer_path(customer),
           params: { customer: { name: "更新後の顧客名" } }
+
         expect(response).to redirect_to(customer_path(customer))
       end
 
       it "re-renders the edit template with invalid parameters" do
         patch customer_path(customer),
           params: { customer: { name: nil } }
+
         expect(response).to have_http_status(:unprocessable_content)
       end
     end
@@ -174,6 +206,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is not logged in" do
       it "redirects to the login page" do
         patch customer_path(customer), params: {}
+
         expect(response).to redirect_to(login_path)
       end
     end

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Customers", type: :request do
 
       it "re-renders the new template with invalid params" do
         post customers_path, params: { customer: { name: nil } }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -167,7 +167,7 @@ RSpec.describe "Customers", type: :request do
       it "re-renders the edit template with invalid parameters" do
         patch customer_path(customer),
           params: { customer: { name: nil } }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 


### PR DESCRIPTION
## 概要
顧客機能のレスポンシブ対応を追加した。
## 変更内容
- 顧客一覧をモバイル用（`_list_mobile`）とデスクトップ用（`_list_desktop`）の partial に分割し、`_list` / `_list_empty` / `_mobile_card` を追加
- 検索フォームを disclosure（開閉式）UI に変更し、Turbo Frame 対応
- 詳細・新規登録・編集画面のレイアウトとレスポンシブスタイルを統一
## 確認済み
- [x] 顧客一覧・詳細・新規登録・編集ページの表示（モバイル/デスクトップ）
- [x] 検索フォームの折りたたみ動作
## 補足
Closes #146 