### PR TITLE
Unify readable and editable checks in models

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -25,9 +25,7 @@ class CommentsController < ApplicationController
 
     raise ActiveRecord::RecordNotFound unless klass
 
-    @commentable = klass.accessible.find(params[:commentable_id])
-
-    raise ActiveRecord::RecordNotFound if @commentable.respond_to?(:restricted?) && @commentable.restricted? && !Current.user.admin?
+    @commentable = klass.readable.find(params[:commentable_id])
   end
 
   def comment_params

--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -4,14 +4,8 @@ module Authorizable
   private
 
   def authorize_edit!(record)
-    return if record.user == Current.user
+    return if record.editable?
 
     redirect_to record, alert: "編集権限がありません"
-  end
-
-  def authorize_view!(record, redirect_path)
-    return if Current.user.admin? || !record.restricted
-
-    redirect_to redirect_path, alert: "閲覧権限がありません"
   end
 end

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -2,7 +2,7 @@ class CustomersController < ApplicationController
   before_action :set_customer, only: [ :show, :edit, :update ]
 
   def index
-    @q = Customer.accessible.ransack(params[:q], auth_object: :customer_list)
+    @q = Customer.readable.ransack(params[:q], auth_object: :customer_list)
     @pagy, @customers = pagy(@q.result.order(:name))
   end
 
@@ -38,7 +38,7 @@ class CustomersController < ApplicationController
   private
 
   def set_customer
-    @customer = Customer.accessible.find(params[:id])
+    @customer = Customer.readable.find(params[:id])
   end
 
   def customer_params

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -6,7 +6,7 @@ class InteractionsController < ApplicationController
   before_action -> { authorize_edit!(@interaction) }, only: [ :edit, :update ]
 
   def index
