### PR TITLE
Fix Access Boundary Leaks in Demo and Restricted Data

### DIFF
--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -29,8 +29,10 @@ class InteractionsController < ApplicationController
   end
 
   def create
+    @parent_interaction = Interaction.accessible.find_by(id: params[:parent_id])
     @interaction = Current.user.interactions.build(interaction_params)
-    @parent_interaction = @interaction.parent
+    @interaction.parent = @parent_interaction
+    @interaction.customer = @parent_interaction ? @parent_interaction.customer : accessible_customer
 
     if @interaction.save
       redirect_to @interaction, notice: "応対履歴を登録しました"
@@ -66,9 +68,16 @@ class InteractionsController < ApplicationController
 
   def interaction_params
     params.require(:interaction).permit(
-      :customer_id, :channel, :occurred_at,
-      :request_content, :response_result, :completed, :parent_id,
+      :channel,
+      :occurred_at,
+      :request_content,
+      :response_result,
+      :completed,
       images: []
     )
+  end
+
+  def accessible_customer
+    Customer.accessible.find_by(id: params[:customer_id])
   end
 end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -8,7 +8,7 @@ class NoticesController < ApplicationController
 
 
   def index
-    @q = visible_notices.ransack(params[:q], auth_object: :admin)
+    @q = visible_notices.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
     @pagy, @notices = pagy(
       @q.result
         .preload(
@@ -22,20 +22,21 @@ class NoticesController < ApplicationController
   end
 
   def new
-    @parent_notice = Notice.accessible.find_by(id: params[:parent_id])
+    @parent_notice = Notice.accessible.visible.find_by(id: params[:parent_id])
     @notice = Notice.new(parent: @parent_notice)
   end
 
   def create
+    @parent_notice = Notice.accessible.visible.find_by(id: params[:parent_id])
     @notice = Current.user.notices.build(notice_params)
-    @parent_notice = @notice.parent
+    @notice.parent = @parent_notice
 
     if @notice.save
       if params[:interaction_id].present?
         @notice.interactions << Interaction.accessible.find(params[:interaction_id])
       end
 
-      @notice.tasks << Task.accessible.find(params[:task_id]) if params[:task_id].present?
+      @notice.tasks << Task.accessible.visible.find(params[:task_id]) if params[:task_id].present?
 
       redirect_to @notice, notice: "お知らせを更新しました"
     else
@@ -44,7 +45,7 @@ class NoticesController < ApplicationController
   end
 
   def show
-    @timeline = @notice.root.rooted_notices.order(:created_at)
+    @timeline = @notice.root.rooted_notices.visible.order(:created_at)
   end
 
   def edit
@@ -69,7 +70,7 @@ class NoticesController < ApplicationController
   end
 
   def visible_notices
-    Current.user.admin? ? Notice.accessible : Notice.accessible.where(restricted: false)
+    Notice.accessible.visible
   end
 
   def notice_params
@@ -79,8 +80,6 @@ class NoticesController < ApplicationController
       level
       start_at
       end_at
-      parent_id
-      images: []
     ]
 
     permitted << :restricted if Current.user.admin?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
   end
 
   def demo
-    demo_user = User.unscoped.find_by!(email_address: User::DEMO_LOGIN_EMAIL, demo: true)
+    demo_user = User.find_by!(email_address: User::DEMO_LOGIN_EMAIL, demo: true)
     start_new_session_for demo_user
     redirect_to interactions_path
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,7 @@ class TasksController < ApplicationController
   before_action -> { authorize_edit!(@task) }, only: [ :edit, :update ]
 
   def index
-    @q = visible_tasks.ransack(params[:q], auth_object: :admin)
+    @q = visible_tasks.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
     @pagy, @tasks = pagy(
       @q.result
         .preload(
@@ -22,14 +22,15 @@ class TasksController < ApplicationController
   end
 
   def new
-    @parent_task = Task.accessible.find_by(id: params[:parent_id])
+    @parent_task = Task.accessible.visible.find_by(id: params[:parent_id])
     @task = Task.new(parent: @parent_task)
     @form = TaskForm.new(task: @task)
   end
 
   def create
+    @parent_task = Task.accessible.visible.find_by(id: params[:parent_id])
     @task = Current.user.tasks.build(task_params)
-    @parent_task = @task.parent
+    @task.parent = @parent_task
 
     @form = TaskForm.new(
       task:           @task,
@@ -46,7 +47,7 @@ class TasksController < ApplicationController
   end
 
   def show
-    @timeline = @task.root.rooted_tasks.order(:created_at)
+    @timeline = @task.root.rooted_tasks.visible.order(:created_at)
   end
 
   def edit
@@ -74,17 +75,18 @@ class TasksController < ApplicationController
   end
 
   def visible_tasks
-    Current.user.admin? ? Task.accessible : Task.accessible.where(restricted: false)
+    Task.accessible.visible
   end
 
   def task_params
     permitted = [
       :title,
       :description,
-      :due_at,
-      :parent_id
+      :due_at
     ]
+
     permitted << :restricted if Current.user.admin?
+
     params.require(:task).permit(*permitted, images: [])
   end
 end

--- a/app/forms/task_form.rb
+++ b/app/forms/task_form.rb
@@ -24,7 +24,7 @@ class TaskForm
     ActiveRecord::Base.transaction do
       task.save!
       task.interactions << Interaction.accessible.find(interaction_id) if interaction_id.present?
-      task.notices      << Notice.accessible.find(notice_id)           if notice_id.present?
+      task.notices      << Notice.accessible.visible.find(notice_id)   if notice_id.present?
 
       assignee_ids.each do |user_id|
         task.task_assignments.create!(user: User.accessible.find(user_id), status: :todo)

--- a/app/models/concerns/restrictable.rb
+++ b/app/models/concerns/restrictable.rb
@@ -1,0 +1,7 @@
+module Restrictable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :visible, -> { Current.user&.admin? ? all : where(restricted: false) }
+  end
+end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,6 +1,7 @@
 class Notice < ApplicationRecord
   include Rootable
   include DemoScoped
+  include Restrictable
   rootable order_column: :created_at
 
   belongs_to :user

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,7 @@
 class Task < ApplicationRecord
   include Rootable
   include DemoScoped
+  include Restrictable
   rootable order_column: :created_at
 
   belongs_to :user

--- a/app/views/interactions/_form.html.erb
+++ b/app/views/interactions/_form.html.erb
@@ -11,21 +11,19 @@
     </div>
   <% end %>
 
-  <%= f.hidden_field :parent_id if interaction.parent_id.present? %>
+  <%= hidden_field_tag :parent_id, interaction.parent_id if interaction.parent_id.present? %>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
     <div>
-      <%= f.label :customer_id, "顧客", class: "block text-xs sm:text-sm text-gray-700 mb-1" %>
+      <%= label_tag :customer_id, "顧客", class: "block text-xs sm:text-sm text-gray-700 mb-1" %>
 
       <% if interaction.new_record? && @parent_interaction.nil? %>
-        <%= f.collection_select :customer_id,
-                                Customer.accessible.order(:name),
-                                :id,
-                                :name,
-                                { prompt: "選択してください" },
-                                { class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" } %>
+        <%= select_tag :customer_id,
+                       options_from_collection_for_select(Customer.accessible.order(:name), :id, :name, interaction.customer_id),
+                       prompt: "選択してください",
+                       class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" %>
       <% else %>
-        <%= f.hidden_field :customer_id %>
+        <%= hidden_field_tag :customer_id, interaction.customer_id %>
 
         <div class="w-full border border-gray-200 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm bg-gray-100 text-gray-600 flex items-center">
           <%= interaction.customer.name %>

--- a/app/views/interactions/_related_notices.html.erb
+++ b/app/views/interactions/_related_notices.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm ">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連お知らせ</h2>
 
-  <% notices = interaction.notices %>
+  <% notices = interaction.notices.visible %>
 
   <% if notices.any? %>
     <ul class="space-y-2">

--- a/app/views/interactions/_related_tasks.html.erb
+++ b/app/views/interactions/_related_tasks.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連タスク</h2>
 
-  <% tasks = interaction.tasks %>
+  <% tasks = interaction.tasks.visible %>
 
   <% if tasks.any? %>
     <ul class="space-y-2">

--- a/app/views/notices/_form.html.erb
+++ b/app/views/notices/_form.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-  <%= f.hidden_field :parent_id %>
+  <%= hidden_field_tag :parent_id, notice.parent_id %>
   <%= hidden_field_tag :interaction_id, params[:interaction_id] if params[:interaction_id].present? %>
   <%= hidden_field_tag :task_id, params[:task_id] if params[:task_id].present? %>
 

--- a/app/views/notices/_list_desktop.html.erb
+++ b/app/views/notices/_list_desktop.html.erb
@@ -12,7 +12,7 @@
 
     <tbody data-controller="related-toggle-list">
       <% notices.each do |notice| %>
-        <% related_notices = notice.related_notices %>
+        <% related_notices = notice.related_notices.reject { |n| n.restricted? && !Current.user.admin? } %>
         <tr class="h-12 hover:bg-gray-100 cursor-pointer"
             data-notice-id="<%= notice.id %>"
             data-controller="clickable"

--- a/app/views/notices/_list_mobile.html.erb
+++ b/app/views/notices/_list_mobile.html.erb
@@ -8,7 +8,7 @@
 
   <div class="space-y-2">
     <% notices.each do |notice| %>
-      <% related_notices = notice.related_notices %>
+      <% related_notices = notice.related_notices.reject { |n| n.restricted? && !Current.user.admin? } %>
 
       <div class="w-full" data-controller="related-toggle">
 

--- a/app/views/notices/_related_tasks.html.erb
+++ b/app/views/notices/_related_tasks.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連タスク</h2>
 
-  <% tasks = notice.tasks %>
+  <% tasks = notice.tasks.visible %>
 
   <% if tasks.any? %>
     <ul class="space-y-2">

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-  <%= f.hidden_field :parent_id %>
+  <%= hidden_field_tag :parent_id, task.parent_id %>
   <%= hidden_field_tag :interaction_id, params[:interaction_id] if params[:interaction_id].present? %>
   <%= hidden_field_tag :notice_id, params[:notice_id] if params[:notice_id].present? %>
 

--- a/app/views/tasks/_list_desktop.html.erb
+++ b/app/views/tasks/_list_desktop.html.erb
@@ -8,7 +8,7 @@
 
   <div data-controller="related-toggle-list">
     <% tasks.each do |task| %>
-      <% related_tasks = task.related_tasks %>
+      <% related_tasks = task.related_tasks.reject { |t| t.restricted? && !Current.user.admin? } %>
       <div class="group related-list-trigger relative flex items-center min-h-12 hover:bg-gray-100 cursor-pointer"
           data-task-id="<%= task.id %>"
           data-controller="clickable"

--- a/app/views/tasks/_list_mobile.html.erb
+++ b/app/views/tasks/_list_mobile.html.erb
@@ -8,7 +8,7 @@
 
   <div class="space-y-2">
     <% tasks.each do |task| %>
-      <% related_tasks = task.related_tasks %>
+      <% related_tasks = task.related_tasks.reject { |t| t.restricted? && !Current.user.admin? } %>
 
       <div class="w-full" data-controller="related-toggle">
 

--- a/app/views/tasks/_related_notices.html.erb
+++ b/app/views/tasks/_related_notices.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連お知らせ</h2>
 
-  <% notices = task.notices %>
+  <% notices = task.notices.visible %>
 
   <% if notices.any? %>
     <ul class="space-y-2">

--- a/spec/requests/demo_isolation_spec.rb
+++ b/spec/requests/demo_isolation_spec.rb
@@ -62,5 +62,65 @@ RSpec.describe "Demo data isolation", type: :request do
     ensure
       Current.demo = false
     end
+
+    context "when signed in as the demo user" do
+      before { sign_in_demo_user }
+
+      it "blocks a demo interaction from being attached to a production customer via customer_id" do
+        post interactions_path, params: { interaction: attributes_for(:interaction), customer_id: production_customer.id }
+
+        expect(Interaction.unscoped.where(customer_id: production_customer.id)).to be_none
+      end
+
+      it "blocks a demo interaction from being attached to a production interaction via parent_id" do
+        production_parent_interaction = create(:interaction, customer: production_customer)
+
+        post interactions_path, params: { interaction: attributes_for(:interaction), parent_id: production_parent_interaction.id }
+
+        expect(Interaction.unscoped.where(parent_id: production_parent_interaction.id)).to be_none
+      end
+
+      it "blocks a demo notice from being attached to a production notice via parent_id" do
+        production_parent_notice = create(:notice, user: production_user)
+
+        post notices_path, params: { notice: attributes_for(:notice), parent_id: production_parent_notice.id }
+
+        expect(Notice.unscoped.where(parent_id: production_parent_notice.id)).to be_none
+      end
+
+      it "blocks a demo task from being attached to a production task via parent_id" do
+        production_parent_task = create(:task, user: production_user)
+
+        post tasks_path, params: {
+          task: attributes_for(:task),
+          parent_id: production_parent_task.id,
+          assignee_ids: [ User.find_by!(email_address: User::DEMO_LOGIN_EMAIL).id ]
+        }
+
+        expect(Task.unscoped.where(parent_id: production_parent_task.id)).to be_none
+      end
+    end
+  end
+
+  describe "record update" do
+    let(:demo_user) { User.find_by!(email_address: User::DEMO_LOGIN_EMAIL) }
+
+    before { sign_in_demo_user }
+
+    def update_params(customer_id:, parent_id:)
+      { interaction: attributes_for(:interaction), customer_id: customer_id, parent_id: parent_id }
+    end
+
+    it "does not let customer_id or parent_id be moved across the boundary via update" do
+      demo_interaction = create(:interaction, customer: demo_customer, user: demo_user, demo: true)
+      other_customer = create(:customer, demo: true)
+      production_parent_interaction = create(:interaction, customer: production_customer)
+
+      patch interaction_path(demo_interaction), params: update_params(customer_id: other_customer.id, parent_id: production_parent_interaction.id)
+
+      demo_interaction.reload
+      expect(demo_interaction.customer_id).to eq(demo_customer.id)
+      expect(demo_interaction.parent_id).not_to eq(production_parent_interaction.id)
+    end
   end
 end

--- a/spec/requests/interactions_parent_child_spec.rb
+++ b/spec/requests/interactions_parent_child_spec.rb
@@ -176,9 +176,9 @@ RSpec.describe "Interactions parent-child", type: :request do
           response_result: "子の応対履歴の詳細",
           completed: false,
           channel: "phone",
-          occurred_at: 1.hour.ago,
-          parent_id: parent.id
-        }
+          occurred_at: 1.hour.ago
+        },
+        parent_id: parent.id
       }
     end
 

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Interactions", type: :request do
       before { sign_in(user) }
 
       let(:valid_params) do
-        { interaction: attributes_for(:interaction).merge(customer_id: customer.id) }
+        { interaction: attributes_for(:interaction), customer_id: customer.id }
       end
 
       it "creates an Interaction with valid params" do
@@ -175,15 +175,13 @@ RSpec.describe "Interactions", type: :request do
   describe "POST /interactions (with images)" do
     subject(:perform_request) do
       post interactions_path, params: {
-        interaction: interaction_params
+        interaction: interaction_params,
+        customer_id: customer.id
       }
     end
 
     let(:interaction_params) do
-      attributes_for(
-        :interaction,
-        customer_id: customer.id
-      ).merge(images: images)
+      attributes_for(:interaction).merge(images: images)
     end
 
     before { sign_in(user) }

--- a/spec/requests/notices_parent_child_spec.rb
+++ b/spec/requests/notices_parent_child_spec.rb
@@ -174,9 +174,9 @@ RSpec.describe "Notices parent-child", type: :request do
           content: "子の詳細",
           level: "normal",
           start_at: 1.hour.ago,
-          end_at: 1.week.from_now,
-          parent_id: parent.id
-        }
+          end_at: 1.week.from_now
+        },
+        parent_id: parent.id
       }
     end
 

