### PR TITLE
Unify permission rules and close access gaps around admin-only records

### DIFF
--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -3,9 +3,11 @@ module Authorizable
 
   private
 
-  def authorize_edit!(record)
+  # 拒否時はそのレコードの詳細へ返す。
+  # 詳細画面を持たないリソースは fallback で戻り先を明示する。
+  def authorize_edit!(record, fallback: record)
     return if record.editable?
 
-    redirect_to record, alert: "編集権限がありません"
+    redirect_to fallback, alert: "編集権限がありません"
   end
 end

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -1,5 +1,8 @@
 class CustomersController < ApplicationController
+  include Authorizable
+
   before_action :set_customer, only: [ :show, :edit, :update ]
+  before_action -> { authorize_edit!(@customer) }, only: [ :edit, :update ]
 
   def index
     @q = Customer.readable.ransack(params[:q], auth_object: :customer_list)

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -6,7 +6,7 @@ class NoticesController < ApplicationController
   before_action -> { authorize_edit!(@notice) }, only: %i[edit update]
 
   def index
-    @q = readable_notices.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
+    @q = readable_notices.ransack(params[:q])
     @pagy, @notices = pagy(
       @q.result
         .preload(:user)
@@ -25,7 +25,7 @@ class NoticesController < ApplicationController
 
   def create
     @parent_notice = Notice.readable.find(params[:parent_id]) if params[:parent_id].present?
-    @notice = Current.user.notices.build(notice_params)
+    @notice = Current.user.notices.build(create_notice_params)
     @notice.parent = @parent_notice
 
     if @notice.save
@@ -71,16 +71,13 @@ class NoticesController < ApplicationController
   end
 
   def notice_params
-    permitted = %i[
-      title
-      content
-      level
-      start_at
-      end_at
-    ]
+    params.require(:notice).permit(:title, :content, :level, :start_at, :end_at, images: [])
+  end
 
-    permitted << :restricted if Current.user.admin?
+  # 公開範囲は新規作成時にのみ admin が選択できる。作成後は変更できない。
+  def create_notice_params
+    return notice_params unless Current.user.admin?
 
-    params.require(:notice).permit(*permitted, images: [])
+    notice_params.merge(params.require(:notice).permit(:restricted))
   end
 end

--- a/app/controllers/task_assignments_controller.rb
+++ b/app/controllers/task_assignments_controller.rb
@@ -1,6 +1,9 @@
 class TaskAssignmentsController < ApplicationController
+  include Authorizable
+
   before_action :set_task_assignment
-  before_action :authorize_owner!
+  # TaskAssignment に show ルートは無いため、親タスクの詳細へ返す。
+  before_action -> { authorize_edit!(@task_assignment, fallback: @task_assignment.task) }
 
   def update
     if @task_assignment.update(task_assignment_params)
@@ -14,12 +17,6 @@ class TaskAssignmentsController < ApplicationController
 
   def set_task_assignment
     @task_assignment = TaskAssignment.readable.find(params[:id])
-  end
-
-  def authorize_owner!
-    return if @task_assignment.editable?
-
-    redirect_to @task_assignment.task, alert: "更新権限がありません"
   end
 
   def task_assignment_params

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,7 +6,7 @@ class TasksController < ApplicationController
   before_action -> { authorize_edit!(@task) }, only: [ :edit, :update ]
 
   def index
-    @q = readable_tasks.ransack(params[:q], auth_object: Current.user.admin? ? :admin : nil)
+    @q = readable_tasks.ransack(params[:q])
     @pagy, @tasks = pagy(
       @q.result
         .preload(:user, task_assignments: [ :user ])
@@ -26,7 +26,7 @@ class TasksController < ApplicationController
 
   def create
     @parent_task = Task.readable.find(params[:parent_id]) if params[:parent_id].present?
-    @task = Current.user.tasks.build(task_params)
+    @task = Current.user.tasks.build(create_task_params)
     @task.parent = @parent_task
 
     @form = TaskForm.new(
@@ -76,14 +76,13 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    permitted = [
-      :title,
-      :description,
-      :due_at
-    ]
+    params.require(:task).permit(:title, :description, :due_at, images: [])
+  end
 
-    permitted << :restricted if Current.user.admin?
+  # 公開範囲は新規作成時にのみ admin が選択できる。作成後は変更できない。
+  def create_task_params
+    return task_params unless Current.user.admin?
 
-    params.require(:task).permit(*permitted, images: [])
+    task_params.merge(params.require(:task).permit(:restricted))
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 class UsersController < ApplicationController
+  include Authorizable
+
   before_action :set_user, only: %i[show edit update]
-  before_action :require_admin, only: %i[new create edit update]
+  # new/create は対象レコードが無く「誰が従業員を登録できるか」という別の問い。
+  before_action :require_admin, only: %i[new create]
+  before_action -> { authorize_edit!(@user) }, only: %i[edit update]
 
   def index
     @q = User.readable.ransack(params[:q], auth_object: :user_list)
@@ -16,7 +20,7 @@ class UsersController < ApplicationController
   end
 
   def create
-    @user = User.new(user_params)
+    @user = User.new(create_user_params)
 
     if @user.save
       redirect_to @user, notice: "従業員を登録しました"
@@ -43,14 +47,18 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    permitted = %i[
-      name
-      email_address
-      admin
-    ]
-
+    permitted = %i[name email_address]
     permitted << :password if params.require(:user)[:password].present?
 
-    params.require(:user).permit(permitted)
+    params.require(:user).permit(*permitted)
+  end
+
+  # 権限は新規登録時にのみ選択できる。登録後は変更できない。
+  # create は require_admin で守られているが、tasks/notices の同名メソッドと
+  # 形を揃えるため、ここでも admin かどうかを明示的に確認する。
+  def create_user_params
+    return user_params unless Current.user.admin?
+
+    user_params.merge(params.require(:user).permit(:admin))
   end
 end

--- a/app/forms/task_form.rb
+++ b/app/forms/task_form.rb
@@ -6,6 +6,9 @@ class TaskForm
 
   validate :task_must_be_valid
   validate :at_least_one_assignee, if: -> { task.new_record? }
+  # 親から restricted を継承するのは task の before_validation なので、
+  # このバリデーションの実行順に関係なく判定できるよう parent も見る。
+  validate :assignees_must_be_admin, if: -> { task.restricted? || task.parent&.restricted? }
 
   def initialize(task:, assignee_ids: [], interaction_id: nil, notice_id: nil)
     @task           = task
@@ -50,5 +53,15 @@ class TaskForm
   def at_least_one_assignee
     return if assignee_ids.any?
     errors.add(:base, "担当者を1人以上選択してください")
+  end
+
+  # TaskAssignment 側のバリデーションと同じ規則をフォームでも検証する。
+  # ここで弾かないと save 内の create! が RecordInvalid を投げて500になる。
+  # 管理者限定タスクの担当者は admin に限られる（TaskAssignment#assignee_must_be_admin）。
+  def assignees_must_be_admin
+    non_admins = User.readable.where(id: assignee_ids, admin: false)
+    return if non_admins.empty?
+
+    errors.add(:base, "管理者限定タスクには管理者以外を担当者に指定できません（#{non_admins.map(&:name).join('、')}）")
   end
 end

--- a/app/models/concerns/restrictable.rb
+++ b/app/models/concerns/restrictable.rb
@@ -3,5 +3,41 @@ module Restrictable
 
   included do
     scope :not_restricted, -> { Current.user&.admin? ? all : where(restricted: false) }
+
+    before_validation :inherit_restricted_from_parent, on: :create
+
+    validates :restricted, inclusion: { in: [ true, false ] }
+    validate :restricted_must_be_owned_by_admin, on: :create
+    validate :restricted_must_not_change, on: :update
+  end
+
+  private
+
+  # 管理者限定のレコードにぶら下がる関連は、必ず親と同じ公開範囲にする。
+  # 関連だけが公開されると、一連の関連の一部だけが意図せず全員に見える状態になるため。
+  # 公開範囲は作成後に変更できないので、親を見て決まる方が扱いも一貫する。
+  def inherit_restricted_from_parent
+    return unless parent&.restricted?
+
+    self.restricted = true
+  end
+
+  # 公開範囲を絞ったレコードは admin しか閲覧できない（readable）。
+  # 非 admin が作成すると作成者自身が到達できないレコードになるため、
+  # コントローラの許可属性だけに頼らずモデル側でも禁止する。
+  def restricted_must_be_owned_by_admin
+    return unless restricted?
+    return if user&.admin?
+
+    errors.add(:restricted, "は管理者のみ設定できます")
+  end
+
+  # 公開範囲は新規作成時にのみ選択できる。
+  # 後から切り替えると、担当者が到達できないタスクが生じたり、
+  # 既に閲覧された内容を事後的に秘匿することになるため。
+  def restricted_must_not_change
+    return unless restricted_changed?
+
+    errors.add(:restricted, "は作成後に変更できません")
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -14,12 +14,16 @@ class Customer < ApplicationRecord
   scope :readable, -> { demo(Current.demo?) }
 
   # 顧客情報は業務の核であり、都度の許可申請では現場が回らないため全員編集可。
+  # 認証済みなら常に true になるため、呼び出し側のガードは通過専用。
+  # それでも他リソースと同じ形で書くのは、後から条件を絞るときの入口を1箇所に保つため。
   def editable?
     Current.user.present?
   end
 
   private
 
+  # auth_object は「どの一覧画面から検索しているか」を表す。
+  # 他モデルの関連を辿った検索では渡らないため、メールアドレス等は開放されない。
   def self.ransackable_attributes(auth_object = nil)
     base = %w[name phone]
     auth_object == :customer_list ? base + %w[email] : base

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -28,7 +28,6 @@ class Notice < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
   validates :content, presence: true,  length: { maximum: 2000 }
   validates :level, presence: true
-  validates :restricted, inclusion: { in: [ true, false ] }
   validates :start_at, presence: true
   validates :end_at, presence: true
   validates :end_at, comparison: { greater_than: :start_at }, if: -> { start_at.present? && end_at.present? }
@@ -52,9 +51,10 @@ class Notice < ApplicationRecord
     end
   }
 
+  # 検索フォームに出せる項目の宣言。閲覧境界は readable が持つ。
   def self.ransackable_attributes(auth_object = nil)
     base = %w[title content level start_at end_at]
-    auth_object == :admin ? base + %w[restricted] : base
+    Current.user&.admin? ? base + %w[restricted] : base
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -25,7 +25,6 @@ class Task < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :description, presence: true, length: { maximum: 2000 }
-  validates :restricted, inclusion: { in: [ true, false ] }
   validates :images,
     content_type: %w[image/jpeg image/png image/gif],
     size: { less_than_or_equal_to: 10.megabytes }
@@ -49,9 +48,10 @@ class Task < ApplicationRecord
     end
   }
 
+  # 検索フォームに出せる項目の宣言。閲覧境界は readable が持つ。
   def self.ransackable_attributes(auth_object = nil)
     base = %w[title description due_at]
-    auth_object == :admin ? base + %w[restricted] : base
+    Current.user&.admin? ? base + %w[restricted] : base
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/models/task_assignment.rb
+++ b/app/models/task_assignment.rb
@@ -10,9 +10,11 @@ class TaskAssignment < ApplicationRecord
     done: "done"
   }, default: :todo
 
