### PR TITLE
Improve landing and auth UI, fix collapsed card widths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,4 @@ end
 gem "tailwindcss-rails", "~> 4.6"
 gem "ransack"
 gem "pagy", "~> 8.6"
+gem "rails_icons"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
     highline (3.0.1)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
+    icons (0.9.0)
+      nokogiri (~> 1.16, >= 1.16.4)
     image_processing (2.0.2)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
@@ -297,6 +299,9 @@ GEM
     rails-i18n (8.1.0)
       i18n (>= 0.7, < 2)
       railties (>= 8.0.0, < 9)
+    rails_icons (1.9.0)
+      icons (~> 0.9.0)
+      rails (>= 7.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -528,6 +533,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.2)
   rails-i18n
+  rails_icons
   ransack
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase

--- a/app/assets/svg/icons/heroicons/mini/envelope.svg
+++ b/app/assets/svg/icons/heroicons/mini/envelope.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+  <path d="M3 4a2 2 0 0 0-2 2v1.161l8.441 4.221a1.25 1.25 0 0 0 1.118 0L19 7.162V6a2 2 0 0 0-2-2H3Z"/>
+  <path d="m19 8.839-7.77 3.885a2.75 2.75 0 0 1-2.46 0L1 8.839V14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8.839Z"/>
+</svg>

--- a/app/assets/svg/icons/heroicons/mini/lock-closed.svg
+++ b/app/assets/svg/icons/heroicons/mini/lock-closed.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+  <path fill-rule="evenodd" d="M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z" clip-rule="evenodd"/>
+</svg>

--- a/app/assets/svg/icons/heroicons/outline/arrow-right-on-rectangle.svg
+++ b/app/assets/svg/icons/heroicons/outline/arrow-right-on-rectangle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"/>
+</svg>

--- a/app/assets/svg/icons/heroicons/outline/user.svg
+++ b/app/assets/svg/icons/heroicons/outline/user.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"/>
+</svg>

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -11,7 +11,7 @@ class PasswordsController < ApplicationController
       PasswordsMailer.reset(user).deliver_later
     end
 
-    redirect_to new_session_path, notice: "Password reset instructions sent (if user with that email address exists)."
+    redirect_to login_path, notice: "Password reset instructions sent (if user with that email address exists)."
   end
 
   def edit
@@ -20,7 +20,7 @@ class PasswordsController < ApplicationController
   def update
     if @user.update(params.permit(:password, :password_confirmation))
       @user.sessions.destroy_all
-      redirect_to new_session_path, notice: "Password has been reset."
+      redirect_to login_path, notice: "Password has been reset."
     else
       redirect_to edit_password_path(params[:token]), alert: "Passwords did not match."
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,11 @@
 class SessionsController < ApplicationController
-  allow_unauthenticated_access only: %i[ new create ]
-  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
+  allow_unauthenticated_access only: %i[ new demo create ]
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to login_path, alert: "Try again later." }
 
   def new
+  end
+
+  def demo
   end
 
   def create

--- a/app/views/customers/edit.html.erb
+++ b/app/views/customers/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 詳細に戻る",
                 customer_path(@customer),

--- a/app/views/customers/index.html.erb
+++ b/app/views/customers/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 py-4">
+<div class="w-full max-w-7xl mx-auto px-4 py-4">
   <div class="flex justify-between items-center mb-4">
     <h1 class="text-base sm:text-xl font-bold">顧客一覧</h1>
 

--- a/app/views/customers/new.html.erb
+++ b/app/views/customers/new.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 一覧に戻る",
                 customers_path,

--- a/app/views/customers/show.html.erb
+++ b/app/views/customers/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 一覧に戻る",
                 customers_path,

--- a/app/views/interactions/edit.html.erb
+++ b/app/views/interactions/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 詳細に戻る",
                 interaction_path(@interaction),

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 py-4">
+<div class="w-full max-w-7xl mx-auto px-4 py-4">
   <div class="flex justify-between items-center mb-4">
     <h1 class="text-base sm:text-xl font-bold">応対履歴一覧</h1>
 