--- a/spec/requests/restricted_visibility_spec.rb
+++ b/spec/requests/restricted_visibility_spec.rb
@@ -1,0 +1,138 @@
+require "rails_helper"
+
+RSpec.describe "Restricted content visibility", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:user)  { create(:user) }
+
+  before { sign_in(user) }
+
+  describe "notice timeline (GET /notices/:id)" do
+    it "does not expose a restricted sibling notice's content" do
+      root = create(:notice, user: admin, restricted: false)
+      create(:notice, user: admin, restricted: true, parent: root, content: "来月の値上げ幅について")
+
+      get notice_path(root)
+
+      expect(response.body).not_to include("来月の値上げ幅について")
+    end
+  end
+
+  describe "task timeline (GET /tasks/:id)" do
+    it "does not expose a restricted sibling task's description" do
+      root = create(:task, user: admin, restricted: false)
+      create(:task, user: admin, restricted: true, parent: root, description: "未公開キャンペーンの準備")
+
+      get task_path(root)
+
+      expect(response.body).not_to include("未公開キャンペーンの準備")
+    end
+  end
+
+  describe "cross-model related sections" do
+    it "does not expose a restricted task linked to a visible notice" do
+      notice = create(:notice, user: admin, restricted: false)
+      restricted_task = create(:task, user: admin, restricted: true, title: "非公開タスク")
+      notice.tasks << restricted_task
+
+      get notice_path(notice)
+
+      expect(response.body).not_to include("非公開タスク")
+    end
+
+    it "does not expose a restricted notice linked to a visible task" do
+      task = create(:task, user: admin, restricted: false)
+      restricted_notice = create(:notice, user: admin, restricted: true, title: "非公開のお知らせ")
+      task.notices << restricted_notice
+
+      get task_path(task)
+
+      expect(response.body).not_to include("非公開のお知らせ")
+    end
+
+    it "does not expose a restricted notice linked to a visible interaction" do
+      interaction = create(:interaction)
+      restricted_notice = create(:notice, user: admin, restricted: true, title: "非公開のお知らせ2")
+      interaction.notices << restricted_notice
+
+      get interaction_path(interaction)
+
+      expect(response.body).not_to include("非公開のお知らせ2")
+    end
+
+    it "does not expose a restricted task linked to a visible interaction" do
+      interaction = create(:interaction)
+      restricted_task = create(:task, user: admin, restricted: true, title: "非公開タスク2")
+      interaction.tasks << restricted_task
+
+      get interaction_path(interaction)
+
+      expect(response.body).not_to include("非公開タスク2")
+    end
+  end
+
+  describe "index related list" do
+    it "does not expose a restricted sibling notice's title or content" do
+      root = create(:notice, user: admin, restricted: false)
+      create(:notice, user: admin, restricted: true, parent: root,
+        title: "非公開のお知らせ件名", content: "非公開のお知らせ内容")
+
+      get notices_path
+
+      expect(response.body).not_to include("非公開のお知らせ件名")
+      expect(response.body).not_to include("非公開のお知らせ内容")
+    end
+
+    it "does not expose a restricted sibling task's title or description" do
+      root = create(:task, user: admin, restricted: false)
+      create(:task, user: admin, restricted: true, parent: root,
+        title: "非公開タスク件名", description: "非公開タスク内容")
+
+      get tasks_path
+
+      expect(response.body).not_to include("非公開タスク件名")
+      expect(response.body).not_to include("非公開タスク内容")
+    end
+  end
+
+  describe "linking to an existing restricted record by id" do
+    it "does not let a non-admin attach an existing restricted task via task_id" do
+      restricted_task = create(:task, user: admin, restricted: true)
+
+      post notices_path, params: { notice: attributes_for(:notice), task_id: restricted_task.id }
+
+      expect(Notice.last.tasks).not_to include(restricted_task)
+    end
+
+    it "does not let a non-admin attach an existing restricted notice via notice_id" do
+      restricted_notice = create(:notice, user: admin, restricted: true)
+
+      post tasks_path, params: {
+        task: attributes_for(:task),
+        notice_id: restricted_notice.id,
+        assignee_ids: [ user.id ]
+      }
+
+      expect(Task.where(user: user)).to be_none
+    end
+
+    it "does not let a non-admin set a restricted notice as parent_id" do
+      restricted_notice = create(:notice, user: admin, restricted: true)
+
+      post notices_path, params: { notice: attributes_for(:notice), parent_id: restricted_notice.id }
+
+      expect(Notice.last.parent).not_to eq(restricted_notice)
+    end
+
+    it "does not let a non-admin set a restricted task as parent_id" do
+      restricted_task = create(:task, user: admin, restricted: true)
+
+      post tasks_path, params: {
+        task: attributes_for(:task),
+        parent_id: restricted_task.id,
+        assignee_ids: [ user.id ]
+      }
+
+      expect(Task.last.parent).not_to eq(restricted_task)
+    end
+  end
+end