-  validates :task_id, uniqueness: { scope: :user_id }
+  # 従属リソースのため、親タスクの閲覧境界をそのまま引き継ぐ。
+  scope :readable, -> { demo(Current.demo?).joins(:task).merge(Task.readable) }
 
-  scope :readable, -> { demo(Current.demo?) }
+  validates :task_id, uniqueness: { scope: :user_id }
+  validate :assignee_must_be_admin, if: -> { task&.restricted? }
 
   # 編集は担当者本人のみ。admin も改ざん防止のため対象外。
   def editable?
@@ -20,6 +22,14 @@ class TaskAssignment < ApplicationRecord
   end
 
   private
+
+  # 管理者限定タスクは admin しか閲覧できないため、
+  # 非 admin を担当者にすると「割り当てられているが見えないタスク」が生まれる。
+  def assignee_must_be_admin
+    return if user.blank? || user.admin?
+
+    errors.add(:user, "は管理者限定タスクの担当者にできません")
+  end
 
   def self.ransackable_attributes(auth_object = nil)
     %w[status user_id]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   validates :email_address, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :name, presence: true, length: { maximum: 50 }
   validates :password, length: { minimum: 8 }, if: -> { new_record? || !password.nil? }
+  validate :admin_must_not_change, on: :update
 
   scope :readable, -> { demo(Current.demo?) }
 
