### PR TITLE
Expand System Spec coverage for core Stimulus controllers

### DIFF
--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,6 +73,14 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # The default selenium_chrome_headless window is narrower than Tailwind's
+  # `md` breakpoint (768px), which silently swaps desktop table/list markup
+  # for mobile card markup mid-test. Force a desktop-sized window so system
+  # specs consistently exercise the desktop layout.
+  config.before(:each, :js, type: :system) do
+    page.driver.browser.manage.window.resize_to(1280, 1024)
+  end
 end
 
 require 'capybara/rspec'

--- a/spec/system/clickable_row_spec.rb
+++ b/spec/system/clickable_row_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Clickable row navigation", type: :system do
+  let(:user) { create(:user) }
+  let!(:interaction) { create(:interaction, user: user) }
+
+  def sign_in(user)
+    visit login_path
+
+    fill_in "email_address", with: user.email_address
+    fill_in "password", with: user.password
+    click_button "ログイン"
+
+    expect(page).to have_current_path(interactions_path)
+  end
+
+  before do
+    sign_in(user)
+    visit interactions_path
+  end
+
+  describe "interaction row", :js do
+    it "navigates to the interaction detail page when clicking a non-link part of the row" do
+      row = find("[data-interaction-id='#{interaction.id}']")
+
+      row.find("td", text: "電話", exact_text: false).click
+
+      expect(page).to have_current_path(interaction_path(interaction))
+      expect(page).to have_content("応対履歴詳細")
+    end
+
+    it "does not navigate via the row click handler when clicking the customer link" do
+      row = find("[data-interaction-id='#{interaction.id}']")
+
+      row.click_link(interaction.customer.name)
+
+      expect(page).to have_current_path(customer_path(interaction.customer))
+    end
+  end
+end

--- a/spec/system/disclosure_spec.rb
+++ b/spec/system/disclosure_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Disclosure search panel", type: :system do
+  let(:user) { create(:user) }
+
+  def sign_in(user)
+    visit login_path
+
+    fill_in "email_address", with: user.email_address
+    fill_in "password", with: user.password
+    click_button "ログイン"
+
+    expect(page).to have_current_path(interactions_path)
+  end
+
+  before do
+    sign_in(user)
+    visit interactions_path
+  end
+
+  describe "search panel", :js do
+    it "is hidden by default" do
+      expect(page).to have_css("[data-disclosure-target='panel'].hidden", visible: :all)
+    end
+
+    it "is revealed when the search header is clicked" do
+      find("h2", text: "検索").click
+
+      expect(page).to have_css("[data-disclosure-target='panel']", visible: :visible)
+      expect(page).not_to have_css("[data-disclosure-target='panel'].hidden")
+    end
+
+    it "is hidden again when clicked a second time" do
+      find("h2", text: "検索").click
+      expect(page).not_to have_css("[data-disclosure-target='panel'].hidden")
+
+      find("h2", text: "検索").click
+      expect(page).to have_css("[data-disclosure-target='panel'].hidden", visible: :all)
+    end
+  end
+end

--- a/spec/system/interaction_flow_spec.rb
+++ b/spec/system/interaction_flow_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Interaction flow", type: :system do
+  let(:user) { create(:user) }
+  let!(:customer) { create(:customer) }
+
+  def sign_in(user)
+    visit login_path
+
+    fill_in "email_address", with: user.email_address
+    fill_in "password", with: user.password
+    click_button "ログイン"
+
+    expect(page).to have_current_path(interactions_path)
+  end
+
+  # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+  it "logs in, creates an interaction with an image, and comments on it", :js do
+    sign_in(user)
+
+    visit new_interaction_path
+
+    select customer.name, from: "顧客"
+    select "電話", from: "問合せ種別"
+
+    fill_in "応対日時", with: 1.hour.ago
+
+    fill_in "要望内容", with: "商品について問い合わせがありました"
+    fill_in "対応結果", with: "在庫を確認し折り返しました"
+    attach_file "画像", Rails.root.join("spec/fixtures/files/test.jpg")
+
+    click_button "登録"
+
+    expect(page).to have_content("応対履歴詳細")
+    expect(page).to have_content("商品について問い合わせがありました")
+    expect(page).to have_content("在庫を確認し折り返しました")
+    expect(page).to have_content("添付画像")
+
+    fill_in "コメントを入力してください...", with: "対応ありがとうございます"
+    click_button "コメントを投稿"
+
+    expect(page).to have_content("対応ありがとうございます")
+  end
+  # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+end

