### PR TITLE
Fix remaining issues found in existing spec files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# Ignore RSpec example status persistence file (local run cache).
+/spec/examples.txt

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :customer do
     sequence(:name) { |n| "テスト顧客#{n}" }
-    email { "tanaka@example.com" }
-    phone { "090-1234-5678" }
+    sequence(:email) { |n| "tanaka#{n}@example.com" }
+    sequence(:phone) { |n| format("090-1234-%04d", n % 10000) }
     key_notes { "常連さん" }
   end
 end

--- a/spec/requests/interactions_search_spec.rb
+++ b/spec/requests/interactions_search_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "Interactions search", type: :request do
     sign_in(user)
 
     create(:interaction, customer: customer, user: user,
-          channel: "phone", completed: false, occurred_at: "2026-06-01 10:00")
+          channel: "phone", completed: false, occurred_at: 10.days.ago)
     create(:interaction, customer: other_customer, user: other_user,
-          channel: "email", completed: true, occurred_at: "2026-06-10 10:00")
+          channel: "email", completed: true, occurred_at: 1.day.ago)
   end
 
   describe "GET /interactions" do
@@ -58,14 +58,14 @@ RSpec.describe "Interactions search", type: :request do
     end
 
     it "filters by occurred_at range" do
-      get interactions_path, params: { q: { occurred_at_gteq: "2026-06-05" } }
+      get interactions_path, params: { q: { occurred_at_gteq: 5.days.ago.strftime("%Y-%m-%d") } }
       expect(response.body).to include(other_customer.name)
       expect(response.body).not_to include(customer.name)
     end
 
     it "filters by multiple conditions combined" do
       get interactions_path, params: {
-        q: { channel_eq: "phone", completed_eq: "false", occurred_at_lteq: "2026-06-05" }
+        q: { channel_eq: "phone", completed_eq: "false", occurred_at_lteq: 5.days.ago.strftime("%Y-%m-%d") }
       }
       expect(response.body).to include(customer.name)
       expect(response.body).not_to include(other_customer.name)

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe "Notices", type: :request do
       end
     end
 
-    context "when the usee is an admin and the creator" do
+    context "when the user is an admin and the creator" do
       before { sign_in(admin) }
 
       it "updates the restricted notice and redirects to the show page" do

--- a/spec/requests/task_assignments_spec.rb
+++ b/spec/requests/task_assignments_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe "Task Assignments", type: :request do
     }
   end
 
-  before { sign_in(task_creator) }
-
   describe "POST /tasks with assignee_ids" do
+    before { sign_in(task_creator) }
+
     context "with assignees" do
       it "creates task_assignments with status todo for each assignee" do
         expect {
@@ -57,6 +57,8 @@ RSpec.describe "Task Assignments", type: :request do
 
   describe "GET /tasks/:id" do
     let(:task) { create(:task, user: task_creator) }
+
+    before { sign_in(task_creator) }
 
     context "with assignees" do
       before do
@@ -117,8 +119,6 @@ RSpec.describe "Task Assignments", type: :request do
 
     context "when not signed in" do
       subject { patch task_assignment_path(assignment), params: { task_assignment: { status: "done" } } }
-
-      before { delete logout_path }
 
       it_behaves_like "requires_authentication"
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,9 +44,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -90,5 +89,4 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end


### PR DESCRIPTION
## 概要

既存のrequest spec / factory / spec_helper を見直したところ残っていた、
typo・factoryの固定値・テスト構造・ハードコード日付・設定に関する5件の不備を修正する。

---

## 変更内容

- `spec/requests/notices_spec.rb`: context説明文のtypo（usee → user）を修正
- `spec/factories/customers.rb`: email/phoneをnameと同様に連番化
- `spec/requests/task_assignments_spec.rb`: sign_inを必要なdescribeブロックにスコープし、未ログインcontextでの明示的なlogoutを撤廃
- `spec/requests/interactions_search_spec.rb`: ハードコードされた絶対日付を相対時間（days.ago）に置き換え
- `spec/spec_helper.rb`: コメントアウトされていたRSpec推奨設定（config.order = :randomなど）を有効化

---

## 確認済

- [x] `bundle exec rspec`が 全件green
- [x] ランダム順序実行を複数seedで確認し、順序依存の失敗がないことを確認
- [x] `bundle exec rubocop` で指摘が0件

---

Closes #173 