@@ -30,6 +31,19 @@ class User < ApplicationRecord
 
   private
 
+  # 権限は新規登録時にのみ選択できる。降格・昇格の両方を止める。
+  # 降格すると管理者限定のタスク・お知らせに到達できなくなり、
+  # 昇格を許すと「作成時は admin だった」という前提で通した
+  # Restrictable の検証（restricted_must_be_owned_by_admin）を後追いで崩せるため。
+  # 既存アカウントへの管理者付与はアプリからは行えない。
+  def admin_must_not_change
+    return unless admin_changed?
+
+    errors.add(:admin, "は登録後に変更できません")
+  end
+
+  # auth_object は「どの一覧画面から検索しているか」を表す。
+  # 他モデルの関連を辿った検索では渡らないため、メールアドレス等は開放されない。
   def self.ransackable_attributes(auth_object = nil)
     base = %w[name]
     auth_object == :user_list ? base + %w[email_address admin] : base

--- a/app/views/customers/show.html.erb
+++ b/app/views/customers/show.html.erb
@@ -45,10 +45,12 @@
 
     <%= render "related_interactions", interactions: @interactions %>
 
-    <div class="mt-6 flex justify-end border-t-4 border-gray-300 pt-6">
-      <%= link_to "編集",
-                  edit_customer_path(@customer),
-                  class: "px-3 xl:px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
-    </div>
+    <% if @customer.editable? %>
+      <div class="mt-6 flex justify-end border-t-4 border-gray-300 pt-6">
+        <%= link_to "編集",
+                    edit_customer_path(@customer),
+                    class: "px-3 xl:px-4 h-8 sm:h-9 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs sm:text-sm inline-flex items-center justify-center whitespace-nowrap" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/notices/_form.html.erb
+++ b/app/views/notices/_form.html.erb
@@ -46,14 +46,21 @@
                                  class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm xl:text-sm" %>
     </div>
 
-    <% if Current.user.admin? %>
+    <%# 公開範囲は新規作成時にのみ選択できる。関連元が管理者限定なら引き継ぐ %>
+    <% if Current.user.admin? && notice.new_record? %>
       <div>
         <span class="block text-xs sm:text-sm text-gray-700 mb-1">公開範囲</span>
 
-        <label class="flex items-center h-8 sm:h-9">
-          <%= f.check_box :restricted, class: "rounded" %>
-          <span class="ml-2 text-xs sm:text-sm text-gray-700">管理者のみ</span>
-        </label>
+        <% if notice.parent&.restricted? %>
+          <p class="flex items-center h-8 sm:h-9 text-xs sm:text-sm text-gray-700">
+            管理者のみ（関連元から引き継ぎます）
+          </p>
+        <% else %>
+          <label class="flex items-center h-8 sm:h-9">
+            <%= f.check_box :restricted, class: "rounded" %>
+            <span class="ml-2 text-xs sm:text-sm text-gray-700">管理者のみ</span>
+          </label>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -41,16 +41,33 @@
       <p class="mt-1 text-xs text-gray-400">
         複数選択可。Windows: Ctrl+クリック / Mac: Command+クリックで複数選択
       </p>
