### PR TITLE
Implement pagination for list views with Pagy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,4 @@ end
 
 gem "tailwindcss-rails", "~> 4.6"
 gem "ransack"
+gem "pagy", "~> 8.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,7 @@ GEM
     observer (0.1.2)
     open3 (0.2.1)
     ostruct (0.6.3)
+    pagy (8.6.3)
     parallel (2.1.0)
     parlour (9.1.2)
       commander (~> 5.0)
@@ -511,6 +512,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  pagy (~> 8.6)
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Authentication
+  include Pagy::Backend
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -3,7 +3,7 @@ class CustomersController < ApplicationController
 
   def index
     @q = Customer.ransack(params[:q], auth_object: :customer_list)
-    @customers = @q.result.order(:name)
+    @pagy, @customers = pagy(@q.result.order(:name))
   end
 
   def new

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -5,15 +5,17 @@ class InteractionsController < ApplicationController
 
   def index
     @q = Interaction.ransack(params[:q])
-    @interactions = @q.result
-                    .preload(
-                      :customer,
-                      :user,
-                      root: {
-                        thread_interactions: [ :customer, :user ]
-                      }
-                    )
-                    .order(occurred_at: :desc)
+    @pagy, @interactions = pagy(
+      @q.result
+        .preload(
+          :customer,
+          :user,
+          root: {
+            thread_interactions: [ :customer, :user ]
+          }
+        )
+        .order(occurred_at: :desc)
+    )
   end
 
   def new

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -7,14 +7,16 @@ class NoticesController < ApplicationController
 
   def index
     @q = visible_notices.ransack(params[:q], auth_object: :admin)
-    @notices = @q.result
-               .preload(
-                 :user,
-                 root: {
-                   thread_notices: [ :user ]
-                 }
-               )
-               .order(start_at: :desc)
+    @pagy, @notices = pagy(
+      @q.result
+        .preload(
+          :user,
+          root: {
+            thread_notices: [ :user ]
+          }
+        )
+        .order(start_at: :desc)
+    )
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,15 +6,17 @@ class TasksController < ApplicationController
 
   def index
     @q = visible_tasks.ransack(params[:q], auth_object: :admin)
-    @tasks = @q.result
-               .preload(
-                 :user,
-                 task_assignments: [ :user ],
-                 root: {
-                   thread_tasks: [ :user, task_assignments: [ :user ] ]
-                 }
-               )
-               .order(due_at: :asc)
+    @pagy, @tasks = pagy(
+      @q.result
+        .preload(
+          :user,
+          task_assignments: [ :user ],
+          root: {
+            thread_tasks: [ :user, task_assignments: [ :user ] ]
+          }
+        )
+        .order(due_at: :asc)
+    )
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
 
   def index
     @q = User.ransack(params[:q], auth_object: :user_list)
