### PR TITLE
Replace dynamic Rootable names with fixed methods

### DIFF
--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -9,14 +9,12 @@ class InteractionsController < ApplicationController
     @q = Interaction.readable.ransack(params[:q])
     @pagy, @interactions = pagy(
       @q.result
-        .preload(
-          :customer,
-          :user,
-          root: {
-            rooted_interactions: [ :customer, :user ]
-          }
-        )
+        .preload(:customer, :user)
         .order(occurred_at: :desc)
+    )
+    @interactions_by_root = Interaction.related_records_by_root(
+      @interactions.map(&:root_id),
+      preload: [ :customer, :user ]
     )
   end
 
@@ -42,7 +40,7 @@ class InteractionsController < ApplicationController
   end
 
   def show
-    @timeline = @interaction.root.rooted_interactions.order(:occurred_at)
+    @timeline = @interaction.related_records
   end
 
   def edit

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -9,13 +9,12 @@ class NoticesController < ApplicationController
     @q = readable_notices.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
     @pagy, @notices = pagy(
       @q.result
-        .preload(
-          :user,
-          root: {
-            rooted_notices: [ :user ]
-          }
-        )
+        .preload(:user)
         .order(start_at: :desc)
+    )
+    @notices_by_root = Notice.related_records_by_root(
+      @notices.map(&:root_id),
+      preload: [ :user ]
     )
   end
 
@@ -43,7 +42,7 @@ class NoticesController < ApplicationController
   end
 
   def show
-    @timeline = @notice.root.rooted_notices.readable.order(:created_at)
+    @timeline = @notice.related_records
   end
 
   def edit

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,14 +9,12 @@ class TasksController < ApplicationController
     @q = readable_tasks.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
     @pagy, @tasks = pagy(
       @q.result
-        .preload(
-          :user,
-          task_assignments: [ :user ],
-          root: {
-            rooted_tasks: [ :user, task_assignments: [ :user ] ]
-          }
-        )
+        .preload(:user, task_assignments: [ :user ])
         .order(due_at: :asc)
+    )
+    @tasks_by_root = Task.related_records_by_root(
+      @tasks.map(&:root_id),
+      preload: [ :user, task_assignments: [ :user ] ]
     )
   end
 
@@ -46,7 +44,7 @@ class TasksController < ApplicationController
   end
 
   def show
-    @timeline = @task.root.rooted_tasks.readable.order(:created_at)
+    @timeline = @task.related_records
   end
 
   def edit

--- a/app/models/concerns/rootable.rb
+++ b/app/models/concerns/rootable.rb
@@ -10,19 +10,24 @@ module Rootable
   end
 
   class_methods do
-    def rootable(order_column:)
-      has_many :children,
-               -> { order(order_column => :desc) },
-               class_name: name,
-               foreign_key: "parent_id"
-
-      has_many :"rooted_#{model_name.plural}", class_name: name, foreign_key: :root_id, dependent: :nullify
-
-      define_method(:"related_#{model_name.plural}") do
-        rooted_all = root.public_send(:"rooted_#{model_name.plural}")
-        rooted_all.reject { |record| record.id == id }.sort_by(&order_column)
-      end
+    # 一覧画面用。複数レコードの関連を root_id の IN 1本でまとめて引き、
+    # root_id をキーにした Hash で返す。自分自身の除外は呼び出し側で行う。
+    # nil を除くのは、root_id が nil のレコード同士が互いの関連として現れるのを防ぐため。
+    def related_records_by_root(root_ids, preload: [])
+      readable
+        .where(root_id: root_ids.compact.uniq)
+        .preload(preload)
+        .order(root_order_column)
+        .group_by(&:root_id)
     end
+  end
+
+  # 自分と同じ root に属する全レコード。自分自身を含む。
+  # readable 経由なので権限境界はここで閉じる。
+  def related_records
+    self.class.readable
+      .where(root_id: root_id)
+      .order(self.class.root_order_column)
   end
 
   private

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -14,7 +14,9 @@ class Customer < ApplicationRecord
   scope :readable, -> { demo(Current.demo?) }
 
   # 顧客情報は業務の核であり、都度の許可申請では現場が回らないため全員編集可。
-  def editable? = Current.user.present?
+  def editable?
+    Current.user.present?
+  end
 
   private
 

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -1,7 +1,10 @@
 class Interaction < ApplicationRecord
   include Rootable
   include DemoScoped