--- a/app/views/interactions/new.html.erb
+++ b/app/views/interactions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <% if @interaction.parent %>
       <%= link_to "← 元の応対履歴に戻る",

--- a/app/views/interactions/show.html.erb
+++ b/app/views/interactions/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 一覧に戻る",
                 interactions_path,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,10 +19,10 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-gray-50 [scrollbar-gutter:stable]">
-    <% if Current.user.present? %>
-      <%= render "shared/header" %>
+  <body class="min-h-screen flex flex-col bg-gray-50 [scrollbar-gutter:stable]">
+    <%= render "shared/header" %>
 
+    <% if Current.user.present? %>
       <nav class="bg-white border-gray-300"
           data-controller="tabs"
           data-tabs-current-value="<%= controller_name %>"
@@ -45,6 +45,10 @@
       <div class="max-w-7xl mx-auto px-4 py-2 bg-red-100 text-red-800 rounded text-xs sm:text-sm"><%= alert %></div>
     <% end %>
 
-    <%= yield %>
+    <div class="flex-1 flex flex-col">
+      <%= yield %>
+    </div>
+
+    <%= render "shared/footer" %>
   </body>
 </html>

--- a/app/views/notices/edit.html.erb
+++ b/app/views/notices/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 詳細に戻る",
                 notice_path(@notice),

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 py-4">
+<div class="w-full max-w-7xl mx-auto px-4 py-4">
   <div class="flex justify-between items-center mb-4">
     <h1 class="text-base sm:text-xl font-bold">お知らせ一覧</h1>
 

--- a/app/views/notices/new.html.erb
+++ b/app/views/notices/new.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <% if @notice.parent %>
       <%= link_to "← 元のお知らせに戻る",

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 一覧に戻る",
                 notices_path,

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,61 +1,60 @@
-<div class="min-h-screen bg-white">
-  <header class="flex items-center justify-between px-12 py-6">
-    <div class="flex items-center gap-3">
-      <div class="flex h-8 w-8 items-center justify-center rounded bg-blue-600 text-white">🏪</div>
-      <span class="font-bold text-gray-900">店舗業務管理システム</span>
-    </div>
-    <nav class="flex items-center gap-8 text-sm text-gray-600">
-      <a href="#" class="hover:text-blue-600">機能紹介</a>
-      <a href="#" class="hover:text-blue-600">導入メリット</a>
-      <%= link_to "ログイン", login_path, class: "hover:text-blue-600" %>
-      <%= link_to "デモを体験する", login_path, class: "rounded-lg bg-blue-600 px-5 py-2 text-white hover:bg-blue-700" %>
-    </nav>
-  </header>
-  <main class="px-12 pt-16">
-    <section class="mx-auto max-w-6xl text-center">
-      <h1 class="text-5xl font-bold leading-tight text-gray-900">
-        店舗業務を、<br>
-        もっとスマートに。
-      </h1>
-      <p class="mt-8 text-gray-600 leading-relaxed">
-        応対履歴、タスク、周知事項の共有まで。<br>
-        日々の業務を一元管理し、生産性を向上させます。
-      </p>
-      <div class="mt-16 grid grid-cols-3 gap-16">
-        <div>
-          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 text-3xl">💬</div>
-          <h3 class="mt-5 font-bold">応対履歴を一元管理</h3>
-          <p class="mt-3 text-sm text-gray-500">
-            顧客とのやり取りを<br>
-            簡単に確認できます。
-          </p>
-        </div>
-        <div>
-          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 text-3xl">📋</div>
-          <h3 class="mt-5 font-bold">タスクで業務を見える化</h3>
-          <p class="mt-3 text-sm text-gray-500">
-            タスクを整理し<br>
-            チームで共有できます。
-          </p>
-        </div>
-        <div>
-          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 text-3xl">📢</div>
-          <h3 class="mt-5 font-bold">お知らせで情報を共有</h3>
-          <p class="mt-3 text-sm text-gray-500">
-            従業員への周知事項を<br>
-            確実に共有できます。
-          </p>
-        </div>
+<div class="flex-1 flex flex-col bg-gray-50">
+  <main class="relative flex-1 flex flex-col justify-center overflow-hidden bg-gradient-to-b from-blue-50 to-gray-50">
+    <div class="pointer-events-none absolute -top-24 -right-24 h-72 w-72 rounded-full bg-blue-100 blur-3xl"></div>
+    <div class="pointer-events-none absolute -bottom-24 -left-24 h-72 w-72 rounded-full bg-blue-50 blur-3xl"></div>
+
+    <section class="relative">
+      <div class="relative max-w-5xl mx-auto px-4 py-4 sm:py-8 text-center w-full">
+        <h2 class="text-2xl font-bold leading-tight text-gray-900 sm:text-4xl">
+          店舗業務を、<br class="sm:hidden">
+          <span class="text-blue-500">もっとスマート</span>に。
+        </h2>
+        <p class="mt-4 text-sm text-gray-600 leading-relaxed sm:text-lg">
+          応対履歴・タスク・お知らせがシームレスにつながり、<br>
+          情報の整理と把握を容易にします。
+        </p>
       </div>
