### PR TITLE
Fix notices/pages spec bugs and generate fixtures at runtime

### DIFF
--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -73,5 +73,29 @@ RSpec.describe "Comments", type: :request do
 
     it_behaves_like "restricts posting comments", "task"
     it_behaves_like "restricts posting comments", "notice"
+
+    context "with a commentable_type outside the whitelist" do
+      it "returns 404 for a non-commentable model" do
+        commentable_user = create(:user)
+
+        post comments_path, params: {
+          commentable_type: "User",
+          commentable_id: commentable_user.id,
+          comment: { content: "テストコメント" }
+        }
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns 404 for a nonexistent class name" do
+        post comments_path, params: {
+          commentable_type: "NonexistentModel",
+          commentable_id: 1,
+          comment: { content: "テストコメント" }
+        }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 end

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe "Notices", type: :request do
   let(:user) { create(:user) }
-  let(:other_user) { create(:user) }
   let(:admin) { create(:user, admin: true) }
   let!(:notice) { create(:notice, user: user) }
   let!(:restricted_notice) { create(:notice, user: admin, restricted: true) }
@@ -328,14 +327,11 @@ RSpec.describe "Notices", type: :request do
     before { sign_in(user) }
 
     context "with a valid image" do
+      let(:images) { [ valid_image ] }
+
       it "creates a notice with images" do
-        expect {
-          post notices_path, params: {
-            notice: attributes_for(:notice).merge(
-              images: [ valid_image ]
-            )
-          }
-        }.to change(Notice, :count).by(1)
+        expect { perform_request }
+          .to change(Notice, :count).by(1)
 
         expect(response).to redirect_to(notice_path(Notice.last))
         expect(Notice.last.images).to be_attached
@@ -343,14 +339,11 @@ RSpec.describe "Notices", type: :request do
     end
 
     context "with an invalid file" do
+      let(:images) { [ invalid_file ] }
+
       it "does not create a notice" do
-        expect {
-          post notices_path, params: {
-            notice: attributes_for(:notice).merge(
-              images: [ invalid_file ]
-            )
-          }
-        }.not_to change(Notice, :count)
+        expect { perform_request }
+          .not_to change(Notice, :count)
       end
     end
   end
@@ -379,6 +372,8 @@ RSpec.describe "Notices", type: :request do
     end
 
     context "when the user is not the creator" do
+      let(:other_user) { create(:user) }
+
       before { sign_in(other_user) }
 
       it "redirects to the show page" do
@@ -452,6 +447,8 @@ RSpec.describe "Notices", type: :request do
     end
 
     context "when the user is not the creator" do
+      let(:other_user) { create(:user) }
+
       before { sign_in(other_user) }
 
       it "does not update the notice and redirects to the show page" do

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe "Pages", type: :request do
   describe "GET /" do
     it "allows users to access landing page" do

--- a/spec/support/image_helpers.rb
+++ b/spec/support/image_helpers.rb
@@ -14,9 +14,10 @@ module ImageHelpers
   end
 
   def oversized_file
-    Rack::Test::UploadedFile.new(
-      Rails.root.join("spec/fixtures/files/oversized.jpg"),
-      "image/jpeg"
-    )
+    tempfile = Tempfile.new([ "oversized", ".jpg" ], binmode: true)
+    tempfile.write(SecureRandom.random_bytes(11.megabytes))
+    tempfile.rewind
+
+    Rack::Test::UploadedFile.new(tempfile.path, "image/jpeg")
   end
 end


### PR DESCRIPTION
## 概要

既存specの中に、実際にはテスト対象のコードを検証できていないものが複数あった。
notices_spec.rbの画像アップロードテストはリクエストを一度も送らずに通っており、pages_spec.rbは他のspecファイルの読み込み順に依存してたまたま動いていた。
また、comments_controllerのホワイトリスト外の値を拒否する挙動には対応するテストがなく、10MBバリデーションを確認するためだけに36MBの画像ファイルをfixtureとしてリポジトリに固定で置いていた。

本PRでは、これらのspecが実際に意図した検証を行うよう修正し、巨大なfixtureファイルを実行時生成に置き換えることで、テストの信頼性とリポジトリの健全性を回復する。

---

## 変更内容

- notices_spec.rb: `perform_request`を各contextから呼び出すよう修正し、`let(:images)`をtasks_spec.rb/interactions_spec.rbと同じ形で定義
- pages_spec.rb: 先頭に`require "rails_helper"`を追加
- image_helpers.rb: `oversized_file`をTempfileで11MBのランダムバイト列を書き込む方式に変更し、`spec/fixtures/files/oversized.jpg`(36MB)を削除
- comments_spec.rb: `commentable_type`が`"User"`や存在しないクラス名などホワイトリスト外の場合に404を返すことを検証するテストを追加

---

## 確認済

- [x] `bundle exec rspec` が全件成功
- [x]  `bundle exec rubocop` がエラー無
- [x] 今後のコミットにoversized.jpgが含まれないことを確認(既存.git履歴に残るblobの削除は今後の対応を検討中)
---
Closes #169 