--- a/spec/requests/tasks_parent_child_spec.rb
+++ b/spec/requests/tasks_parent_child_spec.rb
@@ -174,9 +174,9 @@ RSpec.describe "Tasks parent-child", type: :request do
         task: {
           title: "子お知らせ",
           description: "子の詳細",
-          due_at: 1.hour.ago,
-          parent_id: parent.id
-        }
+          due_at: 1.hour.ago
+        },
+        parent_id: parent.id
       }
     end
 


### PR DESCRIPTION
## 概要

interactions/notices/tasks の親子紐付けおよび関連表示におけるアクセス境界の不備を修正。

---

## 変更内容

- interactions_controller の create/new で parent_id/customer_id を `accessible` スコープ経由でのみ解決するように変更し、フォームの hidden field もトップレベルパラメータ経由に変更
- `Restrictable` concern を追加し、Notice/Task に `visible` スコープ（restricted かつ非admin を除外）を導入
- notices/tasks の parent 参照、notice_id/task_id によるリンク作成、タイムライン(`rooted_notices`/`rooted_tasks`)、一覧の関連表示に `visible` スコープを適用
- interactions の関連notice/task表示（`_related_notices.html.erb`/`_related_tasks.html.erb`）にも `visible` スコープを適用
- sessions_controller のデモログイン処理から冗長な `unscoped` を削除

---

## 確認済
- [x] demo_isolation_spec: デモユーザーが customer_id/parent_id 経由で本番レコードに紐付けできないことを確認
- [x] restricted_visibility_spec: restricted な notice/task がタイムライン・関連一覧・親子紐付け経由で非表示になることを確認
- [x] `bundle exec rspec` 全件green
- [x] `bundle exec rubocop`で 指摘無

---

Closes #182 