-      <div class="mt-20 h-64 rounded-t-3xl bg-blue-50 flex items-end justify-center overflow-hidden">
-        <div class="mb-8 text-center">
-          <div class="text-8xl">🏬</div>
-          <p class="mt-3 text-sm text-gray-400">店舗運営を支える管理システム</p>
+    </section>
+
+    <section class="relative mt-3 pb-6 sm:mt-6 sm:pb-10 md:mt-16">
+      <div class="max-w-5xl mx-auto px-4 text-center w-full">
+        <h3 class="text-xl font-bold text-gray-900 sm:text-3xl">業務の起点は、この3つ</h3>
+
+        <div class="mt-4 grid grid-cols-1 justify-center gap-3 text-center sm:mt-10 md:grid-cols-3 md:gap-6">
+          <div class="rounded-lg border border-gray-100 bg-white p-4 shadow transition-shadow hover:shadow-lg md:p-6">
+            <div class="flex flex-col items-center">
+              <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-blue-50 text-xl mx-auto md:h-14 md:w-14 md:text-2xl">💬</div>
+              <div>
+                <h4 class="font-bold text-sm sm:text-base mt-4">応対履歴</h4>
+                <p class="mt-1 text-xs sm:text-sm text-gray-500">
+                  電話・メール・SNSなどの応対履歴をタスクやお知らせに展開できます。
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="rounded-lg border border-gray-100 bg-white p-4 shadow transition-shadow hover:shadow-lg md:p-6">
+            <div class="flex flex-col items-center">
+              <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-blue-50 text-xl mx-auto md:h-14 md:w-14 md:text-2xl">📋</div>
+              <div>
+                <h4 class="font-bold text-sm sm:text-base mt-4">タスク</h4>
+                <p class="mt-1 text-xs sm:text-sm text-gray-500">
+                  担当者を割り当て、進捗状況をひと目で把握できます。
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="rounded-lg border border-gray-100 bg-white p-4 shadow transition-shadow hover:shadow-lg md:p-6">
+            <div class="flex flex-col items-center">
+              <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-blue-50 text-xl mx-auto md:h-14 md:w-14 md:text-2xl">📢</div>
+              <div>
+                <h4 class="font-bold text-sm sm:text-base mt-4">お知らせ</h4>
+                <p class="mt-1 text-xs sm:text-sm text-gray-500">
+                  全従業員への周知はもちろん、管理者のみの周知も分けて管理できます。
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="mt-8 flex justify-center gap-5">
-        <%= link_to "デモを体験する", login_path, class: "rounded-lg bg-blue-600 px-10 py-3 font-semibold text-white hover:bg-blue-700" %>
-        <%= link_to "ログインはこちら", login_path, class: "rounded-lg border border-blue-600 px-10 py-3 font-semibold text-blue-600 hover:bg-blue-50" %>
       </div>
     </section>
   </main>