-  rootable order_column: :occurred_at
+
+  def self.root_order_column
+    :occurred_at
+  end
 
   before_validation :set_customer_from_parent
 

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -2,7 +2,10 @@ class Notice < ApplicationRecord
   include Rootable
   include DemoScoped
   include Restrictable
-  rootable order_column: :created_at
+
+  def self.root_order_column
+    :created_at
+  end
 
   belongs_to :user
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,7 +2,10 @@ class Task < ApplicationRecord
   include Rootable
   include DemoScoped
   include Restrictable
-  rootable order_column: :created_at
+
+  def self.root_order_column
+    :created_at
+  end
 
   belongs_to :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,9 @@ class User < ApplicationRecord
   scope :readable, -> { demo(Current.demo?) }
 
   # 従業員情報のため admin のみ編集可。
-  def editable? = Current.user&.admin?
+  def editable?
+    Current.user&.admin?
+  end
 
   private
 

--- a/app/views/interactions/_list_desktop.html.erb
+++ b/app/views/interactions/_list_desktop.html.erb
@@ -14,7 +14,7 @@
 
     <tbody data-controller="related-toggle-list">
       <% interactions.each do |interaction| %>
-        <% related_interactions = interaction.related_interactions %>
+        <% related_interactions = @interactions_by_root.fetch(interaction.root_id, []).reject { |i| i.id == interaction.id } %>
         <tr class="h-12 hover:bg-gray-100 cursor-pointer"
             data-interaction-id="<%= interaction.id %>"
             data-controller="clickable"

--- a/app/views/interactions/_list_mobile.html.erb
+++ b/app/views/interactions/_list_mobile.html.erb
@@ -10,7 +10,7 @@
 
   <div class="space-y-2">
     <% interactions.each do |interaction| %>
-      <% related_interactions = interaction.related_interactions %>
+      <% related_interactions = @interactions_by_root.fetch(interaction.root_id, []).reject { |i| i.id == interaction.id } %>
 
       <div class="w-full" data-controller="related-toggle">
 

--- a/app/views/notices/_list_desktop.html.erb
+++ b/app/views/notices/_list_desktop.html.erb
@@ -12,7 +12,7 @@
 
     <tbody data-controller="related-toggle-list">
       <% notices.each do |notice| %>
-        <% related_notices = notice.related_notices.reject { |n| n.restricted? && !Current.user.admin? } %>
+        <% related_notices = @notices_by_root.fetch(notice.root_id, []).reject { |n| n.id == notice.id } %>
         <tr class="h-12 hover:bg-gray-100 cursor-pointer"
             data-notice-id="<%= notice.id %>"
             data-controller="clickable"

--- a/app/views/notices/_list_mobile.html.erb
+++ b/app/views/notices/_list_mobile.html.erb
@@ -8,7 +8,7 @@
 
   <div class="space-y-2">
     <% notices.each do |notice| %>
-      <% related_notices = notice.related_notices.reject { |n| n.restricted? && !Current.user.admin? } %>
+      <% related_notices = @notices_by_root.fetch(notice.root_id, []).reject { |n| n.id == notice.id } %>
 
       <div class="w-full" data-controller="related-toggle">
 

--- a/app/views/tasks/_list_desktop.html.erb
+++ b/app/views/tasks/_list_desktop.html.erb
@@ -8,7 +8,7 @@
 
   <div data-controller="related-toggle-list">
     <% tasks.each do |task| %>
-      <% related_tasks = task.related_tasks.reject { |t| t.restricted? && !Current.user.admin? } %>
+      <% related_tasks = @tasks_by_root.fetch(task.root_id, []).reject { |t| t.id == task.id } %>
       <div class="group related-list-trigger relative flex items-center min-h-12 hover:bg-gray-100 cursor-pointer"
           data-task-id="<%= task.id %>"
           data-controller="clickable"

--- a/app/views/tasks/_list_mobile.html.erb
+++ b/app/views/tasks/_list_mobile.html.erb
@@ -8,7 +8,7 @@
 
   <div class="space-y-2">
     <% tasks.each do |task| %>
-      <% related_tasks = task.related_tasks.reject { |t| t.restricted? && !Current.user.admin? } %>
+      <% related_tasks = @tasks_by_root.fetch(task.root_id, []).reject { |t| t.id == task.id } %>
 
       <div class="w-full" data-controller="related-toggle">
 

--- a/spec/models/interaction_spec.rb
+++ b/spec/models/interaction_spec.rb
@@ -36,28 +36,12 @@ RSpec.describe Interaction, type: :model do
       expect(association.options[:optional]).to be(true)
     end
 
