### PR TITLE
Improve RSpec Suite Reliability and Maintainability

### DIFF
--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :customer do
-    name { "田中健人" }
+    sequence(:name) { |n| "テスト顧客#{n}" }
     email { "tanaka@example.com" }
     phone { "090-1234-5678" }
     key_notes { "常連さん" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    name { "鈴木一郎" }
+    sequence(:name) { |n| "テストユーザー#{n}" }
     sequence(:email_address) { |n| "user#{n}@example.com" }
-    password { "password55" }
+    password { Faker::Internet.password(min_length: 8) }
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -26,40 +26,4 @@ RSpec.describe ApplicationHelper, type: :helper do
       ])
     end
   end
-
-  describe "#tab_link_to" do
-    let(:tab) { { path: "/interactions", label: "応対履歴", name: "interactions" } }
-
-    context "when the tab matches the current controller (active)" do
-      subject(:rendered) { helper.tab_link_to(tab) }
-
-      before { allow(helper).to receive(:controller_name).and_return("interactions") }
-
-      it "applies active border class" do
-        expect(rendered).to include("border-blue-500")
-      end
-
-      it "applies active text class" do
-        expect(rendered).to include("text-blue-600")
-      end
-
-      it "does not apply inactive border class" do
-        expect(rendered).not_to include("border-transparent")
-      end
-    end
-
-    context "when the tab does not match the current controller (inactive)" do
-      subject(:rendered) { helper.tab_link_to(tab) }
-
-      before { allow(helper).to receive(:controller_name).and_return("tasks") }
-
-      it "applies inactive border class" do
-        expect(rendered).to include("border-transparent")
-      end
-
-      it "does not apply active border class" do
-        expect(rendered).not_to include("border-blue-500")
-      end
-    end
-  end
 end

--- a/spec/helpers/notices_helper_spec.rb
+++ b/spec/helpers/notices_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe NoticesHelper, type: :helper do
+  describe "#notice_level_label" do
+    it "marks the notice as requiring everyone's attention" do
+      notice = build(:notice, level: "important")
+
+      expect(helper.notice_level_label(notice)).to eq("高")
+    end
+
+    it "marks the notice as routine information" do
+      notice = build(:notice, level: "normal")
+
+      expect(helper.notice_level_label(notice)).to eq("低")
+    end
+  end
+end