-    @q = Interaction.accessible.ransack(params[:q])
+    @q = Interaction.readable.ransack(params[:q])
     @pagy, @interactions = pagy(
       @q.result
         .preload(
@@ -21,7 +21,7 @@ class InteractionsController < ApplicationController
   end
 
   def new
-    @parent_interaction = Interaction.accessible.find_by(id: params[:parent_id])
+    @parent_interaction = Interaction.readable.find_by(id: params[:parent_id])
     @interaction = Interaction.new(
       parent: @parent_interaction,
       customer: @parent_interaction&.customer
@@ -29,7 +29,7 @@ class InteractionsController < ApplicationController
   end
 
   def create
-    @parent_interaction = Interaction.accessible.find_by(id: params[:parent_id])
+    @parent_interaction = Interaction.readable.find_by(id: params[:parent_id])
     @interaction = Current.user.interactions.build(interaction_params)
     @interaction.parent = @parent_interaction
     @interaction.customer = @parent_interaction ? @parent_interaction.customer : accessible_customer
@@ -59,11 +59,11 @@ class InteractionsController < ApplicationController
   private
 
   def set_interaction
-    @interaction = Interaction.accessible.preload(:customer, :user).find(params[:id])
+    @interaction = Interaction.readable.preload(:customer, :user).find(params[:id])
   end
 
   def set_interaction_with_comments
-    @interaction = Interaction.accessible.preload(:customer, :user, comments: [ :user ]).find(params[:id])
+    @interaction = Interaction.readable.preload(:customer, :user, comments: [ :user ]).find(params[:id])
   end
 
   def interaction_params
@@ -78,6 +78,6 @@ class InteractionsController < ApplicationController
   end
 
   def accessible_customer
-    Customer.accessible.find_by(id: params[:customer_id])
+    Customer.readable.find_by(id: params[:customer_id])
   end
 end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -3,12 +3,10 @@ class NoticesController < ApplicationController
 
   before_action :set_notice, only: %i[edit update]
   before_action :set_notice_with_comments, only: :show
-  before_action -> { authorize_view!(@notice, notices_path) }, only: %i[show edit update]
   before_action -> { authorize_edit!(@notice) }, only: %i[edit update]
 
-
   def index
-    @q = visible_notices.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
+    @q = readable_notices.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
     @pagy, @notices = pagy(
       @q.result
         .preload(
@@ -22,21 +20,21 @@ class NoticesController < ApplicationController
   end
 
   def new
-    @parent_notice = Notice.accessible.visible.find_by(id: params[:parent_id])
+    @parent_notice = Notice.readable.find(params[:parent_id]) if params[:parent_id].present?
     @notice = Notice.new(parent: @parent_notice)
   end
 
   def create
-    @parent_notice = Notice.accessible.visible.find_by(id: params[:parent_id])
+    @parent_notice = Notice.readable.find(params[:parent_id]) if params[:parent_id].present?
     @notice = Current.user.notices.build(notice_params)
     @notice.parent = @parent_notice
 
     if @notice.save
       if params[:interaction_id].present?
-        @notice.interactions << Interaction.accessible.find(params[:interaction_id])
+        @notice.interactions << Interaction.readable.find(params[:interaction_id])
       end
 
-      @notice.tasks << Task.accessible.visible.find(params[:task_id]) if params[:task_id].present?
+      @notice.tasks << Task.readable.find(params[:task_id]) if params[:task_id].present?
 
       redirect_to @notice, notice: "お知らせを更新しました"
     else
@@ -45,7 +43,7 @@ class NoticesController < ApplicationController
   end
 
   def show
-    @timeline = @notice.root.rooted_notices.visible.order(:created_at)
+    @timeline = @notice.root.rooted_notices.readable.order(:created_at)
   end
 
   def edit
@@ -62,15 +60,15 @@ class NoticesController < ApplicationController
   private
 
   def set_notice
-    @notice = Notice.accessible.preload(:user).find(params[:id])
+    @notice = Notice.readable.preload(:user).find(params[:id])
   end
 
   def set_notice_with_comments
-    @notice = Notice.accessible.preload(:user, comments: [ :user ]).find(params[:id])
+    @notice = Notice.readable.preload(:user, comments: [ :user ]).find(params[:id])
   end
 
-  def visible_notices
-    Notice.accessible.visible
+  def readable_notices
+    Notice.readable
   end
 
   def notice_params

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -7,7 +7,8 @@ class PasswordsController < ApplicationController
   end
 
   def create
-    if user = User.accessible.find_by(email_address: params[:email_address])
+    # 認証前は Current.demo が未確定のため readable は使えない。素の検索で境界を掛けない。
+    if user = User.find_by(email_address: params[:email_address])
       PasswordsMailer.reset(user).deliver_later
     end
 
@@ -28,7 +29,8 @@ class PasswordsController < ApplicationController
 
   private
     def set_user_by_token
-      @user = User.accessible.find_by_password_reset_token!(params[:token])
+      # 認証前は Current.demo が未確定のため readable は使えない。素の検索で境界を掛けない。
+      @user = User.find_by_password_reset_token!(params[:token])
     rescue ActiveSupport::MessageVerifier::InvalidSignature
       redirect_to new_password_path, alert: "Password reset link is invalid or has expired."
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,8 @@ class SessionsController < ApplicationController
   end
 
   def create
-    if user = User.accessible.authenticate_by(params.permit(:email_address, :password))
+    # 認証前は Current.demo が未確定のため readable は使えない。素の検索で境界を掛けない。
+    if user = User.authenticate_by(params.permit(:email_address, :password))
       start_new_session_for user
       redirect_to interactions_path
     else

--- a/app/controllers/task_assignments_controller.rb
+++ b/app/controllers/task_assignments_controller.rb
@@ -13,11 +13,11 @@ class TaskAssignmentsController < ApplicationController
   private
 
   def set_task_assignment
-    @task_assignment = TaskAssignment.accessible.find(params[:id])
+    @task_assignment = TaskAssignment.readable.find(params[:id])
   end
 
   def authorize_owner!
-    return if @task_assignment.user == Current.user
+    return if @task_assignment.editable?
 
     redirect_to @task_assignment.task, alert: "更新権限がありません"
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,11 +3,10 @@ class TasksController < ApplicationController
 
   before_action :set_task, only: [ :edit, :update ]
   before_action :set_task_with_associations, only: :show
-  before_action -> { authorize_view!(@task, tasks_path) }, only: [ :show, :edit, :update ]
   before_action -> { authorize_edit!(@task) }, only: [ :edit, :update ]
 
   def index
-    @q = visible_tasks.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
+    @q = readable_tasks.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
     @pagy, @tasks = pagy(
       @q.result
         .preload(
@@ -22,13 +21,13 @@ class TasksController < ApplicationController
   end
 
   def new
-    @parent_task = Task.accessible.visible.find_by(id: params[:parent_id])
+    @parent_task = Task.readable.find(params[:parent_id]) if params[:parent_id].present?
     @task = Task.new(parent: @parent_task)
     @form = TaskForm.new(task: @task)
   end
 
   def create
-    @parent_task = Task.accessible.visible.find_by(id: params[:parent_id])
+    @parent_task = Task.readable.find(params[:parent_id]) if params[:parent_id].present?
     @task = Current.user.tasks.build(task_params)
     @task.parent = @parent_task
 
@@ -47,7 +46,7 @@ class TasksController < ApplicationController
   end
 
   def show
-    @timeline = @task.root.rooted_tasks.visible.order(:created_at)
+    @timeline = @task.root.rooted_tasks.readable.order(:created_at)
   end
 
   def edit
@@ -67,15 +66,15 @@ class TasksController < ApplicationController
   private
 
   def set_task
-    @task = Task.accessible.preload(:user).find(params[:id])
+    @task = Task.readable.preload(:user).find(params[:id])
   end
 
   def set_task_with_associations
-    @task = Task.accessible.preload(:user, task_assignments: [ :user ], comments: [ :user ]).find(params[:id])
+    @task = Task.readable.preload(:user, task_assignments: [ :user ], comments: [ :user ]).find(params[:id])
   end
 
-  def visible_tasks
-    Task.accessible.visible
+  def readable_tasks
+    Task.readable
   end
 
   def task_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :require_admin, only: %i[new create edit update]
 
   def index
-    @q = User.accessible.ransack(params[:q], auth_object: :user_list)
+    @q = User.readable.ransack(params[:q], auth_object: :user_list)
     @pagy, @users = pagy(@q.result.order(:name))
   end
 
@@ -39,7 +39,7 @@ class UsersController < ApplicationController
   private
 
   def set_user
-    @user = User.accessible.find(params[:id])
+    @user = User.readable.find(params[:id])
   end
 
   def user_params

--- a/app/forms/task_form.rb
+++ b/app/forms/task_form.rb
@@ -23,11 +23,11 @@ class TaskForm
 
     ActiveRecord::Base.transaction do
       task.save!
-      task.interactions << Interaction.accessible.find(interaction_id) if interaction_id.present?
-      task.notices      << Notice.accessible.visible.find(notice_id)   if notice_id.present?
+      task.interactions << Interaction.readable.find(interaction_id) if interaction_id.present?
+      task.notices      << Notice.readable.find(notice_id)            if notice_id.present?
 
       assignee_ids.each do |user_id|
-        task.task_assignments.create!(user: User.accessible.find(user_id), status: :todo)
+        task.task_assignments.create!(user: User.readable.find(user_id), status: :todo)
       end
     end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,5 +4,7 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :commentable, polymorphic: true
 
+  scope :readable, -> { demo(Current.demo?) }
+
   validates :content, presence: true, length: { maximum: 200 }
 end

--- a/app/models/concerns/demo_scoped.rb
+++ b/app/models/concerns/demo_scoped.rb
@@ -2,7 +2,7 @@ module DemoScoped
   extend ActiveSupport::Concern
 
   included do
-    scope :accessible, -> { where(demo: Current.demo?) }
+    scope :demo, ->(flag) { where(demo: flag) }
 
     before_validation :assign_demo_flag, on: :create
   end

--- a/app/models/concerns/restrictable.rb
+++ b/app/models/concerns/restrictable.rb
@@ -2,6 +2,6 @@ module Restrictable
   extend ActiveSupport::Concern
 
   included do
-    scope :visible, -> { Current.user&.admin? ? all : where(restricted: false) }
+    scope :not_restricted, -> { Current.user&.admin? ? all : where(restricted: false) }
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -11,6 +11,11 @@ class Customer < ApplicationRecord
   # add associations after other models are created
   has_many :interactions
 
+  scope :readable, -> { demo(Current.demo?) }
+
+  # 顧客情報は業務の核であり、都度の許可申請では現場が回らないため全員編集可。
+  def editable? = Current.user.present?
+
   private
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -17,6 +17,8 @@ class Interaction < ApplicationRecord
   has_many :comments, as: :commentable
   has_many_attached :images
 
+  scope :readable, -> { demo(Current.demo?) }
+
   enum :channel, {
     phone: "phone",
     email: "email",
@@ -33,6 +35,11 @@ class Interaction < ApplicationRecord
   validates :images,
     content_type: %w[image/jpeg image/png image/gif],
     size: { less_than_or_equal_to: 10.megabytes }
+
+  # 編集は作成者本人のみ。admin も改ざん防止のため対象外。
+  def editable?
+    user == Current.user
+  end
 
   private
 

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -15,6 +15,8 @@ class Notice < ApplicationRecord
   has_many :comments, as: :commentable
   has_many_attached :images
 
+  scope :readable, -> { demo(Current.demo?).not_restricted }
+
   enum :level, {
     important: "important",
     normal: "normal"
@@ -30,6 +32,11 @@ class Notice < ApplicationRecord
   validates :images,
     content_type: %w[image/jpeg image/png image/gif],
     size: { less_than_or_equal_to: 10.megabytes }
+
+  # 編集は作成者本人のみ。admin も改ざん防止のため対象外。
+  def editable?
+    user == Current.user
+  end
 
   private
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -18,12 +18,19 @@ class Task < ApplicationRecord
   has_many :comments, as: :commentable
   has_many_attached :images
 
+  scope :readable, -> { demo(Current.demo?).not_restricted }
+
   validates :title, presence: true, length: { maximum: 50 }
   validates :description, presence: true, length: { maximum: 2000 }
   validates :restricted, inclusion: { in: [ true, false ] }
   validates :images,
     content_type: %w[image/jpeg image/png image/gif],
     size: { less_than_or_equal_to: 10.megabytes }
+
+  # 編集は作成者本人のみ。admin も改ざん防止のため対象外。
+  def editable?
+    user == Current.user
+  end
 
   private
 

--- a/app/models/task_assignment.rb
+++ b/app/models/task_assignment.rb
@@ -12,6 +12,13 @@ class TaskAssignment < ApplicationRecord
 
   validates :task_id, uniqueness: { scope: :user_id }
 
+  scope :readable, -> { demo(Current.demo?) }
+
+  # 編集は担当者本人のみ。admin も改ざん防止のため対象外。
+  def editable?
+    user == Current.user
+  end
+
   private
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,11 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 50 }
   validates :password, length: { minimum: 8 }, if: -> { new_record? || !password.nil? }
 
+  scope :readable, -> { demo(Current.demo?) }
+
+  # 従業員情報のため admin のみ編集可。
+  def editable? = Current.user&.admin?
+
   private
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/views/interactions/_form.html.erb
+++ b/app/views/interactions/_form.html.erb
@@ -19,7 +19,7 @@
 
       <% if interaction.new_record? && @parent_interaction.nil? %>
         <%= select_tag :customer_id,
-                       options_from_collection_for_select(Customer.accessible.order(:name), :id, :name, interaction.customer_id),
+                       options_from_collection_for_select(Customer.readable.order(:name), :id, :name, interaction.customer_id),
                        prompt: "選択してください",
                        class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" %>
       <% else %>

--- a/app/views/interactions/_related_notices.html.erb
+++ b/app/views/interactions/_related_notices.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm ">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連お知らせ</h2>
 
-  <% notices = interaction.notices.visible %>
+  <% notices = interaction.notices.readable %>
 
   <% if notices.any? %>
     <ul class="space-y-2">

--- a/app/views/interactions/_related_tasks.html.erb
+++ b/app/views/interactions/_related_tasks.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連タスク</h2>
 
-  <% tasks = interaction.tasks.visible %>
+  <% tasks = interaction.tasks.readable %>
 
   <% if tasks.any? %>
     <ul class="space-y-2">

--- a/app/views/interactions/show.html.erb
+++ b/app/views/interactions/show.html.erb
@@ -76,7 +76,7 @@
     <%= render "related_tasks", interaction: @interaction %>
     <%= render "shared/comment_thread", commentable: @interaction %>
 
-    <% if @interaction.user == Current.user %>
+    <% if @interaction.editable? %>
       <div class="mt-6 flex justify-end border-t-4 border-gray-300 pt-6">
         <%= link_to "編集",
                     edit_interaction_path(@interaction),

--- a/app/views/notices/_related_tasks.html.erb
+++ b/app/views/notices/_related_tasks.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連タスク</h2>
 
-  <% tasks = notice.tasks.visible %>
+  <% tasks = notice.tasks.readable %>
 
   <% if tasks.any? %>
     <ul class="space-y-2">

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -71,7 +71,7 @@
     <%= render "related_tasks", notice: @notice %>
     <%= render "shared/comment_thread", commentable: @notice %>
 
-    <% if @notice.user == Current.user %>
+    <% if @notice.editable? %>
       <div class="mt-6 flex justify-end border-t-4 border-gray-300 pt-6">
         <%= link_to "編集",
                     edit_notice_path(@notice),

--- a/app/views/tasks/_assignment_table.html.erb
+++ b/app/views/tasks/_assignment_table.html.erb
@@ -19,7 +19,7 @@
         </div>
 
         <div class="flex items-center justify-center px-4 break-words">
-          <% if !compact && assignment.user == Current.user %>
+          <% if !compact && assignment.editable? %>
             <%= form_with model: assignment, url: task_assignment_path(assignment), method: :patch, class: "inline-block", data: { controller: "auto-submit" } do |f| %>
               <%= f.select :status,
                     TaskAssignment.statuses.keys.map { |status| [ I18n.t("enums.task_assignment.status.#{status}"), status ] },

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -34,7 +34,7 @@
       <%= label_tag :assignee_ids, "担当者", class: "block text-xs sm:text-sm text-gray-700 mb-1" %>
 
       <%= select_tag "assignee_ids[]",
-                     options_from_collection_for_select(User.accessible.order(:name), :id, :name, params[:assignee_ids]),
+                     options_from_collection_for_select(User.readable.order(:name), :id, :name, params[:assignee_ids]),
                      multiple: true,
                      class: "w-full border border-gray-300 rounded px-3 py-2 text-xs sm:text-sm" %>
 

--- a/app/views/tasks/_related_notices.html.erb
+++ b/app/views/tasks/_related_notices.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連お知らせ</h2>
 
-  <% notices = task.notices.visible %>
+  <% notices = task.notices.readable %>
 
   <% if notices.any? %>
     <ul class="space-y-2">

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -50,7 +50,7 @@
     <%= render "related_notices", task: @task %>
     <%= render "shared/comment_thread", commentable: @task %>
 
-    <% if @task.user == Current.user %>
+    <% if @task.editable? %>
       <div class="mt-6 flex justify-end border-t-4 border-gray-300 pt-6">
         <%= link_to "編集",
                     edit_task_path(@task),

--- a/spec/requests/notices_parent_child_spec.rb
+++ b/spec/requests/notices_parent_child_spec.rb
@@ -157,10 +157,10 @@ RSpec.describe "Notices parent-child", type: :request do
     end
 
     context "when creating a follow-up notice with a non-existent parent notice" do
-      it "responds with HTTP 200 OK and ignores the invalid parent_id" do
+      it "responds with HTTP 404 Not Found" do
         get new_notice_path(parent_id: 0)
 
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Notices", type: :request do
       it "cannot access a restricted notice" do
         get notice_path(restricted_notice)
 
-        expect(response).to redirect_to notices_path
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -332,10 +332,10 @@ RSpec.describe "Notices", type: :request do
         expect(response.body).not_to include("管理者のみ")
       end
 
-      it "cannot access a restricted notice and redirects to the index page" do
+      it "cannot access a restricted notice" do
         get edit_notice_path(restricted_notice)
 
-        expect(response).to redirect_to notices_path
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -403,12 +403,12 @@ RSpec.describe "Notices", type: :request do
         expect(response).to have_http_status(:unprocessable_content)
       end
 
-      it "cannot update a restricted notice and redirects to the index template" do
+      it "cannot update a restricted notice" do
         patch notice_path(restricted_notice),
           params: { notice: { content: "追記" } }
 
         expect(restricted_notice.reload.content).not_to eq("追記")
-        expect(response).to redirect_to notices_path
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/spec/requests/restricted_visibility_spec.rb
+++ b/spec/requests/restricted_visibility_spec.rb
@@ -115,24 +115,28 @@ RSpec.describe "Restricted content visibility", type: :request do
       expect(Task.where(user: user)).to be_none
     end
 
-    it "does not let a non-admin set a restricted notice as parent_id" do
+    it "returns 404 when a non-admin sets a restricted notice as parent_id" do
       restricted_notice = create(:notice, user: admin, restricted: true)
 
-      post notices_path, params: { notice: attributes_for(:notice), parent_id: restricted_notice.id }
+      expect {
+        post notices_path, params: { notice: attributes_for(:notice), parent_id: restricted_notice.id }
+      }.not_to change(Notice, :count)
 
-      expect(Notice.last.parent).not_to eq(restricted_notice)
+      expect(response).to have_http_status(:not_found)
     end
 
-    it "does not let a non-admin set a restricted task as parent_id" do
+    it "returns 404 when a non-admin sets a restricted task as parent_id" do
       restricted_task = create(:task, user: admin, restricted: true)
 
-      post tasks_path, params: {
-        task: attributes_for(:task),
-        parent_id: restricted_task.id,
-        assignee_ids: [ user.id ]
-      }
+      expect {
+        post tasks_path, params: {
+          task: attributes_for(:task),
+          parent_id: restricted_task.id,
+          assignee_ids: [ user.id ]
+        }
+      }.not_to change(Task, :count)
 
-      expect(Task.last.parent).not_to eq(restricted_task)
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/tasks_parent_child_spec.rb
+++ b/spec/requests/tasks_parent_child_spec.rb
@@ -159,10 +159,10 @@ RSpec.describe "Tasks parent-child", type: :request do
     end
 
     context "when creating a follow-up task with a non-existent parent task" do
-      it "responds with HTTP 200 OK and ignores the invalid parent_id" do
+      it "responds with HTTP 404 Not Found" do
         get new_task_path(parent_id: 0)
 
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "Tasks", type: :request do
       it "cannot access a restricted task" do
         get task_path(restricted_task)
 
-        expect(response).to redirect_to tasks_path
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -308,10 +308,10 @@ RSpec.describe "Tasks", type: :request do
         expect(response.body).not_to include("管理者のみ")
       end
 
-      it "cannot access a restricted task and redirects to the index page" do
+      it "cannot access a restricted task" do
         get edit_task_path(restricted_task)
 
-        expect(response).to redirect_to tasks_path
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -382,12 +382,12 @@ RSpec.describe "Tasks", type: :request do
         expect(response).to have_http_status(:unprocessable_content)
       end
 
-      it "cannot update a restricted task and redirects to the index template" do
+      it "cannot update a restricted task" do
         patch task_path(restricted_task),
           params: { task: { description: "追記" } }
 
         expect(restricted_task.reload.description).not_to eq("追記")
-        expect(response).to redirect_to tasks_path
+        expect(response).to have_http_status(:not_found)
       end
     end
 


### PR DESCRIPTION
## 概要

閲覧可否（readable）と編集可否（editable?）の判定ロジックが4箇所に分散していたのを、各モデルに定義した `readable` スコープと `editable?` 述語に一本化した。

---

## 変更内容

- `DemoScoped#accessible` を `demo(flag)` に、`Restrictable#visible` を `not_restricted` にリネーム
- 各モデルに `readable` スコープを追加（Task/Notice は demo + not_restricted、それ以外は demo のみ）
- Task/Notice/Interaction/TaskAssignment/Customer/User に `editable?` 述語を追加
- コントローラ・フォーム・ビューの呼び出し箇所を `Model.readable` / `record.editable?` に統一
- `Authorizable#authorize_view!` を削除し、`authorize_edit!` を `editable?` を呼ぶだけに簡素化
- `comments_controller.rb` のインライン制限チェックを削除し `klass.readable.find` に統一
- tasks/notices の new・create で親レコード取得を `find_by` から `find` に変更（到達不能な parent_id は404）
- SessionsController/PasswordsController は認証前で `Current.demo` が未確定なため、`User.readable` ではなく素の検索に変更
- 上記の404化に伴い、関連する request spec を新しい挙動に合わせて更新

---

## 確認済
- [x] bundle exec rspec が全て緑（575 examples, 0 failures）
- [x] bundle exec rubocop がエラーなし
- [x] grep で accessible / visible / authorize_view! の残存なし

---

Closes #184 