-    it 'has many children interactions' do
-      association = described_class.reflect_on_association(:children)
-
-      expect(association.macro).to eq(:has_many)
-      expect(association.options[:class_name]).to eq("Interaction")
-      expect(association.options[:foreign_key]).to eq("parent_id")
-    end
-
     it 'belongs to root interaction (optional)' do
       association = described_class.reflect_on_association(:root)
 
       expect(association.macro).to eq(:belongs_to)
       expect(association.options[:class_name]).to eq("Interaction")
       expect(association.options[:optional]).to be(true)
-    end
-
-    it 'has many rooted_interactions' do
-      association = described_class.reflect_on_association(:rooted_interactions)
-
-      expect(association.macro).to eq(:has_many)
-      expect(association.options[:class_name]).to eq("Interaction")
-      expect(association.options[:foreign_key]).to eq(:root_id)
     end
   end
 
@@ -84,28 +68,29 @@ RSpec.describe Interaction, type: :model do
     end
   end
 
-  describe '#related_interactions' do
-    it 'returns other interactions in the same thread ordered by occurred_at' do
+  describe '#related_records' do
+    it 'returns every interaction with the same root ordered by occurred_at' do
       parent = create(:interaction, occurred_at: 3.days.ago)
       earlier_related_interaction = create(:interaction, parent: parent, occurred_at: 2.days.ago)
       later_related_interaction = create(:interaction, parent: parent, occurred_at: 1.day.ago)
+      same_root = [ parent, earlier_related_interaction, later_related_interaction ]
 
-      expect(parent.related_interactions).to eq([ earlier_related_interaction, later_related_interaction ])
-      expect(earlier_related_interaction.related_interactions).to eq([ parent, later_related_interaction ])
-      expect(later_related_interaction.related_interactions).to eq([ parent, earlier_related_interaction ])
+      expect(parent.related_records).to eq(same_root)
+      expect(earlier_related_interaction.related_records).to eq(same_root)
+      expect(later_related_interaction.related_records).to eq(same_root)
     end
 
-    it 'returns an empty array when there are no related interactions' do
+    it 'returns only itself when there are no related interactions' do
       interaction = create(:interaction)
 
-      expect(interaction.related_interactions).to eq([])
+      expect(interaction.related_records).to eq([ interaction ])
     end
 
-    it 'does not include itself' do
+    it 'includes itself' do
       parent = create(:interaction)
       create(:interaction, parent: parent)
 
-      expect(parent.related_interactions).not_to include(parent)
+      expect(parent.related_records).to include(parent)
     end
   end
 

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -26,13 +26,6 @@ RSpec.describe Notice, type: :model do
       expect(association.options[:optional]).to be(true)
     end
 
-    it 'has many children notices' do
-      association = described_class.reflect_on_association(:children)
-      expect(association.macro).to eq(:has_many)
-      expect(association.options[:class_name]).to eq("Notice")
-      expect(association.options[:foreign_key]).to eq("parent_id")
-    end
-
     it 'belongs to root notice (optional)' do
       association = described_class.reflect_on_association(:root)
 
@@ -40,38 +33,31 @@ RSpec.describe Notice, type: :model do
       expect(association.options[:class_name]).to eq("Notice")
       expect(association.options[:optional]).to be(true)
     end
-
-    it 'has many rooted_notices' do
-      association = described_class.reflect_on_association(:rooted_notices)
-
-      expect(association.macro).to eq(:has_many)
-      expect(association.options[:class_name]).to eq("Notice")
-      expect(association.options[:foreign_key]).to eq(:root_id)
-    end
   end
 
-  describe '#related_notices' do
-    it 'returns other notices in the same thread ordered by created_at' do
+  describe '#related_records' do
+    it 'returns every notice with the same root ordered by created_at' do
       parent = create(:notice)
       earlier_related_notice = create(:notice, parent: parent)
       later_related_notice = create(:notice, parent: parent)
+      same_root = [ parent, earlier_related_notice, later_related_notice ]
 
-      expect(parent.related_notices).to eq([ earlier_related_notice, later_related_notice ])
-      expect(earlier_related_notice.related_notices).to eq([ parent, later_related_notice ])
-      expect(later_related_notice.related_notices).to eq([ parent, earlier_related_notice ])
+      expect(parent.related_records).to eq(same_root)
+      expect(earlier_related_notice.related_records).to eq(same_root)
+      expect(later_related_notice.related_records).to eq(same_root)
     end
 
