### PR TITLE
Enable Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,28 +2,30 @@
 
 # Define an application-wide content security policy.
 # See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
+# https://guides.rubyonrails.org/security.html#content-security-policy
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
-#   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
-#   # config.content_security_policy_nonce_auto = true
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src    :self, :data
+    policy.img_src     :self, :data
+    policy.object_src  :none
+    policy.script_src  :self
+    policy.style_src   :self
+    policy.connect_src :self
+    policy.base_uri    :none
+    policy.form_action :self
+  end
+
+  # importmap-rails renders the importmap and entry-point <script> tags inline,
+  # so they need a per-request nonce to be allowed under script-src :self.
+  # Note: session.id can be blank before anything is written to the session
+  # (e.g. on the first request, or in some test/headless-browser setups),
+  # which would render an empty 'nonce-' and break every inline script -
+  # so a random nonce is generated per request instead.
+  config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = %w(script-src)
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
## 概要
`config/initializers/content_security_policy.rb` が全てコメントアウトされ、CSPが実質未設定だった状態を解消し、実設定を追加した。

---

## 変更内容
- `default_src :self` を設定
- `font_src :self, :data` / `img_src :self, :data` を設定
- `object_src :none` を設定
- `script_src :self` / `style_src :self` を設定
- `connect_src :self` / `base_uri :none` / `form_action :self` を追加
- importmap-rails が出力するインラインの `<script type="importmap">` / `<script type="module">` を許可するため、`content_security_policy_nonce_generator` に `SecureRandom.base64(16)` を設定し、`content_security_policy_nonce_directives` に `script-src` を指定

---

## 確認済み
- [x] bin/brakeman で Security Warnings 0 件
- [x] bundle exec rspec で 529 examples, 0 failures
- [x] 開発環境でログイン、一覧、詳細、フォーム（新規登録・バリデーションエラー）、画像アップロード表示を操作し、ブラウザコンソールにCSP違反が出ないことを確認

---

Closes #152 