--- a/spec/system/related_toggle_mobile_spec.rb
+++ b/spec/system/related_toggle_mobile_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe "Related toggle list (mobile)", type: :system do
+  let(:user) { create(:user) }
+  let(:parent_task) { create(:task, user: user) }
+  let!(:related_task) { create(:task, :with_parent, user: user, parent: parent_task) }
+  let!(:lone_task) { create(:task, user: user) }
+
+  def sign_in(user)
+    visit login_path
+
+    fill_in "email_address", with: user.email_address
+    fill_in "password", with: user.password
+    click_button "ログイン"
+
+    expect(page).to have_current_path(interactions_path)
+  end
+
+  def mobile_card_group_for(task)
+    all("[data-controller='related-toggle']").find { |el| el.text.include?(task.title) }
+  end
+
+  before do
+    # The mobile card markup (app/views/tasks/_mobile_card.html.erb) and its
+    # related_toggle_controller.js are only rendered below Tailwind's `md`
+    # breakpoint (768px). The global system-spec hook forces a desktop-sized
+    # window, so we deliberately narrow it back down here to exercise the
+    # mobile-only code path.
+    page.driver.browser.manage.window.resize_to(375, 812)
+
+    sign_in(user)
+    visit tasks_path
+  end
+
+  describe "mobile task card with related tasks", :js do
+    it "shows a related toggle button for a task that has related tasks" do
+      group = mobile_card_group_for(parent_task)
+
+      expect(group).to have_button("関連")
+    end
+
+    it "does not show a related toggle button for a task without related tasks" do
+      group = mobile_card_group_for(lone_task)
+
+      expect(group).not_to have_button("関連")
+    end
+
+    it "reveals the related cards when the button is clicked" do
+      group = mobile_card_group_for(parent_task)
+
+      expect(group).to have_css("[data-related-toggle-target='list'].hidden", visible: :all)
+
+      group.find(".related-toggle-button").click
+
+      expect(group).to have_css("[data-related-toggle-target='list']", text: related_task.title, visible: :visible)
+    end
+
+    it "hides the related cards again when clicked a second time" do
+      group = mobile_card_group_for(parent_task)
+      button = group.find(".related-toggle-button")
+
+      button.click
+      expect(group).to have_css("[data-related-toggle-target='list']", text: related_task.title, visible: :visible)
+
+      button.click
+      expect(group).to have_css("[data-related-toggle-target='list'].hidden", text: related_task.title, visible: :all)
+    end
+  end
+end

--- a/spec/system/related_toggle_spec.rb
+++ b/spec/system/related_toggle_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Related toggle list", type: :system do
+  let(:user) { create(:user) }
+  let(:parent_task) { create(:task, user: user) }
+  let!(:related_task) { create(:task, :with_parent, user: user, parent: parent_task) }
+  let!(:lone_task) { create(:task, user: user) }
+
+  def sign_in(user)
+    visit login_path
+
+    fill_in "email_address", with: user.email_address
+    fill_in "password", with: user.password
+    click_button "ログイン"
+
+    expect(page).to have_current_path(interactions_path)
+  end
+
+  before do
+    sign_in(user)
+    visit tasks_path
+  end
+
+  describe "task row with related tasks", :js do
+    it "shows a related toggle button for a task that has related tasks" do
+      row = find(".related-list-trigger[data-task-id='#{parent_task.id}']")
+
+      expect(row).to have_button("関連")
+    end
+
+    it "does not show a related toggle button for a task without related tasks" do
+      row = find(".related-list-trigger[data-task-id='#{lone_task.id}']")
+
+      expect(row).not_to have_button("関連")
+    end
+
+    it "reveals the related rows when the button is clicked" do
+      expect(page).to have_css(".related-list-row.hidden", visible: :all)
+
+      find(".related-list-trigger[data-task-id='#{parent_task.id}'] .related-toggle-button").click
+
+      expect(page).to have_css(".related-list-row", text: related_task.title, visible: :visible)
+    end
+
+    it "hides the related rows again when clicked a second time" do
+      button = find(".related-list-trigger[data-task-id='#{parent_task.id}'] .related-toggle-button")
+
+      button.click
+      expect(page).to have_css(".related-list-row", text: related_task.title, visible: :visible)
+
+      button.click
+      expect(page).to have_css(".related-list-row.hidden", text: related_task.title, visible: :all)
+    end
+  end
+end

--- a/spec/system/task_assignment_auto_submit_spec.rb
+++ b/spec/system/task_assignment_auto_submit_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Task assignment auto-submit", type: :system do
+  let(:user) { create(:user) }
+  let(:task) { create(:task, user: user) }
+  let!(:task_assignment) { create(:task_assignment, task: task, user: user, status: "todo") }
+
+  def sign_in(user)
+    visit login_path
+
+    fill_in "email_address", with: user.email_address
+    fill_in "password", with: user.password
+    click_button "ログイン"
+
+    expect(page).to have_current_path(interactions_path)
+  end
+
+  before do
+    sign_in(user)
+    visit task_path(task)
+  end
+
+  describe "progress status select", :js do
+    it "submits the update as soon as the status is changed, without a submit button" do
+      select "進行中", from: "task_assignment_status"
+
+      expect(page).to have_current_path(task_path(task))
+      expect(page).to have_content("進捗状況を更新しました")
+      expect(task_assignment.reload.status).to eq("in_progress")
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Stimulusコントローラが関わる主要なUI操作と、応対履歴登録の一連のフローをSystem Specでカバーした。

---

## 変更内容

- `spec/system/disclosure_spec.rb`: 検索パネルの開閉(disclosureコントローラ)
- `spec/system/clickable_row_spec.rb`: 一覧行クリックでの画面遷移(clickableコントローラ)
- `spec/system/related_toggle_spec.rb`: 関連行の表示切替(デスクトップ、related-toggle-listコントローラ)
- `spec/system/related_toggle_mobile_spec.rb`: 関連行の表示切替(モバイルカード、related-toggleコントローラ)
- `spec/system/task_assignment_auto_submit_spec.rb`: タスク担当者のステータス変更時の自動送信(auto-submitコントローラ)
- `spec/system/interaction_flow_spec.rb`: ログイン〜応対履歴登録(画像添付)〜詳細確認〜コメント投稿までの一連の操作
- `spec/rails_helper.rb`: `:js`タグ付きSystem Spec実行時にウィンドウ幅を1280x1024へ固定するフックを追加(デフォルト幅がmdブレークポイント未満になり、デスクトップ/モバイルのマークアップが意図せず切り替わる問題への対応)
- `app/javascript/controllers/hello_controller.js`: どのビューからも参照されていなかったため削除

---

## 確認済
- [x] `bundle exec rspec` 全件green
- [x] `bundle exec rubocop`で 指摘無

Closes #175 