--- a/spec/helpers/task_assignments_helper_spec.rb
+++ b/spec/helpers/task_assignments_helper_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe TaskAssignmentsHelper, type: :helper do
+  describe "#task_status_label" do
+    it "indicates the assignee has not touched the work yet" do
+      assignment = build(:task_assignment, status: "todo")
+
+      expect(helper.task_status_label(assignment)).to eq("未着手")
+    end
+
+    it "indicates the assignee is currently working on it" do
+      assignment = build(:task_assignment, status: "in_progress")
+
+      expect(helper.task_status_label(assignment)).to eq("進行中")
+    end
+
+    it "indicates the assignee has finished the work" do
+      assignment = build(:task_assignment, status: "done")
+
+      expect(helper.task_status_label(assignment)).to eq("完了")
+    end
+  end
+end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe UsersHelper, type: :helper do
+  describe "#user_admin_label" do
+    it "labels the user as an administrator when admin is true" do
+      user = build(:user, admin: true)
+
+      expect(helper.user_admin_label(user)).to eq("管理者")
+    end
+
+    it "labels the user as general when admin is false" do
+      user = build(:user, admin: false)
+
+      expect(helper.user_admin_label(user)).to eq("一般")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,8 @@ end
 RSpec.configure do |config|
   config.include ImageHelpers
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include AuthenticationHelpers, type: :request
+  config.include AuthenticationHelpers, type: :system
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -3,10 +3,6 @@ require "rails_helper"
 RSpec.describe "Authentication", type: :request do
   let(:user) { create(:user) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /login" do
     it "allows users to access login page" do
       get login_path
@@ -16,11 +12,9 @@ RSpec.describe "Authentication", type: :request do
   end
 
   describe "GET /interactions" do
-    it "redirects unauthenticated users to login page" do
-      get interactions_path
+    subject { get interactions_path }
 
-      expect(response).to redirect_to(login_path)
-    end
+    it_behaves_like "requires_authentication"
   end
 
   describe "POST /login" do

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Comments", type: :request do
   let(:user) { create(:user) }
   let(:other_user) { create(:user) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   before { sign_in(user) }
 
   shared_examples "allows posting comments" do |commentable_factory|

--- a/spec/requests/customers_search_spec.rb
+++ b/spec/requests/customers_search_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe "Customers search", type: :request do
     other_customer
   end
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /customers" do
     it "returns all records when no search params are given" do
       get customers_path

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe "Customers", type: :request do
   let(:user) { create(:user) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /customers" do
     context "when the user is logged in" do
       before { sign_in(user) }
@@ -42,11 +38,9 @@ RSpec.describe "Customers", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get customers_path
+      subject { get customers_path }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -62,11 +56,9 @@ RSpec.describe "Customers", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get new_customer_path
+      subject { get new_customer_path }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -74,16 +66,7 @@ RSpec.describe "Customers", type: :request do
     context "when the user is logged in" do
       before { sign_in(user) }
 
-      let(:valid_params) do
-        {
-          customer: {
-            name: "テスト顧客",
-            email: "test@example.com",
-            phone: "090-1234-5678",
-            key_notes: "常連"
-          }
-        }
-      end
+      let(:valid_params) { { customer: attributes_for(:customer) } }
 
       it "creates a Customer with valid params" do
         expect {
@@ -111,11 +94,9 @@ RSpec.describe "Customers", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        post customers_path, params: {}
+      subject { post customers_path, params: {} }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -157,11 +138,9 @@ RSpec.describe "Customers", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get customer_path(customer)
+      subject { get customer_path(customer) }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -179,11 +158,9 @@ RSpec.describe "Customers", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get edit_customer_path(customer)
+      subject { get edit_customer_path(customer) }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -216,11 +193,9 @@ RSpec.describe "Customers", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        patch customer_path(customer), params: {}
+      subject { patch customer_path(customer), params: {} }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 end

--- a/spec/requests/interaction_tasks_spec.rb
+++ b/spec/requests/interaction_tasks_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe "Interaction Tasks", type: :request do
   let(:task) { create(:task) }
   let(:customer) { create(:customer) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   before { sign_in(user) }
 
   describe "GET /interactions/:id - related tasks display" do

--- a/spec/requests/interactions_parent_child_spec.rb
+++ b/spec/requests/interactions_parent_child_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Interactions parent-child", type: :request do
   let(:user)  { create(:user) }
   let(:admin) { create(:user, admin: true) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /interactions/:id - back link" do
     before { sign_in(user) }
 

--- a/spec/requests/interactions_search_spec.rb
+++ b/spec/requests/interactions_search_spec.rb
@@ -15,10 +15,6 @@ RSpec.describe "Interactions search", type: :request do
           channel: "email", completed: true, occurred_at: "2026-06-10 10:00")
   end
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /interactions" do
     it "returns all records when no search params are given" do
       get interactions_path

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe "Interactions", type: :request do
   let(:customer) { create(:customer, name: "鈴木太郎", phone: "090-1111-2222", email: "suzuki@example.com") }
   let(:other_customer) { create(:customer, name: "佐藤花子", phone: "080-3333-4444", email: "sato@example.com") }
 
-
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /interactions" do
     context "when the user is logged in" do
       before { sign_in(user) }
@@ -105,10 +100,9 @@ RSpec.describe "Interactions", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get interactions_path
-        expect(response).to redirect_to(login_path)
-      end
+      subject { get interactions_path }
+
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -129,10 +123,9 @@ RSpec.describe "Interactions", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get interactions_path
-        expect(response).to redirect_to(login_path)
-      end
+      subject { get interactions_path }
+
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -140,18 +133,8 @@ RSpec.describe "Interactions", type: :request do
     context "when the user is logged in" do
       before { sign_in(user) }
 
-      let(:customer) { create(:customer) }
       let(:valid_params) do
-        {
-          interaction: {
-            customer_id: customer.id,
-            channel: "phone",
-            occurred_at: Time.current,
-            request_content: "新規要望",
-            response_result: "対応しました！",
-            completed: true
-          }
-        }
+        { interaction: attributes_for(:interaction).merge(customer_id: customer.id) }
       end
 
       it "creates an Interaction with valid params" do
@@ -183,10 +166,9 @@ RSpec.describe "Interactions", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        post interactions_path, params: {}
-        expect(response).to redirect_to(login_path)
-      end
+      subject { post interactions_path, params: {} }
+
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -197,7 +179,6 @@ RSpec.describe "Interactions", type: :request do
       }
     end
 
-    let(:customer) { create(:customer) }
     let(:interaction_params) do
       attributes_for(
         :interaction,
@@ -282,10 +263,9 @@ RSpec.describe "Interactions", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get interaction_path(interaction)
-        expect(response).to redirect_to(login_path)
-      end
+      subject { get interaction_path(interaction) }
+
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -311,11 +291,12 @@ RSpec.describe "Interactions", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        interaction = create(:interaction, user: user)
-        get edit_interaction_path(interaction)
-        expect(response).to redirect_to(login_path)
-      end
+      subject { get edit_interaction_path(interaction) }
+
+      let(:interaction) { create(:interaction, user: user) }
+
+
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -360,10 +341,9 @@ RSpec.describe "Interactions", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        patch interaction_path(interaction), params: {}
-        expect(response).to redirect_to(login_path)
-      end
+      subject { patch interaction_path(interaction), params: {} }
+
+      it_behaves_like "requires_authentication"
     end
   end
 

--- a/spec/requests/notice_interactions_spec.rb
+++ b/spec/requests/notice_interactions_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Notice Interactions", type: :request do
   let(:user) { create(:user) }
   let(:interaction) { create(:interaction) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   before { sign_in(user) }
 
   describe "GET/notices/new with interaction_id" do
@@ -21,13 +17,7 @@ RSpec.describe "Notice Interactions", type: :request do
   describe "POST /notices with interaction_id" do
     let(:valid_params) do
       {
-        notice: {
-          title: "テストお知らせ",
-          content: "テストお知らせの詳細",
-          level: "normal",
-          start_at: 1.day.from_now,
-          end_at: 7.days.from_now
-        },
+        notice: attributes_for(:notice),
         interaction_id: interaction.id
       }
     end

--- a/spec/requests/notice_tasks_spec.rb
+++ b/spec/requests/notice_tasks_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Notice Tasks", type: :request do
   let(:user) { create(:user) }
   let(:task) { create(:task) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   before { sign_in(user) }
 
   describe "GET /notices/new with task_id" do
@@ -21,13 +17,7 @@ RSpec.describe "Notice Tasks", type: :request do
   describe "POST /notices with task_id" do
     let(:valid_params) do
       {
-        notice: {
-          title: "テストお知らせ",
-          content: "テストお知らせの詳細",
-          level: "normal",
-          start_at: 1.day.from_now,
-          end_at: 7.days.from_now
-        },
+        notice: attributes_for(:notice),
         task_id: task.id
       }
     end

--- a/spec/requests/notices_parent_child_spec.rb
+++ b/spec/requests/notices_parent_child_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Notices parent-child", type: :request do
   let(:user)  { create(:user) }
   let(:admin) { create(:user, admin: true) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /notices/:id - back link" do
     before { sign_in(user) }
 

--- a/spec/requests/notices_search_spec.rb
+++ b/spec/requests/notices_search_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe "Notices search", type: :request do
     create(:notice, title: "ユーザーお知らせ", content: "一般ユーザーの作業", user: regular_user)
   end
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /notices" do
     context "when signed in as admin" do
       before { sign_in(admin) }

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -6,32 +6,8 @@ RSpec.describe "Notices", type: :request do
   let!(:notice) { create(:notice, user: user) }
   let!(:restricted_notice) { create(:notice, user: admin, restricted: true) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   def valid_params
-    {
-      notice: {
-        title: "テストお知らせ",
-        content: "テストタスクの詳細",
-        level: "important",
-        start_at: 1.hour.ago,
-        end_at: 1.week.from_now
-      }
-    }
-  end
-
-  def child_params
-    {
-      notice: {
-        title: "子テストタスク",
-        content: "子テストタスクの詳細",
-        level: "important",
-        start_at: 1.hour.ago,
-        end_at: 1.week.from_now
-      }
-    }
+    { notice: attributes_for(:notice) }
   end
 
   describe "GET /notices" do
@@ -123,11 +99,9 @@ RSpec.describe "Notices", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get notices_path
+      subject { get notices_path }
 
-        expect(response).to redirect_to login_path
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -213,11 +187,9 @@ RSpec.describe "Notices", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get notice_path(notice)
+      subject { get notice_path(notice) }
 
-        expect(response).to redirect_to login_path
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -249,11 +221,9 @@ RSpec.describe "Notices", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get new_notice_path
+      subject { get new_notice_path }
 
-        expect(response).to redirect_to login_path
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -292,7 +262,7 @@ RSpec.describe "Notices", type: :request do
       end
 
       it "ignores restricted parameter" do
-        post notices_path, params: { notice: child_params[:notice].merge(restricted: true) }
+        post notices_path, params: { notice: attributes_for(:notice).merge(restricted: true) }
 
         expect(Notice.last.restricted).to be(false)
       end
@@ -302,18 +272,16 @@ RSpec.describe "Notices", type: :request do
       before { sign_in(admin) }
 
       it "allows to set restricted" do
-        post notices_path, params: { notice: child_params[:notice].merge(restricted: true) }
+        post notices_path, params: { notice: attributes_for(:notice).merge(restricted: true) }
 
         expect(Notice.last.restricted).to be(true)
       end
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        post notices_path, params: {}
+      subject { post notices_path, params: {} }
 
-        expect(response).to redirect_to login_path
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -410,11 +378,9 @@ RSpec.describe "Notices", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get edit_notice_path(notice)
+      subject { get edit_notice_path(notice) }
 
-        expect(response).to redirect_to login_path
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -482,11 +448,9 @@ RSpec.describe "Notices", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        patch notice_path(notice), params: {}
+      subject { patch notice_path(notice), params: {} }
 
-        expect(response).to redirect_to login_path
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 

--- a/spec/requests/task_assignments_spec.rb
+++ b/spec/requests/task_assignments_spec.rb
@@ -13,10 +13,6 @@ RSpec.describe "Task Assignments", type: :request do
     }
   end
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   before { sign_in(task_creator) }
 
   describe "POST /tasks with assignee_ids" do
@@ -120,13 +116,11 @@ RSpec.describe "Task Assignments", type: :request do
     end
 
     context "when not signed in" do
+      subject { patch task_assignment_path(assignment), params: { task_assignment: { status: "done" } } }
+
       before { delete logout_path }
 
-      it "redirects to the login page" do
-        patch task_assignment_path(assignment), params: { task_assignment: { status: "done" } }
-
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 end

--- a/spec/requests/task_interactions_spec.rb
+++ b/spec/requests/task_interactions_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe "Task Interactions", type: :request do
   let(:user) { create(:user) }
   let(:interaction) { create(:interaction) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   before { sign_in(user) }
 
   describe "GET/tasks/new with interaction_id" do
@@ -23,12 +19,7 @@ RSpec.describe "Task Interactions", type: :request do
   describe "POST /tasks with interaction_id" do
     let(:valid_params) do
       {
-        task: {
-          title: "テストタスク",
-          description: "テストタスクの詳細",
-          restricted: false,
-          due_at: 7.days.from_now
-        },
+        task: attributes_for(:task),
         interaction_id: interaction.id
       }
     end

--- a/spec/requests/task_notices_spec.rb
+++ b/spec/requests/task_notices_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe "Task Notices", type: :request do
   let(:user) { create(:user) }
   let(:notice) { create(:notice) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   before { sign_in(user) }
 
   describe "GET/tasks/new with notice_id" do
@@ -23,12 +19,7 @@ RSpec.describe "Task Notices", type: :request do
   describe "POST /tasks with notice_id" do
     let(:valid_params) do
       {
-        task: {
-          title: "テストタスク",
-          description: "テストタスクの詳細",
-          restricted: false,
-          due_at: 7.days.from_now
-        },
+        task: attributes_for(:task),
         notice_id: notice.id
       }
     end

--- a/spec/requests/tasks_parent_child_spec.rb
+++ b/spec/requests/tasks_parent_child_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe "Tasks parent-child", type: :request do
   let(:user)  { create(:user) }
   let(:admin) { create(:user, admin: true) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /tasks/:id - back link" do
     before { sign_in(user) }
 

--- a/spec/requests/tasks_search_spec.rb
+++ b/spec/requests/tasks_search_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe "Tasks search", type: :request do
   let!(:restricted_task) { create(:task, title: "限定タスク", description: "管理者専用コンテンツ", restricted: true, user: admin) }
   let!(:user_task)       { create(:task, title: "ユーザータスク", description: "一般ユーザーの作業", user: regular_user) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /tasks" do
     context "when signed in as admin" do
       before { sign_in(admin) }

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe "Tasks", type: :request do
   let!(:task) { create(:task, user: user) }
   let(:restricted_task) { create(:task, user: admin, restricted: true) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /tasks" do
     context "when the user is logged in" do
       before do
@@ -121,11 +117,9 @@ RSpec.describe "Tasks", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get tasks_path
+      subject { get tasks_path }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -166,11 +160,9 @@ RSpec.describe "Tasks", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get task_path(task)
+      subject { get task_path(task) }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -202,11 +194,9 @@ RSpec.describe "Tasks", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get new_task_path
+      subject { get new_task_path }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -214,13 +204,7 @@ RSpec.describe "Tasks", type: :request do
     context "when the user is logged in" do
       before { sign_in(user) }
 
-      let(:valid_params) do
-        {
-          title:       "テストタスク",
-          description: "テストタスクの詳細",
-          due_at:      1.week.from_now
-        }
-      end
+      let(:valid_params) { attributes_for(:task) }
 
       it "creates a Task with valid params" do
         expect {
@@ -251,13 +235,7 @@ RSpec.describe "Tasks", type: :request do
 
       it "ignores restricted parameter" do
         post tasks_path, params: create_task_with_assignees(
-          {
-            task: {
-              title:       "テストタスク",
-              description: "テストタスクの詳細",
-              restricted:  true
-            }
-          }
+          { task: attributes_for(:task).merge(restricted: true) }
         )
         expect(Task.last.restricted).to be(false)
       end
@@ -268,23 +246,16 @@ RSpec.describe "Tasks", type: :request do
 
       it "allows to set restricted" do
         post tasks_path, params: create_task_with_assignees(
-          {
-            task: {
-              title:       "テストタスク",
-              description: "テストタスクの詳細",
-              restricted:  true
-            }
-          }
+          { task: attributes_for(:task).merge(restricted: true) }
         )
         expect(Task.last.restricted).to be(true)
       end
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        post tasks_path, params: {}
-        expect(response).to redirect_to(login_path)
-      end
+      subject { post tasks_path, params: {} }
+
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -384,11 +355,9 @@ RSpec.describe "Tasks", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get edit_task_path(task)
+      subject { get edit_task_path(task) }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -459,11 +428,9 @@ RSpec.describe "Tasks", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        patch task_path(task), params: {}
+      subject { patch task_path(task), params: {} }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 

--- a/spec/requests/users_search_spec.rb
+++ b/spec/requests/users_search_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe "Users search", type: :request do
     sign_in(user)
   end
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /users" do
     it "returns all records when no search params are given" do
       get users_path

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Users", type: :request do
   let(:user) { create(:user) }
   let!(:admin) { create(:user, admin: true) }
 
-  def sign_in(user)
-    post login_path, params: { email_address: user.email_address, password: "password55" }
-  end
-
   describe "GET /users" do
     context "when the user is logged in" do
       before { sign_in(user) }
@@ -40,11 +36,9 @@ RSpec.describe "Users", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get users_path
+      subject { get users_path }
 
-        expect(response).to redirect_to login_path
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -119,11 +113,9 @@ RSpec.describe "Users", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get user_path(user)
+      subject { get user_path(user) }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -164,11 +156,9 @@ RSpec.describe "Users", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        get new_user_path
+      subject { get new_user_path }
 
-        expect(response).to redirect_to login_path
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 
@@ -244,11 +234,9 @@ RSpec.describe "Users", type: :request do
     end
 
     context "when the user is not logged in" do
-      it "redirects to the login page" do
-        post users_path, params: {}
+      subject { post users_path, params: {} }
 
-        expect(response).to redirect_to(login_path)
-      end
+      it_behaves_like "requires_authentication"
     end
   end
 

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,0 +1,5 @@
+module AuthenticationHelpers
+  def sign_in(user, password: user.password)
+    post login_path, params: { email_address: user.email_address, password: password }
+  end
+end

--- a/spec/support/shared_examples/requires_authentication.rb
+++ b/spec/support/shared_examples/requires_authentication.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples "requires_authentication" do
+  it "redirects to the login page" do
+    subject
+
+    expect(response).to redirect_to(login_path)
+  end
+end

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -1,30 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "Header", type: :system do
-  let(:user) { create(:user, password: "password55") }
+  let(:user) { create(:user) }
 
   def sign_in(user)
     visit login_path
 
     fill_in "email_address", with: user.email_address
-    fill_in "password", with: "password55"
+    fill_in "password", with: user.password
     click_button "ログイン"
 
     expect(page).to have_current_path(interactions_path)
-  end
-
-  describe "navigation tabs" do
-    before do
-      sign_in(user)
-    end
-
-    it "highlights the active tab for the current controller" do
-      expect(find("[data-tab-name='interactions']")[:class]).to include("border-blue-500")
-    end
-
-    it "does not highlight inactive tabs" do
-      expect(find("[data-tab-name='tasks']")[:class]).to include("border-transparent")
-    end
   end
 
   describe "user menu dropdown", :js do


### PR DESCRIPTION
## 概要

機能追加は行わず、既存のRSpecテストスイートの信頼性と保守性を改善するリファクタ。

---

## 変更内容

- spec/factories/users.rb, spec/factories/customers.rb のnameをsequence化し、同一Factoryレコード同士を比較するテストの偽陽性を修正
- spec/support/authentication_helpers.rb を新設し、20ファイル超に重複していた sign_in 定義とハードコードされたパスワード文字列を排除
- spec/support/shared_examples/requires_authentication.rb を新設し、未ログインリダイレクトの検証を共通化
- spec/helpers/application_helper_spec.rb, spec/system/header_spec.rb からTailwindクラスを直接検証するテストを削除
- spec/helpers/notices_helper_spec.rb, spec/helpers/task_assignments_helper_spec.rb, spec/helpers/users_helper_spec.rb を新規追加

---

## 確認済
- [x] bundle exec rspec が全てgreen
- [x] bundle exec rubocop が全てgreen
- [x] コード上に平文パスワード文字列が存在しないことを確認済み

---

Closes #171 