### PR TITLE
Extract Rootable concern and rename thread_xxx to rooted_xxx

### DIFF
--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -11,7 +11,7 @@ class InteractionsController < ApplicationController
           :customer,
           :user,
           root: {
-            thread_interactions: [ :customer, :user ]
+            rooted_interactions: [ :customer, :user ]
           }
         )
         .order(occurred_at: :desc)
@@ -38,7 +38,7 @@ class InteractionsController < ApplicationController
   end
 
   def show
-    @timeline = @interaction.root.thread_interactions.order(:occurred_at)
+    @timeline = @interaction.root.rooted_interactions.order(:occurred_at)
   end
 
   def edit

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -12,7 +12,7 @@ class NoticesController < ApplicationController
         .preload(
           :user,
           root: {
-            thread_notices: [ :user ]
+            rooted_notices: [ :user ]
           }
         )
         .order(start_at: :desc)
@@ -42,7 +42,7 @@ class NoticesController < ApplicationController
   end
 
   def show
-    @timeline = @notice.root.thread_notices.order(:created_at)
+    @timeline = @notice.root.rooted_notices.order(:created_at)
   end
 
   def edit

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,7 +12,7 @@ class TasksController < ApplicationController
           :user,
           task_assignments: [ :user ],
           root: {
-            thread_tasks: [ :user, task_assignments: [ :user ] ]
+            rooted_tasks: [ :user, task_assignments: [ :user ] ]
           }
         )
         .order(due_at: :asc)
@@ -44,7 +44,7 @@ class TasksController < ApplicationController
   end
 
   def show
-    @timeline = @task.root.thread_tasks.order(:created_at)
+    @timeline = @task.root.rooted_tasks.order(:created_at)
   end
 
   def edit

--- a/app/models/concerns/rootable.rb
+++ b/app/models/concerns/rootable.rb
@@ -1,0 +1,39 @@
+module Rootable
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :assign_root
+    after_create :assign_self_as_root
+
+    belongs_to :parent, class_name: name, optional: true
+    belongs_to :root, class_name: name, optional: true
+  end
+
+  class_methods do
+    def rootable(order_column:)
+      has_many :children,
+               -> { order(order_column => :desc) },
+               class_name: name,
+               foreign_key: "parent_id"
+
+      has_many :"rooted_#{model_name.plural}", class_name: name, foreign_key: :root_id, dependent: :nullify
+
+      define_method(:"related_#{model_name.plural}") do
+        rooted_all = root.public_send(:"rooted_#{model_name.plural}")
+        rooted_all.reject { |record| record.id == id }.sort_by(&order_column)
+      end
+    end
+  end
+
+  private
+
+  def assign_root
+    return unless parent
+
+    self.root = parent.root || parent
+  end
+
+  def assign_self_as_root
+    update_column(:root_id, id) if root_id.nil?
+  end
+end

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -1,19 +1,11 @@
 class Interaction < ApplicationRecord
-  before_validation :assign_root
+  include Rootable
+  rootable order_column: :occurred_at
+
   before_validation :set_customer_from_parent
-  after_create :assign_self_as_root
 
   belongs_to :customer
   belongs_to :user
-
-  belongs_to :parent, class_name: "Interaction", optional: true
-  has_many :children,
-           -> { order(occurred_at: :desc) },
-           class_name: "Interaction",
-           foreign_key: "parent_id"
-
-  belongs_to :root, class_name: "Interaction", optional: true
-  has_many :thread_interactions, class_name: "Interaction", foreign_key: :root_id, dependent: :nullify
 
   has_many :interaction_notices
   has_many :notices, through: :interaction_notices
@@ -41,25 +33,10 @@ class Interaction < ApplicationRecord
     content_type: %w[image/jpeg image/png image/gif],
     size: { less_than_or_equal_to: 10.megabytes }
 
-  def related_interactions
-    thread_interactions_all = root.thread_interactions
-    thread_interactions_all.reject { |interaction| interaction.id == id }.sort_by(&:occurred_at)
-  end
-
   private
-
-  def assign_root
-    return unless parent
-
-    self.root = parent.root || parent
-  end
 
   def set_customer_from_parent
     self.customer ||= parent&.customer
-  end
-
-  def assign_self_as_root
-    update_column(:root_id, id) if root_id.nil?
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,17 +1,8 @@
 class Notice < ApplicationRecord
-  before_validation :assign_root
-  after_create :assign_self_as_root
+  include Rootable
+  rootable order_column: :created_at
 
   belongs_to :user