-    it 'returns an empty array when there are no related notices' do
+    it 'returns only itself when there are no related notices' do
       notice = create(:notice)
 
-      expect(notice.related_notices).to eq([])
+      expect(notice.related_records).to eq([ notice ])
     end
 
-    it 'does not include itself' do
+    it 'includes itself' do
       parent = create(:notice)
       create(:notice, parent: parent)
 
-      expect(parent.related_notices).not_to include(parent)
+      expect(parent.related_records).to include(parent)
     end
   end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -29,14 +29,6 @@ RSpec.describe Task, type: :model do
       expect(association.options[:optional]).to be(true)
     end
 
-    it 'has many children tasks' do
-      association = described_class.reflect_on_association(:children)
-
-      expect(association.macro).to eq(:has_many)
-      expect(association.options[:class_name]).to eq("Task")
-      expect(association.options[:foreign_key]).to eq("parent_id")
-    end
-
     it 'has many task_assignments' do
       association = described_class.reflect_on_association(:task_assignments)
 
@@ -57,14 +49,6 @@ RSpec.describe Task, type: :model do
       expect(association.macro).to eq(:belongs_to)
       expect(association.options[:class_name]).to eq("Task")
       expect(association.options[:optional]).to be(true)
-    end
-
-    it 'has many rooted_tasks' do
-      association = described_class.reflect_on_association(:rooted_tasks)
-
-      expect(association.macro).to eq(:has_many)
-      expect(association.options[:class_name]).to eq("Task")
-      expect(association.options[:foreign_key]).to eq(:root_id)
     end
   end
 
@@ -91,28 +75,29 @@ RSpec.describe Task, type: :model do
     end
   end
 
-  describe '#related_tasks' do
-    it 'returns other tasks in the same thread ordered by created_at' do
+  describe '#related_records' do
+    it 'returns every task with the same root ordered by created_at' do
       parent = create(:task)
       earlier_related_task = create(:task, parent: parent)
       later_related_task = create(:task, parent: parent)
+      same_root = [ parent, earlier_related_task, later_related_task ]
 
-      expect(parent.related_tasks).to eq([ earlier_related_task, later_related_task ])
-      expect(earlier_related_task.related_tasks).to eq([ parent, later_related_task ])
-      expect(later_related_task.related_tasks).to eq([ parent, earlier_related_task ])
+      expect(parent.related_records).to eq(same_root)
+      expect(earlier_related_task.related_records).to eq(same_root)
+      expect(later_related_task.related_records).to eq(same_root)
     end
 
-    it 'returns an empty array when there are no related tasks' do
+    it 'returns only itself when there are no related tasks' do
       task = create(:task)
 
-      expect(task.related_tasks).to eq([])
+      expect(task.related_records).to eq([ task ])
     end
 
-    it 'does not include itself' do
+    it 'includes itself' do
       parent = create(:task)
       create(:task, parent: parent)
 
-      expect(parent.related_tasks).not_to include(parent)
+      expect(parent.related_records).to include(parent)
     end
   end
 


### PR DESCRIPTION
## 概要

`Rootable` がモデルごとに組み立てていた関連名・メソッド名を、固定名の `related_records` / `related_records_by_root` に置き換えた。`related_tasks` のように grep しても定義が出てこない名前が無くなる。
呼び出し側が Relation を扱えるようになったため、ビューに手書きされていた権限判定を `readable` に寄せ、一覧の関連取得を1クエリのまとめ引きにした。

---

## 変更内容

- `rootable(order_column:)` DSL と動的な名前生成を除去し、固定名の `related_records` / `related_records_by_root` にした
- 並び順を各モデルの `self.root_order_column` で宣言するようにした
- 3つの `index` を root_id のまとめ引きに変更し、3つの `show` を `related_records` に統一した
- 一覧ビューの `restricted` / `admin?` 判定を削除し、除外を自分自身のみにした
- デッドコードの `has_many :children` / `has_many :rooted_records` を削除した
- Customer / User の `editable?` を他3モデルと同じ複数行の `def` に揃えた

---

## 確認済

- [x] `bundle exec rspec` が全て緑（569 examples, 0 failures）
- [x] `bundle exec rubocop app/ spec/` が offense なし
- [x] 3つの一覧画面で、スレッド数を増やしてもクエリ数が一定（N+1 なし）
- [x] 3つの詳細画面で timeline が全件・正しい順序で表示される
- [x] 非 admin に `restricted` なレコードが timeline / 一覧の関連行に出ない

---

Closes #186 