--- a/app/views/passwords/_edit_form.html.erb
+++ b/app/views/passwords/_edit_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with url: password_path(params[:token]), method: :put, class: "mt-8 space-y-5" do |form| %>
+  <div>
+    <%= form.label :password, "新しいパスワード", class: "block mb-2 text-xs sm:text-sm font-medium text-gray-700" %>
+    <div class="relative">
+      <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
+        <%= icon "lock-closed", variant: :mini, class: "h-4 w-4" %>
+      </span>
+      <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "新しいパスワードを入力", maxlength: 72, class: "w-full rounded-lg border border-gray-300 pl-9 pr-4 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
+    </div>
+  </div>
+  <div>
+    <%= form.label :password_confirmation, "新しいパスワード(確認)", class: "block mb-2 text-xs sm:text-sm font-medium text-gray-700" %>
+    <div class="relative">
+      <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
+        <%= icon "lock-closed", variant: :mini, class: "h-4 w-4" %>
+      </span>
+      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "新しいパスワードを再入力", maxlength: 72, class: "w-full rounded-lg border border-gray-300 pl-9 pr-4 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
+    </div>
+  </div>
+  <%= form.submit "パスワードを更新", class: "w-full rounded-lg bg-blue-500 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-600" %>
+<% end %>

--- a/app/views/passwords/_new_form.html.erb
+++ b/app/views/passwords/_new_form.html.erb
@@ -1,0 +1,12 @@
+<%= form_with url: passwords_path, class: "mt-8 space-y-5" do |form| %>
+  <div>
+    <%= form.label :email_address, "メールアドレス", class: "block mb-2 text-xs sm:text-sm font-medium text-gray-700" %>
+    <div class="relative">
+      <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
+        <%= icon "envelope", variant: :mini, class: "h-4 w-4" %>
+      </span>
+      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "メールアドレスを入力", value: params[:email_address], class: "w-full rounded-lg border border-gray-300 pl-9 pr-4 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
+    </div>
+  </div>
+  <%= form.submit "再設定メールを送信", class: "w-full rounded-lg bg-blue-500 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-600" %>
+<% end %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,9 +1,21 @@
-<h1>Update your password</h1>
+<div class="flex-1 flex flex-col">
+  <main class="relative flex-1 flex flex-col justify-center overflow-hidden bg-gradient-to-b from-blue-50 to-gray-50">
+    <div class="pointer-events-none absolute -top-24 -right-24 h-72 w-72 rounded-full bg-blue-100 blur-3xl"></div>
+    <div class="pointer-events-none absolute -bottom-24 -left-24 h-72 w-72 rounded-full bg-blue-50 blur-3xl"></div>
 
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
+    <div class="relative w-full max-w-md mx-auto px-4 py-8">
+      <div class="rounded-2xl bg-white px-6 py-10 shadow-xl shadow-blue-100/50 sm:px-8 sm:py-12">
+        <div class="mb-8 text-center">
+          <h1 class="text-xl font-bold text-gray-900 sm:text-2xl">新しいパスワードを設定</h1>
+          <p class="mt-2 text-xs text-gray-500 sm:text-sm">新しいパスワードを入力してください</p>
+        </div>
 
-<%= form_with url: password_path(params[:token]), method: :put do |form| %>
-  <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72 %><br>
-  <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72 %><br>
-  <%= form.submit "Save" %>
-<% end %>
+        <%= render "edit_form" %>
+
+        <p class="mt-6 text-center text-xs sm:text-sm">
+          <%= link_to "← ログイン画面に戻る", login_path, class: "text-blue-600 hover:underline" %>
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,8 +1,21 @@
-<h1>Forgot your password?</h1>
+<div class="flex-1 flex flex-col">
+  <main class="relative flex-1 flex flex-col justify-center overflow-hidden bg-gradient-to-b from-blue-50 to-gray-50">
+    <div class="pointer-events-none absolute -top-24 -right-24 h-72 w-72 rounded-full bg-blue-100 blur-3xl"></div>
+    <div class="pointer-events-none absolute -bottom-24 -left-24 h-72 w-72 rounded-full bg-blue-50 blur-3xl"></div>
 
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
+    <div class="relative w-full max-w-md mx-auto px-4 py-8">
+      <div class="rounded-2xl bg-white px-6 py-10 shadow-xl shadow-blue-100/50 sm:px-8 sm:py-12">
+        <div class="mb-8 text-center">
+          <h1 class="text-xl font-bold text-gray-900 sm:text-2xl">パスワードをお忘れですか？</h1>
+          <p class="mt-2 text-xs text-gray-500 sm:text-sm">登録済みのメールアドレスを入力してください</p>
+        </div>
 
