### PR TITLE
Remove unused customers.uuid column

### DIFF
--- a/db/migrate/20260721231848_remove_uuid_from_customers.rb
+++ b/db/migrate/20260721231848_remove_uuid_from_customers.rb
@@ -1,0 +1,5 @@
+class RemoveUuidFromCustomers < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :customers, :uuid, :uuid, default: -> { "gen_random_uuid()" }, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_29_144145) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_231848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -60,8 +60,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_144145) do
     t.string "name", null: false
     t.string "phone"
     t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
-    t.index ["uuid"], name: "index_customers_on_uuid", unique: true
   end
 
   create_table "interaction_notices", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -68,28 +68,28 @@ user_satou  = User.find_by!(email_address: "satou@example.com")
 # ==============================================================================
 customers_data = [
   {
-    uuid: "11111111-1111-1111-1111-111111111111",
+    key: :hanako,
     name: "山田 花子",
     email: "hanako@example.com",
     phone: "090-1234-5678",
     key_notes: "初回訪問済み。次回は2月にフォロー予定。"
   },
   {
-    uuid: "22222222-2222-2222-2222-222222222222",
+    key: :jiro,
     name: "佐藤 次郎",
     email: "",
     phone: "",
     key_notes: "メール・電話なし。家族経由で連絡。"
   },
   {
-    uuid: "33333333-3333-3333-3333-333333333333",
+    key: :john,
     name: "John Smith",
     email: "john.smith@example.com",
     phone: "03-1234-5678",
     key_notes: "英語対応が必要。"
   },
   {
-    uuid: "44444444-4444-4444-4444-444444444444",
+    key: :hanako_regular,
     name: "山田 花子",
     email: "",
     phone: "",
@@ -97,22 +97,25 @@ customers_data = [
   }
 ]
 
+created_customers = {}
+
 customers_data.each do |attrs|
-  customer = Customer.find_or_create_by!(uuid: attrs[:uuid]) do |c|
-    c.assign_attributes(attrs)
+  customer = Customer.find_or_create_by!(name: attrs[:name], email: attrs[:email], phone: attrs[:phone]) do |c|
+    c.key_notes = attrs[:key_notes]
   end
+
+  created_customers[attrs[:key]] = customer
 
   if customer.previously_new_record?
     puts "初期顧客を作成しました！"
     puts "名前: #{customer.name}"
-    puts "UUID: #{customer.uuid}"
   end
 end
 
-# 以降で顧客をUUIDで参照
-customer_hanako = Customer.find_by!(uuid: "11111111-1111-1111-1111-111111111111")
-customer_jiro   = Customer.find_by!(uuid: "22222222-2222-2222-2222-222222222222")
-customer_john   = Customer.find_by!(uuid: "33333333-3333-3333-3333-333333333333")
+# 以降で顧客を参照
+customer_hanako = created_customers[:hanako]
+customer_jiro   = created_customers[:jiro]
+customer_john   = created_customers[:john]
 
 # ==============================================================================
 # ヘルパーメソッド

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -81,18 +81,6 @@ RSpec.describe Customer, type: :model do
         expect(customer).to be_invalid
       end
     end
-
-    describe 'uuid' do
-      it 'generates a uuid on creation' do
-        expect(create(:customer).uuid).to be_present
-      end
-
-      it 'assigns different uuids when multiple customers have the same name' do
-        customer_a = create(:customer, name: '伊藤綾香')
-        customer_b = create(:customer, name: '伊藤綾香')
-        expect(customer_a.uuid).not_to eq(customer_b.uuid)
-      end
-    end
   end
 
   describe 'ransackable_attributes' do


### PR DESCRIPTION
## 概要

customersテーブルの未使用uuidカラムを削除する。

---

## 変更内容

- customers.uuidカラムおよびユニークインデックス(index_customers_on_uuid)を削除するマイグレーションを追加
- db/schema.rbを更新
- db/seeds.rbのcustomer生成処理を、uuidベースの検索からname/email/phoneによるfind_or_create_by + key付きハッシュ参照に変更
- spec/models/customer_spec.rbからuuid関連のテストを削除

---

## 確認済み
- [x] bundle exec rspec が全件パスすること
- [x] bundle exec rubocop でエラーがないこと
- [x] db/seeds.rb実行後、uuidへの言及が残っていないこと

---

Closes #162 