+
+      <% if Current.user.admin? && task.new_record? %>
+        <p class="mt-1 text-xs text-gray-400">
+          <% if task.parent&.restricted? %>
+            管理者限定タスクのため、担当者は管理者のみ指定できます。
+          <% else %>
+            公開範囲を管理者限定にする場合、担当者は管理者のみ指定できます。
+          <% end %>
+        </p>
+      <% end %>
     </div>
 
-    <% if Current.user.admin? %>
+    <%# 公開範囲は新規作成時にのみ選択できる。関連元が管理者限定なら引き継ぐ %>
+    <% if Current.user.admin? && task.new_record? %>
       <div>
         <span class="block text-xs sm:text-sm text-gray-700 mb-1">公開範囲</span>
 
-        <label class="flex items-center h-8 sm:h-9">
-          <%= f.check_box :restricted, class: "rounded" %>
-          <span class="ml-2 text-xs sm:text-sm text-gray-700">管理者のみ</span>
-        </label>
+        <% if task.parent&.restricted? %>
+          <p class="flex items-center h-8 sm:h-9 text-xs sm:text-sm text-gray-700">
+            管理者のみ（関連元から引き継ぎます）
+          </p>
+        <% else %>
+          <label class="flex items-center h-8 sm:h-9">
+            <%= f.check_box :restricted, class: "rounded" %>
+            <span class="ml-2 text-xs sm:text-sm text-gray-700">管理者のみ</span>
+          </label>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -30,6 +30,11 @@
           </div>
 
           <div class="flex items-center">
+            <span class="w-16 shrink-0 text-gray-600">対象:</span>
+            <span><%= @task.restricted? ? "管理者のみ" : "全員" %></span>
+          </div>
+
+          <div class="flex items-center">
             <span class="w-16 shrink-0 text-gray-600">期限:</span>
             <span><%= @task.due_at ? l(@task.due_at) : "未設定" %></span>
           </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -36,7 +36,8 @@
                          class: "w-full border border-gray-300 rounded px-3 py-2 h-8 sm:h-9 text-xs sm:text-sm" %>
   </div>
 
-  <% if Current.user.admin? %>
+  <%# 権限は新規登録時にのみ選択できる %>
+  <% if Current.user.admin? && user.new_record? %>
     <div class="flex items-center gap-2">
       <%= f.check_box :admin, class: "rounded" %>
       <%= f.label :admin, "管理者権限を付与", class: "text-xs sm:text-sm text-gray-700" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -47,7 +47,7 @@
 
     <%= render "related_interactions", interactions: @interactions %>
 
-    <% if Current.user&.admin? %>
+    <% if @user.editable? %>
       <div class="mt-6 flex justify-end border-t-4 border-gray-300 pt-6">
         <%= link_to "編集",
                     edit_user_path(@user),

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,28 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "f619ca75a347b9b03bcd67e53329dc92dedfac0f09856481e3f6bb4af090556f",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/users_controller.rb",
+      "line": 62,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:user).permit(:admin)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "UsersController",
+        "method": "create_user_params"
+      },
+      "user_input": ":admin",
+      "confidence": "High",
+      "cwe_id": [
+        915
+      ],
+      "note": "権限は新規登録時にのみ admin が選択でき、登録後は変更できない仕様。create は require_admin で保護し、create_user_params 内でも Current.user.admin? を再確認している。update が通る user_params に :admin は含まれないため、権限昇格の経路はない。spec/requests/users_spec.rb で昇格も降格もできないことを検証済み。"
+    }
+  ],
+  "brakeman_version": "8.0.5"
+}

--- a/db/seeds/demo_seed.rb
+++ b/db/seeds/demo_seed.rb
@@ -303,11 +303,14 @@ end
 puts "デモ用タスク #{demo_tasks.size}件を作成しました"
 
 # タスク担当割り当て（作成者 + ランダムに1〜2名を追加）
+# 管理者限定タスクは admin しか閲覧できないため、追加担当者も admin に限る。
 statuses = %i[todo in_progress done]
 
 demo_tasks.each_value do |task|
+  assignable_users = task.restricted? ? all_demo_users.select(&:admin?) : all_demo_users
+
   assignees = [ task.user ]
