### PR TITLE
Improve related task due date display for unset deadlines

### DIFF
--- a/app/views/interactions/_related_tasks.html.erb
+++ b/app/views/interactions/_related_tasks.html.erb
@@ -12,8 +12,8 @@
                       class: "flex-1 min-w-0 truncate text-gray-700 group-hover:text-blue-600" %>
 
           <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right tabular-nums text-gray-500 group-hover:text-blue-600">
-            <span class="sm:hidden"><%= task.due_at.strftime("%-m/%-d") %></span>
-            <span class="hidden sm:inline"><%= l task.due_at %></span>
+            <span class="sm:hidden"><%= task.due_at ? task.due_at.strftime("%-m/%-d") : "未設定" %></span>
+            <span class="hidden sm:inline"><%= task.due_at ? l(task.due_at) : "未設定" %></span>
           </span>
         </li>
       <% end %>

--- a/app/views/notices/_related_tasks.html.erb
+++ b/app/views/notices/_related_tasks.html.erb
@@ -12,8 +12,8 @@
                       class: "flex-1 min-w-0 truncate text-gray-700 group-hover:text-blue-600" %>
 
           <span class="w-10 sm:w-32 shrink-0 whitespace-nowrap text-right tabular-nums text-gray-500 group-hover:text-blue-600">
-            <span class="sm:hidden"><%= task.due_at.strftime("%-m/%-d") %></span>
-            <span class="hidden sm:inline"><%= l task.due_at %></span>
+            <span class="sm:hidden"><%= task.due_at ? task.due_at.strftime("%-m/%-d") : "未設定" %></span>
+            <span class="hidden sm:inline"><%= task.due_at ? l(task.due_at) : "未設定" %></span>
           </span>
         </li>
       <% end %>

--- a/spec/requests/interaction_tasks_spec.rb
+++ b/spec/requests/interaction_tasks_spec.rb
@@ -20,6 +20,19 @@ RSpec.describe "Interaction Tasks", type: :request do
       end
     end
 
+    context "when the linked task has no due date" do
+      let(:task) { create(:task, due_at: nil) }
+
+      before { interaction.tasks << task }
+
+      it "displays the fallback text instead of failing" do
+        get interaction_path(interaction)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("未設定")
+      end
+    end
+
     context "when the interaction has no linked tasks" do
       it "displays the empty message" do
         get interaction_path(interaction)

--- a/spec/requests/notice_tasks_spec.rb
+++ b/spec/requests/notice_tasks_spec.rb
@@ -6,6 +6,23 @@ RSpec.describe "Notice Tasks", type: :request do
 
   before { sign_in(user) }
 
+  describe "GET /notices/:id - related tasks display" do
+    let(:notice) { create(:notice, user: user) }
+
+    context "when the linked task has no due date" do
+      let(:task) { create(:task, due_at: nil) }
+
+      before { notice.tasks << task }
+
+      it "displays the fallback text instead of failing" do
+        get notice_path(notice)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("未設定")
+      end
+    end
+  end
+
   describe "GET /notices/new with task_id" do
     it "passes task_id to the form" do
       get new_notice_path(task_id: task.id)


### PR DESCRIPTION
## 概要

応対履歴とお知らせの関連タスクセクションの期限表示に nil ガードを入れ、タスク側の画面と同じ「未設定」表記に揃えた。

---

## 変更内容

- `app/views/interactions/_related_tasks.html.erb` / `app/views/notices/_related_tasks.html.erb` の期限表示を三項演算子で nil ガードし、`due_at` が nil の場合は「未設定」を表示するようにした
- モバイル幅は `strftime("%-m/%-d")`、デスクトップ幅は `l` という既存の出し分けはそのまま維持している
- `spec/requests/interaction_tasks_spec.rb` / `spec/requests/notice_tasks_spec.rb` に、期限未設定のタスクを紐づけた詳細画面が 200 を返し「未設定」を含むことを検証するスペックを追加した

---

## 確認済

- [x] `bundle exec rspec` が全てgreen
- [x] `bundle exec rubocop` が offense なし
- [x] 修正前のビューでは追加したスペック 2 件が `NoMethodError` で失敗することを確認
- [x] 関連セクションのその他のマークアップおよびタスク側の既存表示ロジックは変更していない

---

Closes #190 