-<%= form_with url: passwords_path do |form| %>
-  <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
-  <%= form.submit "Email reset instructions" %>
-<% end %>
+        <%= render "new_form" %>
+
+        <p class="mt-6 text-center text-xs sm:text-sm">
+          <%= link_to "← ログイン画面に戻る", login_path, class: "text-blue-600 hover:underline" %>
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/sessions/_demo_form.html.erb
+++ b/app/views/sessions/_demo_form.html.erb
@@ -1,0 +1,31 @@
+<p class="mb-6 rounded-lg bg-blue-50 px-3 py-2 text-xs text-blue-700 text-center sm:text-sm">
+  デモ用アカウントを自動入力しました。<br>
+  そのままログインできます。
+</p>
+
+<%= form_with url: login_path, class: "mt-8 space-y-5" do |f| %>
+  <div>
+    <%= f.label :email_address, "メールアドレス", class: "block mb-2 text-xs sm:text-sm font-medium text-gray-700" %>
+    <div class="relative">
+      <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
+        <%= icon "envelope", variant: :mini, class: "h-4 w-4" %>
+      </span>
+      <%= f.email_field :email_address, value: "manager@example.com", placeholder: "メールアドレスを入力", class: "w-full rounded-lg border border-gray-300 pl-9 pr-4 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
+    </div>
+  </div>
+  <div>
+    <%= f.label :password, "パスワード", class: "block mb-2 text-xs sm:text-sm font-medium text-gray-700" %>
+    <div class="relative">
+      <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
+        <%= icon "lock-closed", variant: :mini, class: "h-4 w-4" %>
+      </span>
+      <%= f.password_field :password, value: "Admin2026!", placeholder: "パスワードを入力", class: "w-full rounded-lg border border-gray-300 pl-9 pr-4 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
+    </div>
+  </div>
+  <div class="flex justify-end text-xs sm:text-sm">
+    <%= link_to "パスワードを忘れた方", new_password_path, class: "text-blue-600 hover:underline" %>
+  </div>
+  <%= f.submit "ログイン", class: "w-full rounded-lg bg-blue-500 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-600" %>
+<% end %>
+
+<p class="mt-4 text-center text-xs text-gray-400">※ デモデータは予告なくリセットされます。</p>

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_with url: login_path, class: "mt-8 space-y-5" do |f| %>
+  <div>
+    <%= f.label :email_address, "メールアドレス", class: "block mb-2 text-xs sm:text-sm font-medium text-gray-700" %>
+    <div class="relative">
+      <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
+        <%= icon "envelope", variant: :mini, class: "h-4 w-4" %>
+      </span>
+      <%= f.email_field :email_address, placeholder: "メールアドレスを入力", class: "w-full rounded-lg border border-gray-300 pl-9 pr-4 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
+    </div>
+  </div>
+  <div>
+    <%= f.label :password, "パスワード", class: "block mb-2 text-xs sm:text-sm font-medium text-gray-700" %>
+    <div class="relative">
+      <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-400">
+        <%= icon "lock-closed", variant: :mini, class: "h-4 w-4" %>
+      </span>
+      <%= f.password_field :password, placeholder: "パスワードを入力", class: "w-full rounded-lg border border-gray-300 pl-9 pr-4 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
+    </div>
+  </div>
+  <div class="flex justify-end text-xs sm:text-sm">
+    <%= link_to "パスワードを忘れた方", new_password_path, class: "text-blue-600 hover:underline" %>
+  </div>
+  <%= f.submit "ログイン", class: "w-full rounded-lg bg-blue-500 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-600" %>
+<% end %>