-    @users = @q.result.order(:name)
+    @pagy, @users = pagy(@q.result.order(:name))
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include Pagy::Frontend
+
   def navigation_tabs
     [
       { path: interactions_path, label: "応対履歴", name: "interactions" },
@@ -20,5 +22,34 @@ module ApplicationHelper
             data:  { tab_name: tab[:name] } do
       tab[:label]
     end
+  end
+
+  def pagy_tailwind_nav(pagy)
+    return "".html_safe if pagy.pages <= 1
+
+    link_classes    = "min-w-8 h-8 px-2 inline-flex items-center justify-center rounded text-xs sm:text-sm border border-gray-300 text-gray-600 hover:bg-gray-50"
+    active_classes  = "min-w-8 h-8 px-2 inline-flex items-center justify-center rounded text-xs sm:text-sm bg-blue-500 text-white"
+    disabled_classes = "min-w-8 h-8 px-2 inline-flex items-center justify-center rounded text-xs sm:text-sm border border-gray-200 text-gray-300"
+
+    items = []
+
+    items << (pagy.prev ? link_to("前へ", pagy_url_for(pagy, pagy.prev), class: link_classes)
+                         : content_tag(:span, "前へ", class: disabled_classes))
+
+    pagy.series.each do |item|
+      items << case item
+      when Integer
+        link_to(item, pagy_url_for(pagy, item), class: link_classes)
+      when String
+        content_tag(:span, item, class: active_classes, aria: { current: "page" })
+      when :gap
+        content_tag(:span, "…", class: "min-w-8 h-8 px-1 inline-flex items-center justify-center text-xs sm:text-sm text-gray-400")
+      end
+    end
+
+    items << (pagy.next ? link_to("次へ", pagy_url_for(pagy, pagy.next), class: link_classes)
+                         : content_tag(:span, "次へ", class: disabled_classes))
+
+    content_tag(:nav, safe_join(items), class: "flex items-center justify-center gap-1 mt-4", aria: { label: "pagination" })
   end
 end

--- a/app/views/customers/_list_desktop.html.erb
+++ b/app/views/customers/_list_desktop.html.erb
@@ -40,4 +40,8 @@
       <% end %>
     </tbody>
   </table>
+
+  <div class="border-t border-gray-200 py-3">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/customers/_list_mobile.html.erb
+++ b/app/views/customers/_list_mobile.html.erb
@@ -10,4 +10,8 @@
       <%= render "mobile_card", customer: customer %>
     <% end %>
   </div>
+
+  <div class="bg-white rounded-lg shadow py-3 mt-2">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/interactions/_list_desktop.html.erb
+++ b/app/views/interactions/_list_desktop.html.erb
@@ -131,4 +131,8 @@
       <% end %>
     </tbody>
   </table>
+
+  <div class="border-t border-gray-200 py-3">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/interactions/_list_mobile.html.erb
+++ b/app/views/interactions/_list_mobile.html.erb
@@ -31,4 +31,8 @@
       </div>
     <% end %>
   </div>
+
+  <div class="bg-white rounded-lg shadow py-3 mt-2">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/notices/_list_desktop.html.erb
+++ b/app/views/notices/_list_desktop.html.erb
@@ -103,4 +103,8 @@
       <% end %>
     </tbody>
   </table>
+
+  <div class="border-t border-gray-200 py-3">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/notices/_list_mobile.html.erb
+++ b/app/views/notices/_list_mobile.html.erb
@@ -29,4 +29,8 @@
       </div>
     <% end %>
   </div>
+
+  <div class="bg-white rounded-lg shadow py-3 mt-2">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/tasks/_list_desktop.html.erb
+++ b/app/views/tasks/_list_desktop.html.erb
@@ -90,4 +90,8 @@
       <% end %>
     <% end %>
   </div>
+
+  <div class="border-t border-gray-200 py-3">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/tasks/_list_mobile.html.erb
+++ b/app/views/tasks/_list_mobile.html.erb
@@ -29,4 +29,8 @@
       </div>
     <% end %>
   </div>
+
+  <div class="bg-white rounded-lg shadow py-3 mt-2">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/users/_list_desktop.html.erb
+++ b/app/views/users/_list_desktop.html.erb
@@ -35,4 +35,8 @@
       <% end %>
     </tbody>
   </table>
+
+  <div class="border-t border-gray-200 py-3">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/users/_list_mobile.html.erb
+++ b/app/views/users/_list_mobile.html.erb
@@ -10,4 +10,8 @@
       <%= render "mobile_card", user: user %>
     <% end %>
   </div>
+
+  <div class="bg-white rounded-lg shadow py-3 mt-2">
+    <%= pagy_tailwind_nav(@pagy) %>
+  </div>
 </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,4 @@
+require "pagy/extras/overflow"
+
+Pagy::DEFAULT[:items] = 20
+Pagy::DEFAULT[:overflow] = :last_page

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe "Customers", type: :request do
         expect(response.body).to include(customer.phone)
         expect(response.body).to include(customer.key_notes)
       end
+
+      it "shows the (limit+1)th customer only on page 2" do
+        limit = Pagy::DEFAULT[:items]
+        (1..limit).each { |i| create(:customer, name: format("aaa_page_test_%02d", i), email: "aaa_page_test_#{i}@example.com") }
+        target_customer = create(:customer, name: "zzz_page_test_target", email: "zzz_page_test_target@example.com")
+
+        get customers_path
+        expect(response.body).not_to include(target_customer.name)
+
+        get customers_path, params: { page: 2 }
+        expect(response.body).to include(target_customer.name)
+      end
     end
 
     context "when the user is not logged in" do

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe "Interactions", type: :request do
         expect(response.body).to include(second_sibling_interaction.request_content)
       end
 
+      it "shows the (limit+1)th interaction only on page 2" do
+        limit = Pagy::DEFAULT[:items]
+        old_interaction = create(:interaction, user: user, occurred_at: (limit + 1).days.ago, request_content: "1番古い応対履歴")
+        (1..limit).each { |i| create(:interaction, user: user, occurred_at: i.days.ago) }
+
+        get interactions_path
+        expect(response.body).not_to include(old_interaction.request_content)
+
+        get interactions_path, params: { page: 2 }
+        expect(response.body).to include(old_interaction.request_content)
+      end
+
       it "ignores unauthorized customer email filter and returns unfiltered results" do
         create(:interaction, customer: customer, user: user)
         create(:interaction, customer: other_customer, user: user)

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe "Notices", type: :request do
         expect(response.body).to include(notice.title, other_notice.title)
       end
 
+      it "shows the (limit+1)th notice only on page 2" do
+        limit = Pagy::DEFAULT[:items]
+        (1..limit).each { |i| create(:notice, user: user, start_at: i.minutes.ago) }
+        target_notice = create(:notice, user: user, start_at: 1.year.ago, title: "2ページ目のお知らせ")
+
+        get notices_path
+        expect(response.body).not_to include(target_notice.title)
+
+        get notices_path, params: { page: 2 }
+        expect(response.body).to include(target_notice.title)
+      end
+
       it "uses full-page navigation for user links inside turbo frame" do
         get notices_path
 

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe "Tasks", type: :request do
         expect(response.body).to include(task.title, other_task.title)
       end
 
+      it "shows the (limit+1)th task only on page 2" do
+        limit = Pagy::DEFAULT[:items]
+        (1..limit).each { |i| create(:task, user: user, due_at: i.hours.from_now) }
+        target_task = create(:task, user: user, due_at: 1.month.from_now, title: "2ページ目のタスク")
+
+        get tasks_path
+        expect(response.body).not_to include(target_task.title)
+
+        get tasks_path, params: { page: 2 }
+        expect(response.body).to include(target_task.title)
+      end
+
       it "uses full-page navigation for user links inside turbo frame" do
         get tasks_path
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe "Users", type: :request do
         expect(response.body).to include(admin.name)
         expect(response.body).to include(I18n.t("users.admin.#{user.admin?}"))
       end
+
+      it "shows the (limit+1)th user only on page 2" do
+        limit = Pagy::DEFAULT[:items]
+        (1..limit).each { |i| create(:user, name: format("aaa_page_test_%02d", i), email_address: "aaa_page_test_#{i}@example.com") }
+        target_user = create(:user, name: "zzz_page_test_target", email_address: "zzz_page_test_target@example.com")
+
+        get users_path
+        expect(response.body).not_to include(target_user.name)
+
+        get users_path, params: { page: 2 }
+        expect(response.body).to include(target_user.name)
+      end
     end
 
     context "when the user is not logged in" do


### PR DESCRIPTION
## 概要

interactions/tasks/notices/customers/users の一覧画面に pagy によるページネーションを追加する。

---

## 変更内容

- Gemfile に `pagy` (`~> 8.6`) を追加、`config/initializers/pagy.rb` を新規作成
- `ApplicationController` に `Pagy::Backend` を include
- `ApplicationHelper` に `Pagy::Frontend` を include し、`pagy_tailwind_nav` ヘルパーを追加
- interactions/tasks/notices/customers/users の5コントローラの index アクションで `@q.result` を `pagy(...)` でラップ
- 各リソースの `_list_desktop.html.erb` / `_list_mobile.html.erb` にページネーションナビを追加
- spec/requests/interactions_spec.rb, tasks_spec.rb, notices_spec.rb, customers_spec.rb, users_spec.rb にページ超過時に2ページ目へ表示されることを確認するテストを追加
- 
---

## 確認済み
- [x] `bundle exec rspec` が全件成功
- [x]  `bundle exec rubocop` がエラー無
---

Closes #156 