### PR TITLE
Fix Comment Authorization on restricted records

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -26,6 +26,8 @@ class CommentsController < ApplicationController
     raise ActiveRecord::RecordNotFound unless klass
 
     @commentable = klass.find(params[:commentable_id])
+
+    raise ActiveRecord::RecordNotFound if @commentable.respond_to?(:restricted?) && @commentable.restricted? && !Current.user.admin?
   end
 
   def comment_params

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Comments", type: :request do
   let(:user) { create(:user) }
-  let(:other_user) { create(:other_user) }
+  let(:other_user) { create(:user) }
 
   def sign_in(user)
     post login_path, params: { email_address: user.email_address, password: "password55" }
@@ -36,9 +36,42 @@ RSpec.describe "Comments", type: :request do
     end
   end
 
+  shared_examples "restricts posting comments" do |commentable_factory|
+    let(:commentable) { create(commentable_factory, user: other_user, restricted: true) }
+
+    it "does not allow a non-admin user to comment on a restricted record" do
+      expect {
+        post comments_path, params: {
+          commentable_type: commentable.class.name,
+          commentable_id: commentable.id,
+          comment: { content: "テストコメント" }
+        }
+      }.not_to change(Comment, :count)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "allows an admin user to comment on a restricted record" do
+      sign_in(create(:user, admin: true))
+
+      expect {
+        post comments_path, params: {
+          commentable_type: commentable.class.name,
+          commentable_id: commentable.id,
+          comment: { content: "テストコメント" }
+        }
+      }.to change(Comment, :count).by(1)
+
+      expect(response).to redirect_to commentable
+    end
+  end
+
   describe "POST /comments" do
     it_behaves_like "allows posting comments", "interaction"
     it_behaves_like "allows posting comments", "task"
     it_behaves_like "allows posting comments", "notice"
+
+    it_behaves_like "restricts posting comments", "task"
+    it_behaves_like "restricts posting comments", "notice"
   end
 end


### PR DESCRIPTION
## 概要
管理者のみ閲覧可能なタスク・お知らせに対して、管理者権限のない一般利用者がコメントを投稿できてしまう不具合を修正。

---

## 変更内容
- comments_controller.rb の set_commentable に、管理者のみ閲覧可能なタスク・お知らせであり、かつ現在の利用者が管理者でない場合に ActiveRecord::RecordNotFound を発生させるチェックを追加
- spec/requests/comments_spec.rb に「一般利用者は管理者のみ閲覧可能なタスク・お知らせへ投稿できない」「管理者は投稿できる」テストを追加

---

## 確認済み
- [x] bundle exec rspec spec/requests/comments_spec.rb が green（10 examples, 0 failures）
- [x] bundle exec rubocop app/controllers/comments_controller.rb spec/requests/comments_spec.rb で offense なし

---

## 補足
Closes #150 