-
-  belongs_to :parent, class_name: "Notice", optional: true
-  has_many :children,
-           -> { order(created_at: :desc) },
-           class_name: "Notice",
-           foreign_key: "parent_id"
-
-  belongs_to :root, class_name: "Notice", optional: true
-  has_many :thread_notices, class_name: "Notice", foreign_key: :root_id, dependent: :nullify
 
   has_many :interaction_notices
   has_many :interactions, through: :interaction_notices
@@ -38,22 +29,7 @@ class Notice < ApplicationRecord
     content_type: %w[image/jpeg image/png image/gif],
     size: { less_than_or_equal_to: 10.megabytes }
 
-  def related_notices
-    thread_notices_all = root.thread_notices
-    thread_notices_all.reject { |notice| notice.id == id }.sort_by(&:created_at)
-  end
-
   private
-
-  def assign_root
-    return unless parent
-
-    self.root = parent.root || parent
-  end
-
-  def assign_self_as_root
-    update_column(:root_id, id) if root_id.nil?
-  end
 
   scope :status, ->(value) {
     now = Time.current

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,17 +1,8 @@
 class Task < ApplicationRecord
-  before_validation :assign_root
-  after_create :assign_self_as_root
+  include Rootable
+  rootable order_column: :created_at
 
   belongs_to :user
-
-  belongs_to :parent, class_name: "Task", optional: true
-  has_many :children,
-           -> { order(created_at: :desc) },
-           class_name: "Task",
-           foreign_key: "parent_id"
-
-  belongs_to :root, class_name: "Task", optional: true
-  has_many :thread_tasks, class_name: "Task", foreign_key: :root_id, dependent: :nullify
 
   has_many :task_assignments
   has_many :assigned_users, through: :task_assignments, source: :user
@@ -32,22 +23,7 @@ class Task < ApplicationRecord
     content_type: %w[image/jpeg image/png image/gif],
     size: { less_than_or_equal_to: 10.megabytes }
 
-  def related_tasks
-    thread_tasks_all = root.thread_tasks
-    thread_tasks_all.reject { |task| task.id == id }.sort_by(&:created_at)
-  end
-
   private
-
-  def assign_root
-    return unless parent
-
-    self.root = parent.root || parent
-  end
-
-  def assign_self_as_root
-    update_column(:root_id, id) if root_id.nil?
-  end
 
   scope :due_within, ->(period) {
     from = Time.current.beginning_of_day

--- a/spec/models/interaction_spec.rb
+++ b/spec/models/interaction_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Interaction, type: :model do
       expect(association.options[:optional]).to be(true)
     end
 
-    it 'has many thread_interactions' do
-      association = described_class.reflect_on_association(:thread_interactions)
+    it 'has many rooted_interactions' do
+      association = described_class.reflect_on_association(:rooted_interactions)
 
       expect(association.macro).to eq(:has_many)
       expect(association.options[:class_name]).to eq("Interaction")

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Notice, type: :model do
       expect(association.options[:optional]).to be(true)
     end
 
-    it 'has many thread_notices' do
-      association = described_class.reflect_on_association(:thread_notices)
+    it 'has many rooted_notices' do
+      association = described_class.reflect_on_association(:rooted_notices)
 
       expect(association.macro).to eq(:has_many)
       expect(association.options[:class_name]).to eq("Notice")

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Task, type: :model do
       expect(association.options[:optional]).to be(true)
     end
 
-    it 'has many thread_tasks' do
-      association = described_class.reflect_on_association(:thread_tasks)
+    it 'has many rooted_tasks' do
+      association = described_class.reflect_on_association(:rooted_tasks)
 
       expect(association.macro).to eq(:has_many)
       expect(association.options[:class_name]).to eq("Task")


### PR DESCRIPTION
## 概要

Interaction, Task, Notice の3モデルに重複していたroot/parent/children関連ロジックを Rootable concern に共通化した。
あわせて thread_xxx という紛らわしい関連名を rooted_xxx にリネームした。

---

## 変更内容

- app/models/concerns/rootable.rb を新規作成し、belongs_to :parent / has_many :children / belongs_to :root / assign_root / assign_self_as_root / related_xxx を共通化
- Interaction/Task/Notice に include Rootable + rootable order_column: ... を追加し、個別ロジックを削除
- thread_interactions / thread_tasks / thread_notices を rooted_interactions / rooted_tasks / rooted_notices にリネーム
- interactions_controller.rb / tasks_controller.rb / notices_controller.rb の preload と show アクションの参照箇所を修正
- interaction_spec.rb / task_spec.rb / notice_spec.rb の reflect_on_association 対象を rooted_xxx に修正

---

## 確認済み
- [x] bundle exec rubocop がエラー無
- [x] bundle exec rspec 全体がグリーン(538 examples, 0 failures)
- [x] thread_interactions / thread_tasks / thread_notices への参照が残っていないことをgrepで確認

---

Closes #158 