### PR TITLE
Extract shared authorization logic into Authorizable concern

### DIFF
--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -1,0 +1,17 @@
+module Authorizable
+  extend ActiveSupport::Concern
+
+  private
+
+  def authorize_edit!(record)
+    return if record.user == Current.user
+
+    redirect_to record, alert: "編集権限がありません"
+  end
+
+  def authorize_view!(record, redirect_path)
+    return if Current.user.admin? || !record.restricted
+
+    redirect_to redirect_path, alert: "閲覧権限がありません"
+  end
+end

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,7 +1,9 @@
 class InteractionsController < ApplicationController
+  include Authorizable
+
   before_action :set_interaction, only: [ :edit, :update ]
   before_action :set_interaction_with_comments, only: :show
-  before_action :authorize_edit!, only: [ :edit, :update ]
+  before_action -> { authorize_edit!(@interaction) }, only: [ :edit, :update ]
 
   def index
     @q = Interaction.ransack(params[:q])
@@ -68,11 +70,5 @@ class InteractionsController < ApplicationController
       :request_content, :response_result, :completed, :parent_id,
       images: []
     )
-  end
-
-  def authorize_edit!
-    return if @interaction.user == Current.user
-
-    redirect_to @interaction, alert: "編集権限がありません"
   end
 end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,8 +1,10 @@
 class NoticesController < ApplicationController
+  include Authorizable
+
   before_action :set_notice, only: %i[edit update]
   before_action :set_notice_with_comments, only: :show
-  before_action :authorize_view!, only: %i[show edit update]
-  before_action :authorize_edit!, only: %i[edit update]
+  before_action -> { authorize_view!(@notice, notices_path) }, only: %i[show edit update]
+  before_action -> { authorize_edit!(@notice) }, only: %i[edit update]
 
 
   def index
@@ -68,18 +70,6 @@ class NoticesController < ApplicationController
 
   def visible_notices
     Current.user.admin? ? Notice.all : Notice.where(restricted: false)
-  end
-
-  def authorize_view!
-    return if Current.user.admin? || !@notice.restricted
-
-    redirect_to notices_path, alert: "アクセス権限がありません"
-  end
-
-  def authorize_edit!
-    return if @notice.user == Current.user
-
-    redirect_to @notice, alert: "編集権限がありません"
   end
 
   def notice_params

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,8 +1,10 @@
 class TasksController < ApplicationController
+  include Authorizable
+
   before_action :set_task, only: [ :edit, :update ]
   before_action :set_task_with_associations, only: :show
-  before_action :authorize_view!, only: [ :show, :edit, :update ]
-  before_action :authorize_edit!, only: [ :edit, :update ]
+  before_action -> { authorize_view!(@task, tasks_path) }, only: [ :show, :edit, :update ]
+  before_action -> { authorize_edit!(@task) }, only: [ :edit, :update ]
 
   def index
     @q = visible_tasks.ransack(params[:q], auth_object: :admin)
@@ -73,16 +75,6 @@ class TasksController < ApplicationController
 
   def visible_tasks
     Current.user.admin? ? Task.all : Task.where(restricted: false)
-  end
-
-  def authorize_view!
-    return if Current.user.admin? || !@task.restricted
-    redirect_to tasks_path, alert: "アクセス権限がありません"
-  end
-
-  def authorize_edit!
-    return if @task.user == Current.user
-    redirect_to @task, alert: "編集権限がありません"
   end
 
   def task_params


### PR DESCRIPTION
## 概要

TasksController / NoticesController / InteractionsController に重複していた authorize_edit! / authorize_view! を
Authorizable concern に共通化した。

---

## 変更内容

- app/controllers/concerns/authorizable.rb を新規作成し、authorize_edit!(record) / authorize_view!(record, redirect_path) を定義
- TasksController / NoticesController / InteractionsController に include Authorizable し、個別の authorize_edit! / authorize_view! 実装を削除
- before_action を lambda 化し、対象レコード（と NoticesController/TasksController では redirect_path）を明示的に渡す形に変更
- NoticesController の authorize_view! のリダイレクト時 alert メッセージを「アクセス権限がありません」から「閲覧権限がありません」に変更
- 
---

## 確認済み

- [x] 各コントローラの before_action の対象アクション（only）は変更なし
- [x] リダイレクト先（record / index path）は変更なし
- [x] `bundle exec rspec` が全件成功
- [x]  `bundle exec rubocop` がエラー無

---

Closes #160 