-  assignees += all_demo_users.reject { |u| u == task.user }.sample(rng.rand(1..2), random: rng)
+  assignees += assignable_users.reject { |u| u == task.user }.sample(rng.rand(1..2), random: rng)
 
   assignees.uniq.each do |user|
     TaskAssignment.create!(

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Notice, type: :model do
 
     describe 'restricted' do
       it 'is valid when restricted is true' do
-        notice = build(:notice, restricted: true)
+        notice = build(:notice, restricted: true, user: build(:user, admin: true))
         expect(notice).to be_valid
       end
 
@@ -157,6 +157,53 @@ RSpec.describe Notice, type: :model do
       it 'is invalid when restricted is nil' do
         notice = build(:notice, restricted: nil)
         expect(notice).to be_invalid
+      end
+
+      it 'inherits restricted from a restricted parent' do
+        admin  = create(:user, admin: true)
+        parent = create(:notice, restricted: true, user: admin)
+
+        child = create(:notice, restricted: false, user: admin, parent: parent)
+
+        expect(child.restricted).to be(true)
+      end
+
+      it 'keeps a restricted child under a parent that is not restricted' do
+        parent = create(:notice, restricted: false)
+
+        child = create(:notice, restricted: true, user: create(:user, admin: true), parent: parent)
+
+        expect(child.restricted).to be(true)
+      end
+
+      it 'is invalid when a non-admin owns a restricted notice' do
+        notice = build(:notice, restricted: true, user: build(:user, admin: false))
+
+        expect(notice).to be_invalid
+        expect(notice.errors[:restricted]).to be_present
+      end
+    end
+
+    describe 'restricted is fixed at creation' do
+      it 'cannot be switched on after creation' do
+        notice = create(:notice, restricted: false)
+        notice.restricted = true
+
+        expect(notice).to be_invalid
+        expect(notice.errors[:restricted]).to be_present
+      end
+
+      it 'cannot be switched off after creation' do
+        notice = create(:notice, restricted: true, user: create(:user, admin: true))
+        notice.restricted = false
+
+        expect(notice).to be_invalid
+      end
+
+      it 'allows updating other attributes without touching restricted' do
+        notice = create(:notice, restricted: true, user: create(:user, admin: true))
+
+        expect(notice.update(content: "追記")).to be(true)
       end
     end
 
@@ -225,16 +272,20 @@ RSpec.describe Notice, type: :model do
   end
 
   describe "ransackable_attributes" do
-    it "permits restricted in addition to base attributes when auth_object is :admin" do
-      expect(described_class.ransackable_attributes(:admin)).to match_array(%w[title content level start_at end_at restricted])
+    it "permits restricted in addition to base attributes for an admin" do
+      Current.session = Session.new(user: build(:user, admin: true))
+
+      expect(described_class.ransackable_attributes).to match_array(%w[title content level start_at end_at restricted])
     end
 
-    it "does not permit restricted when auth_object is nil" do
-      expect(described_class.ransackable_attributes(nil)).to match_array(%w[title content level start_at end_at])
+    it "does not permit restricted when the current user is unset" do
+      expect(described_class.ransackable_attributes).to match_array(%w[title content level start_at end_at])
     end
 
-    it "falls back to the base list without restricted for unexpected auth_object values" do
-      expect(described_class.ransackable_attributes(:something_else)).to match_array(%w[title content level start_at end_at])
+    it "does not permit restricted for a non-admin" do
+      Current.session = Session.new(user: build(:user, admin: false))
+
+      expect(described_class.ransackable_attributes).to match_array(%w[title content level start_at end_at])
     end
   end
 

--- a/spec/models/task_assignment_spec.rb
+++ b/spec/models/task_assignment_spec.rb
@@ -33,5 +33,45 @@ RSpec.describe TaskAssignment, type: :model do
         expect(duplicate).to be_invalid
       end
     end
+
+    describe 'assignee of a restricted task' do
+      let(:restricted_task) { create(:task, restricted: true, user: create(:user, admin: true)) }
+
+      it 'is invalid when the assignee is not an admin' do
+        assignment = build(:task_assignment, task: restricted_task, user: create(:user, admin: false))
+
+        expect(assignment).to be_invalid
+        expect(assignment.errors[:user]).to be_present
+      end
+
+      it 'is valid when the assignee is an admin' do
+        assignment = build(:task_assignment, task: restricted_task, user: create(:user, admin: true))
+
+        expect(assignment).to be_valid
+      end
+
+      it 'allows a non-admin assignee on a task that is not restricted' do
+        assignment = build(:task_assignment, task: create(:task, restricted: false), user: create(:user, admin: false))
+
+        expect(assignment).to be_valid
+      end
+    end
+  end
+
+  describe '.readable' do
+    let(:restricted_task) { create(:task, restricted: true, user: create(:user, admin: true)) }
+    let!(:assignment) { create(:task_assignment, task: restricted_task, user: create(:user, admin: true)) }
+
+    it 'excludes assignments of restricted tasks for a non-admin' do
+      Current.session = Session.new(user: create(:user, admin: false))
+
+      expect(described_class.readable).not_to include(assignment)
+    end
+
+    it 'includes assignments of restricted tasks for an admin' do
+      Current.session = Session.new(user: create(:user, admin: true))
+
+      expect(described_class.readable).to include(assignment)
+    end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -102,6 +102,29 @@ RSpec.describe Task, type: :model do
   end
 
   describe 'validations' do
+    describe 'restricted is fixed at creation' do
+      it 'cannot be switched on after creation' do
+        task = create(:task, restricted: false)
+        task.restricted = true
+
+        expect(task).to be_invalid
+        expect(task.errors[:restricted]).to be_present
+      end
+
+      it 'cannot be switched off after creation' do
+        task = create(:task, restricted: true, user: create(:user, admin: true))
+        task.restricted = false
+
+        expect(task).to be_invalid
+      end
+
+      it 'allows updating other attributes without touching restricted' do
+        task = create(:task, restricted: true, user: create(:user, admin: true))
+
+        expect(task.update(description: "追記")).to be(true)
+      end
+    end
+
     describe 'title' do
       it 'is required' do
         task = build(:task, title: "")
@@ -144,7 +167,7 @@ RSpec.describe Task, type: :model do
 
     describe 'restricted' do
       it 'is valid when restricted is true' do
-        task = build(:task, restricted: true)
+        task = build(:task, restricted: true, user: build(:user, admin: true))
 
         expect(task).to be_valid
       end
@@ -159,6 +182,30 @@ RSpec.describe Task, type: :model do
         task = build(:task, restricted: nil)
 
         expect(task).to be_invalid
+      end
+
+      it 'inherits restricted from a restricted parent' do
+        admin  = create(:user, admin: true)
+        parent = create(:task, restricted: true, user: admin)
+
+        child = create(:task, restricted: false, user: admin, parent: parent)
+
+        expect(child.restricted).to be(true)
+      end
+
+      it 'keeps a restricted child under a parent that is not restricted' do
+        parent = create(:task, restricted: false)
+
+        child = create(:task, restricted: true, user: create(:user, admin: true), parent: parent)
+
+        expect(child.restricted).to be(true)
+      end
+
+      it 'is invalid when a non-admin owns a restricted task' do
+        task = build(:task, restricted: true, user: build(:user, admin: false))
+
+        expect(task).to be_invalid
+        expect(task.errors[:restricted]).to be_present
       end
     end
 
@@ -199,17 +246,22 @@ RSpec.describe Task, type: :model do
   end
 
   describe "ransackable_attributes" do
-    it "permits restricted in addition to base attributes when auth_object is :admin" do
-      expect(described_class.ransackable_attributes(:admin)).to include("title", "description", "due_at", "restricted")
+    it "permits restricted in addition to base attributes for an admin" do
+      Current.session = Session.new(user: build(:user, admin: true))
+
+      expect(described_class.ransackable_attributes).to include("title", "description", "due_at", "restricted")
     end
 
-    it "does not permit restricted when auth_object is nil" do
-      expect(described_class.ransackable_attributes(nil)).to include("title", "description", "due_at")
-      expect(described_class.ransackable_attributes(nil)).not_to include("restricted")
+    it "does not permit restricted when the current user is unset" do
+      expect(described_class.ransackable_attributes).to include("title", "description", "due_at")
+      expect(described_class.ransackable_attributes).not_to include("restricted")
     end
 
-    it "falls back to the base list without restricted for unexpected auth_object values" do
-      expect(described_class.ransackable_attributes(:something_else)).not_to include("restricted")
+    it "does not permit restricted for a non-admin" do
+      Current.session = Session.new(user: build(:user, admin: false))
+
+      expect(described_class.ransackable_attributes).to include("title", "description", "due_at")
+      expect(described_class.ransackable_attributes).not_to include("restricted")
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -100,6 +100,29 @@ RSpec.describe User, type: :model do
         expect(user.admin).to be true
       end
     end
+
+    describe 'admin is fixed at registration' do
+      it 'cannot be revoked after registration' do
+        user = create(:user, admin: true)
+        user.admin = false
+
+        expect(user).to be_invalid
+        expect(user.errors[:admin]).to be_present
+      end
+
+      it 'cannot be granted after registration' do
+        user = create(:user, admin: false)
+        user.admin = true
+
+        expect(user).to be_invalid
+      end
+
+      it 'allows updating other attributes without touching admin' do
+        user = create(:user, admin: true)
+
+        expect(user.update(name: "新しい名前")).to be(true)
+      end
+    end
   end
 
   describe 'ransackable_attributes' do

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Comments", type: :request do
   end
 
   shared_examples "restricts posting comments" do |commentable_factory|
-    let(:commentable) { create(commentable_factory, user: other_user, restricted: true) }
+    let(:commentable) { create(commentable_factory, user: create(:user, admin: true), restricted: true) }
 
     it "does not allow a non-admin user to comment on a restricted record" do
       expect {

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -360,10 +360,11 @@ RSpec.describe "Notices", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "displays restricted check box" do
+      # 公開範囲は新規作成時にのみ選択できる
+      it "does not display restricted check box" do
         get edit_notice_path(restricted_notice)
 
-        expect(response.body).to include("管理者のみ")
+        expect(response.body).not_to include("管理者のみ")
       end
     end
 
@@ -433,6 +434,14 @@ RSpec.describe "Notices", type: :request do
 
         expect(restricted_notice.reload.content).to eq("追記")
         expect(response).to redirect_to notice_path(restricted_notice)
+      end
+
+      # 公開範囲は新規作成時にのみ選択できる
+      it "ignores restricted and still applies the other attributes" do
+        patch notice_path(restricted_notice), params: { notice: { content: "追記", restricted: false } }
+
+        expect(restricted_notice.reload.restricted).to be(true)
+        expect(restricted_notice.content).to eq("追記")
       end
     end
 

--- a/spec/requests/restricted_visibility_spec.rb
+++ b/spec/requests/restricted_visibility_spec.rb
@@ -28,6 +28,74 @@ RSpec.describe "Restricted content visibility", type: :request do
     end
   end
 
+  describe "creating a follow-up under a restricted record" do
+    context "with a notice" do
+      let(:parent) { create(:notice, user: admin, restricted: true) }
+      let(:child) do
+        sign_in(admin)
+        post notices_path, params: {
+          parent_id: parent.id,
+          notice: attributes_for(:notice).merge(title: "続報", content: "上記の件の続き", restricted: "0")
+        }
+        Notice.find_by!(title: "続報")
+      end
+
+      it "stays restricted even when the admin leaves the checkbox off" do
+        expect(child.restricted).to be(true)
+      end
+
+      it "is not reachable by a non-admin" do
+        target = child
+        sign_in(user)
+        get notice_path(target)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "with a task" do
+      let(:parent) { create(:task, user: admin, restricted: true) }
+      let(:child) do
+        sign_in(admin)
+        post tasks_path, params: {
+          parent_id: parent.id,
+          task: attributes_for(:task).merge(title: "続報", description: "続き", restricted: "0"),
+          assignee_ids: [ admin.id ]
+        }
+        Task.find_by!(title: "続報")
+      end
+
+      it "stays restricted even when the admin leaves the checkbox off" do
+        expect(child.restricted).to be(true)
+      end
+
+      it "is not reachable by a non-admin" do
+        target = child
+        sign_in(user)
+        get task_path(target)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      # 親から継承した restricted は task の before_validation で立つため、
+      # TaskForm 側の担当者チェックがその前に走ると素通りして500になる。
+      it "rejects a non-admin assignee even though restricted is only inherited" do
+        parent_task = parent
+        sign_in(admin)
+        params = {
+          parent_id: parent_task.id,
+          task: attributes_for(:task).merge(title: "継承続報", description: "続き"),
+          assignee_ids: [ user.id ]
+        }
+
+        expect { post tasks_path, params: params }.not_to change(Task, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("管理者以外を担当者に指定できません")
+      end
+    end
+  end
+
   describe "cross-model related sections" do
     it "does not expose a restricted task linked to a visible notice" do
       notice = create(:notice, user: admin, restricted: false)

--- a/spec/requests/task_assignments_spec.rb
+++ b/spec/requests/task_assignments_spec.rb
@@ -122,5 +122,86 @@ RSpec.describe "Task Assignments", type: :request do
 
       it_behaves_like "requires_authentication"
     end
+
+    # 過去データ由来で非 admin が管理者限定タスクの assignment を持っている状況を再現する。
+    # 割り当て後に restricted へ切り替えることでしか作れないため update_column で作る。
+    context "when the assignment belongs to a restricted task" do
+      # 割り当て後に restricted へ切り替えないと作れない状態のため update_column で作る。
+      def assign_then_restrict(assignee)
+        task = create(:task, user: task_creator, restricted: false)
+        assignment = create(:task_assignment, task: task, user: assignee, status: :todo)
+        task.update_column(:restricted, true)
+        assignment
+      end
+
+      it "does not let a non-admin assignee update the status" do
+        assignment = assign_then_restrict(first_assignee)
+        sign_in(first_assignee)
+
+        expect {
+          patch task_assignment_path(assignment), params: { task_assignment: { status: "done" } }
+        }.not_to change { assignment.reload.status }
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "lets an admin assignee update the status" do
+        admin_assignee = create(:user, admin: true)
+        assignment = assign_then_restrict(admin_assignee)
+
+        sign_in(admin_assignee)
+        patch task_assignment_path(assignment), params: { task_assignment: { status: "done" } }
+
+        expect(assignment.reload.status).to eq("done")
+      end
+    end
+  end
+
+  describe "POST /tasks with a restricted task" do
+    let(:admin) { create(:user, admin: true) }
+
+    def restricted_task_attributes
+      {
+        title:       "管理者限定タスク",
+        description: "管理者限定タスクの説明",
+        restricted:  true
+      }
+    end
+
+    before { sign_in(admin) }
+
+    it "returns 422 and re-renders the form when a non-admin is selected" do
+      post tasks_path, params: {
+        task:         restricted_task_attributes,
+        assignee_ids: [ create(:user, admin: false).id ]
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("管理者以外を担当者に指定できません")
+    end
+
+    it "does not create the task when a non-admin is selected" do
+      expect {
+        post tasks_path, params: {
+          task:         restricted_task_attributes,
+          assignee_ids: [ create(:user, admin: false).id ]
+        }
+      }.not_to change(Task, :count)
+
+      expect(TaskAssignment.count).to eq(0)
+    end
+
+    it "creates the task when every assignee is an admin" do
+      other_admin = create(:user, admin: true)
+
+      expect {
+        post tasks_path, params: {
+          task:         restricted_task_attributes,
+          assignee_ids: [ other_admin.id ]
+        }
+      }.to change(Task, :count).by(1)
+
+      expect(response).to redirect_to(task_path(Task.last))
+    end
   end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -246,8 +246,10 @@ RSpec.describe "Tasks", type: :request do
 
       it "allows to set restricted" do
         post tasks_path, params: create_task_with_assignees(
-          { task: attributes_for(:task).merge(restricted: true) }
+          { task: attributes_for(:task).merge(restricted: true) },
+          user: create(:user, admin: true)
         )
+
         expect(Task.last.restricted).to be(true)
       end
     end
@@ -337,10 +339,11 @@ RSpec.describe "Tasks", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "displays restricted check box" do
+      # 公開範囲は新規作成時にのみ選択できる
+      it "does not display restricted check box" do
         get edit_task_path(restricted_task)
 
-        expect(response.body).to include("管理者のみ")
+        expect(response.body).not_to include("管理者のみ")
       end
     end
 
@@ -413,6 +416,14 @@ RSpec.describe "Tasks", type: :request do
 
         expect(restricted_task.reload.description).to eq("追記")
         expect(response).to redirect_to task_path(restricted_task)
+      end
+
+      # 公開範囲は新規作成時にのみ選択できる
+      it "ignores restricted and still applies the other attributes" do
+        patch task_path(restricted_task), params: { task: { description: "追記", restricted: false } }
+
+        expect(restricted_task.reload.restricted).to be(true)
+        expect(restricted_task.description).to eq("追記")
       end
     end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -198,6 +198,15 @@ RSpec.describe "Users", type: :request do
         expect(response).to redirect_to(user_path(User.last))
       end
 
+      # 権限は新規登録時にのみ選択できる
+      it "can register a new user as an admin" do
+        post users_path, params: {
+          user: valid_params[:user].merge(admin: true)
+        }
+
+        expect(User.last.admin).to be(true)
+      end
+
       it "sets a success notice" do
         post users_path, params: valid_params
 
@@ -256,23 +265,24 @@ RSpec.describe "Users", type: :request do
         expect(response.body).to include("従業員名")
         expect(response.body).to include("メールアドレス")
         expect(response.body).to include("パスワード（変更する場合のみ）")
-        expect(response.body).to include("管理者権限を付与")
+        # 権限は新規登録時にのみ選択できる
+        expect(response.body).not_to include("管理者権限を付与")
       end
     end
 
     context "when the current user is not an admin" do
       before { sign_in(user) }
 
-      it "redirects to the root page" do
+      it "redirects to the show page" do
         get edit_user_path(user)
 
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(user_path(user))
       end
 
       it "sets an alert message" do
         get edit_user_path(user)
 
-        expect(flash[:alert]).to eq("管理者権限が必要です")
+        expect(flash[:alert]).to eq("編集権限がありません")
       end
     end
   end
@@ -304,6 +314,22 @@ RSpec.describe "Users", type: :request do
 
         expect(user.reload.name).to eq("Updated Name")
         expect(user.reload.email_address).to eq("updated@example.com")
+      end
+
+      # 権限は新規登録時にのみ選択できる
+      it "ignores admin and still applies the other attributes" do
+        other_admin = create(:user, admin: true)
+
+        patch user_path(other_admin), params: { user: { name: "新しい名前", admin: false } }
+
+        expect(other_admin.reload.admin).to be(true)
+        expect(other_admin.name).to eq("新しい名前")
+      end
+
+      it "cannot grant the admin flag to a general user" do
+        patch user_path(user), params: { user: { admin: true } }
+
+        expect(user.reload.admin).to be(false)
       end
 
       it "redirects to the user page" do
@@ -357,16 +383,16 @@ RSpec.describe "Users", type: :request do
         expect(user.reload.name).to eq(original_name)
       end
 
-      it "redirects to the root page" do
+      it "redirects to the show page" do
         patch user_path(user), params: valid_params
 
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(user_path(user))
       end
 
       it "sets an alert message" do
         patch user_path(user), params: valid_params
 
-        expect(flash[:alert]).to eq("管理者権限が必要です")
+        expect(flash[:alert]).to eq("編集権限がありません")
       end
     end
   end


### PR DESCRIPTION
## 概要

権限ルールの分散を解消し、`TaskAssignment` に残っていたアクセス境界の欠落を塞いだ。
あわせて `restricted` と `admin` を作成時にのみ設定できる仕様として確定させた。

---

## 変更内容

- `TaskAssignment#readable` が親タスクの `readable` を継承するようにし、独自の認可メソッドを `Authorizable#authorize_edit!` に統一
- 管理者限定タスクに非管理者を割り当てられないよう、`TaskAssignment` と `TaskForm` の両方に検証を追加
- `restricted` の検証を `Restrictable` に集約し、作成者が管理者であることと、作成後に変更できないことを検証
- `User#admin` も登録後は変更できないよう検証を追加
- `restricted` と `admin` を `create_*_params` に分離し、編集フォームから入力欄を除外
- `Customer` の編集に `authorize_edit!` を追加し、`users/show` と `customers/show` の編集リンクを `editable?` で出し分け
- ransack の `auth_object` から権限の意味を外し、`Task` と `Notice` は `Current.user&.admin?` を参照する形に変更
- 新しい検証に合わせ、デモ用シードの管理者限定タスクには管理者のみを割り当てるよう修正

---

## 確認済

- [x] 非管理者が管理者限定タスクの割り当てを更新できない
- [x] 管理者限定タスクに非管理者を担当者として指定すると 422 でフォームに戻る
- [x] 作成後に `restricted` を変更できない
- [x] 登録後に `admin` を変更できない
- [x] `editable?` がすべて呼び出し元を持つ
- [x] デモ用シードが新しい検証のもとで読み込める
- [x] `bundle exec rspec` が全てgreen
- [x] `bundle exec rubocop` が offense なし

---

Closes #188 