--- a/app/views/sessions/demo.html.erb
+++ b/app/views/sessions/demo.html.erb
@@ -10,7 +10,7 @@
           <p class="mt-2 text-xs text-gray-500 sm:text-sm">アカウント情報を入力してください</p>
         </div>
 
-        <%= render "form" %>
+        <%= render "demo_form" %>
       </div>
     </div>
   </main>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,5 @@
+<footer class="border-t border-gray-200 bg-white">
+  <div class="max-w-7xl mx-auto px-4 py-6 text-center text-xs text-gray-400">
+    &copy; <%= Date.current.year %> 店舗業務管理システム
+  </div>
+</footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,13 +1,20 @@
 <header class="bg-white shadow sticky top-0 z-20">
   <div class="max-w-7xl mx-auto px-3 sm:px-4">
-    <div class="flex justify-between items-center gap-2 pt-3 pb-2 sm:pt-5 sm:pb-3">
+    <div class="flex justify-between items-center gap-2 h-14 sm:h-17">
       <h1 class="text-base sm:text-xl font-bold truncate min-w-0">
         <%= link_to "店舗業務管理システム", root_path, class: "hover:text-blue-600" %>
       </h1>
 
-      <div class="shrink-0">
-        <%= render "shared/user_menu" %>
-      </div>
+      <% if Current.user.present? %>
+        <div class="shrink-0">
+          <%= render "shared/user_menu" %>
+        </div>
+      <% elsif !current_page?(login_path) && !current_page?(demo_login_path) %>
+        <div class="shrink-0 flex items-center gap-4">
+          <%= link_to "ログイン", login_path, class: "text-xs sm:text-sm font-semibold text-gray-600 hover:text-blue-600" %>
+          <%= link_to "デモを試す", demo_login_path, class: "px-3 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </header>

--- a/app/views/shared/_user_menu.html.erb
+++ b/app/views/shared/_user_menu.html.erb
@@ -4,34 +4,42 @@
           class="flex items-center gap-2 rounded focus:outline-none focus:ring-2 focus:ring-blue-400"
           aria-haspopup="true"
           aria-expanded="false">
-    <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-    </svg>
+    <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-50 text-sm font-semibold text-blue-600 sm:h-9 sm:w-9">
+      <%= Current.user.name.first %>
+    </span>
 
     <span class="hidden sm:inline text-sm text-gray-800"><%= Current.user.name %></span>
   </button>
 
   <div data-dropdown-target="panel"
-       class="hidden absolute right-0 mt-2 w-56 bg-white border border-gray-200 rounded shadow-lg text-sm z-30">
-    <div class="px-4 py-3 border-b">
-      <div class="font-semibold"><%= Current.user.name %></div>
-
-      <div class="text-xs text-gray-500"><%= Current.user.email_address %></div>
+       class="hidden absolute right-0 mt-2 w-60 overflow-hidden rounded-xl border border-gray-100 bg-white text-sm shadow-xl shadow-gray-200/60 z-30">
+    <div class="flex items-center gap-3 px-4 py-3 bg-gray-50">
+      <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-600">
+        <%= Current.user.name.first %>
+      </span>
+      <div class="min-w-0">
+        <div class="truncate font-semibold text-gray-900"><%= Current.user.name %></div>
+        <div class="truncate text-xs text-gray-500"><%= Current.user.email_address %></div>
+      </div>
     </div>
 
     <div class="py-1">
-      <%= link_to "プロフィール",
-                  user_path(Current.user),
-                  class: "block px-4 py-2 hover:bg-gray-50" %>
+      <%= link_to user_path(Current.user),
+                  class: "flex items-center gap-2 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-50" do %>
+        <%= icon "user", variant: :outline, class: "h-4 w-4 text-gray-400" %>
+        プロフィール
+      <% end %>
     </div>
 
