### PR TITLE
Render Thumbnail Variants for Attached Images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Install libvips
+        run: sudo apt-get update -qq && sudo apt-get install --no-install-recommends -y libvips
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -87,6 +90,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+
+      - name: Install libvips
+        run: sudo apt-get update -qq && sudo apt-get install --no-install-recommends -y libvips
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 2.0"
+gem "ruby-vips", "~> 2.0"
 gem "active_storage_validations"
 
 gem "rails-i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,13 @@ GEM
       railties (>= 6.1.0)
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -369,6 +376,9 @@ GEM
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
     rubyzip (3.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.46.0)
@@ -522,6 +532,7 @@ DEPENDENCIES
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase
   rubocop-rspec
+  ruby-vips (~> 2.0)
   selenium-webdriver
   solargraph
   solargraph-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,10 @@ module ApplicationHelper
     end
   end
 
+  def thumbnail_variant(image)
+    image.variant(resize_to_limit: [ 800, 800 ])
+  end
+
   def pagy_tailwind_nav(pagy)
     return "".html_safe if pagy.pages <= 1
 

--- a/app/views/shared/_images.html.erb
+++ b/app/views/shared/_images.html.erb
@@ -4,7 +4,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
       <% record.images.each do |image| %>
         <div class="bg-gray-50 rounded p-2 text-center">
-          <%= image_tag image, alt: image.filename.to_s, class: "rounded object-cover w-full h-auto" %>
+          <%= image_tag thumbnail_variant(image), alt: image.filename.to_s, class: "rounded object-cover w-full h-auto" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## 概要

詳細ページに表示する添付画像を、原寸ではなく800x800以内のvariantで表示するようにした

---

## 変更内容

- app/helpers/application_helper.rbにthumbnail_variant(image)ヘルパーを追加（resize_to_limit: [800, 800]）
- app/views/shared/_images.html.erbのimage_tag imageをimage_tag thumbnail_variant(image)に変更
- Gemfile/Gemfile.lockにruby-vips (~> 2.0)を追加

---

## 確認済み

- [x] `bundle exec rspec` が全件成功
- [x]  `bundle exec rubocop` がエラー無

---

Closes #164 