### PR TITLE
Implement status updates for task assignments

### DIFF
--- a/app/controllers/task_assignments_controller.rb
+++ b/app/controllers/task_assignments_controller.rb
@@ -1,0 +1,28 @@
+class TaskAssignmentsController < ApplicationController
+  before_action :set_task_assignment
+  before_action :authorize_owner!
+
+  def update
+    if @task_assignment.update(task_assignment_params)
+      redirect_to @task_assignment.task, notice: "進捗状況を更新しました"
+    else
+      redirect_to @task_assignment.task, alert: "進捗状況の更新に失敗しました"
+    end
+  end
+
+  private
+
+  def set_task_assignment
+    @task_assignment = TaskAssignment.find(params[:id])
+  end
+
+  def authorize_owner!
+    return if @task_assignment.user == Current.user
+
+    redirect_to @task_assignment.task, alert: "更新権限がありません"
+  end
+
+  def task_assignment_params
+    params.require(:task_assignment).permit(:status)
+  end
+end

--- a/app/javascript/controllers/auto_submit_controller.js
+++ b/app/javascript/controllers/auto_submit_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  submit() {
+    this.element.requestSubmit()
+  }
+}

--- a/app/views/tasks/_assignment_table.html.erb
+++ b/app/views/tasks/_assignment_table.html.erb
@@ -19,9 +19,18 @@
         </div>
 
         <div class="flex items-center justify-center px-4 break-words">
-          <span class="<%= task_status_badge_class(assignment) %> px-2 py-1">
-            <%= task_status_label(assignment) %>
-          </span>
+          <% if !compact && assignment.user == Current.user %>
+            <%= form_with model: assignment, url: task_assignment_path(assignment), method: :patch, class: "inline-block", data: { controller: "auto-submit" } do |f| %>
+              <%= f.select :status,
+                    TaskAssignment.statuses.keys.map { |status| [ I18n.t("enums.task_assignment.status.#{status}"), status ] },
+                    { selected: assignment.status },
+                    class: "#{task_status_badge_class(assignment)} px-2 py-1", data: { action: "change->auto-submit#submit" } %>
+            <% end %>
+          <% else %>
+            <span class="<%= task_status_badge_class(assignment) %> px-2 py-1">
+              <%= task_status_label(assignment) %>
+            </span>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resources :tasks, except: :destroy
   resources :notices, except: :destroy
   resources :comments, only: [ :create ]
+  resources :task_assignments, only: [ :update ]
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/spec/requests/task_assignments_spec.rb
+++ b/spec/requests/task_assignments_spec.rb
@@ -86,4 +86,47 @@ RSpec.describe "Task Assignments", type: :request do
       end
     end
   end
+
+  describe "PATCH /task_assignments/:id" do
+    let(:assignment) do
+      create(:task_assignment, task: create(:task, user: task_creator), user: first_assignee, status: :todo)
+    end
+
+    context "when the current user is the assignee" do
+      before { sign_in(first_assignee) }
+
+      it "updates the status" do
+        patch task_assignment_path(assignment), params: { task_assignment: { status: "done" } }
+
+        expect(assignment.reload.status).to eq("done")
+        expect(response).to redirect_to(task_path(assignment.task))
+      end
+    end
+
+    context "when the current user is not the assignee" do
+      before { sign_in(second_assignee) }
+
+      it "does not update the status" do
+        patch task_assignment_path(assignment), params: { task_assignment: { status: "done" } }
+
+        expect(assignment.reload.status).to eq("todo")
+      end
+
+      it "redirects to the task page with an alert" do
+        patch task_assignment_path(assignment), params: { task_assignment: { status: "done" } }
+
+        expect(response).to redirect_to(task_path(assignment.task))
+      end
+    end
+
+    context "when not signed in" do
+      before { delete logout_path }
+
+      it "redirects to the login page" do
+        patch task_assignment_path(assignment), params: { task_assignment: { status: "done" } }
+
+        expect(response).to redirect_to(login_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

task_assignmentsのstatusをタスク担当者本人が更新できるようにする。

---

## 変更内容

- config/routes.rbにresources :task_assignments, only: [:update]を追加
- TaskAssignmentsControllerを新規作成し、authorize_owner!で担当者本人以外の更新を拒否
- app/views/tasks/_assignment_table.html.erbに、自分の担当分のみステータス変更用のselectを表示し、Stimulusのauto_submit_controller.js経由でchange時に自動送信するよう実装
- spec/requests/task_assignments_spec.rbに、担当者本人による更新・担当者以外の拒否・未ログイン時のリダイレクトのテストを追加

---

## 確認済み
- [x] bundle exec rspec が green
- [x] bundle exec rubocop がエラー無

---

Closes #154 