-    <div class="border-t py-1">
-      <%= button_to "ログアウト",
-                    logout_path,
+    <div class="border-t border-gray-100 py-1">
+      <%= button_to logout_path,
                     method: :delete,
                     form_class: "block",
                     data: { turbo_confirm: "ログアウトしますか？" },
-                    class: "w-full text-left px-4 py-2 text-red-600 hover:bg-red-50 cursor-pointer" %>
+                    class: "flex w-full items-center gap-2 px-4 py-2 text-left text-red-600 transition-colors hover:bg-red-50 cursor-pointer" do %>
+        <%= icon "arrow-right-on-rectangle", variant: :outline, class: "h-4 w-4 text-red-400" %>
+        ログアウト
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 詳細に戻る",
                 task_path(@task),

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 py-4">
+<div class="w-full max-w-7xl mx-auto px-4 py-4">
   <div class="flex justify-between items-center mb-4">
     <h1 class="text-base sm:text-xl font-bold">タスク一覧</h1>
 

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <% if @task.parent %>
       <%= link_to "← 元のタスクに戻る",

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 一覧に戻る",
                 tasks_path,

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 詳細に戻る",
                 user_path(@user),

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 py-4">
+<div class="w-full max-w-7xl mx-auto px-4 py-4">
   <div class="flex justify-between items-center mb-4">
     <h1 class="text-base sm:text-xl font-bold">従業員一覧</h1>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 一覧に戻る",
                 users_path,

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 py-4">
+<div class="w-full max-w-4xl mx-auto px-4 py-4">
   <div class="mb-4">
     <%= link_to "← 一覧に戻る", users_path, class: "text-blue-600 hover:underline text-xs sm:text-sm" %>
   </div>

--- a/config/initializers/rails_icons.rb
+++ b/config/initializers/rails_icons.rb
@@ -1,0 +1,3 @@
+RailsIcons.configure do |config|
+  config.default_library = "heroicons"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root "pages#home"
 
   get "/login", to: "sessions#new"
+  get "/login/demo", to: "sessions#demo", as: :demo_login
   post "/login", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"
 


### PR DESCRIPTION
## 概要

トップページ(LP)とログイン・パスワード再設定・ヘッダー周りのUIを刷新した。
あわせて、フッター追加によるレイアウト変更で発生していた既存画面の幅崩れと、ルート整理時に直し漏れていたパスヘルパー参照を修正した。

---

## 変更内容

- トップページ(`pages/home.html.erb`)のヒーロー/ナビ/CTAをグラデーション背景・カード型の機能紹介セクションに作り替え
- `rails_icons`(Heroicons)を導入し、ヘッダー・ログイン・パスワード画面の手書きSVGをインラインSVGヘルパー呼び出しに置き換え
- `application.html.erb`にフッターを常時描画するよう追加し、`body`を`min-h-screen flex flex-col`にしてsticky footer構成にした
- 上記のflex化で幅が縮んでいた`customers`/`interactions`/`notices`/`tasks`/`users`の`index`/`new`/`edit`/`show`(計20ファイル)に`w-full`を追加し、`max-w-4xl`/`max-w-7xl`本来の幅に復元
- ログイン画面(`sessions/new.html.erb`)を再構築し、デモログイン専用ルート(`/login/demo`)・アクション(`SessionsController#demo`)・ビューを追加
- `SessionsController`と`PasswordsController`に残っていた`new_session_path`(存在しないルートヘルパー)への参照を`login_path`に修正
- パスワード再設定画面(`passwords/new.html.erb` `passwords/edit.html.erb`)をログイン画面と統一感のあるデザインに作り替え、フォームを`_new_form.html.erb`/`_edit_form.html.erb`にパーシャル化
- ヘッダー(`_header.html.erb`)のログイン/デモ導線と、ユーザーメニュー(`_user_menu.html.erb`)のドロップダウンをアバター付きデザインに刷新

---

## 確認済

- [x] `bundle exec rspec` 全件green
- [x] `bundle exec rubocop`で 指摘無
- [x] `new_session_path`など存在しないパスヘルパーへの参照が残っていないことを確認

---

Closes #177 