### PR TITLE
Replace ActiveStorage URLs with an authorized attachments controller

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,0 +1,27 @@
+class AttachmentsController < ApplicationController
+  ATTACHABLES = {
+    "Interaction" => Interaction,
+    "Task" => Task,
+    "Notice" => Notice
+  }.freeze
+
+  # ActiveStorage の既定ルートはアプリの認可を通らないため、
+  # 添付が属するレコードを readable で引き直したうえでバイト列を直接返す。
+  # URL を発行しないので署名付き URL も残らない。
+  def show
+    attachment = ActiveStorage::Attachment.where(name: "images").find(params[:id])
+    klass = ATTACHABLES[attachment.record_type]
+
+    raise ActiveRecord::RecordNotFound unless klass
+
+    # 到達できないレコードの添付は 404。認可はレコード側の readable が唯一の判断基準。
+    klass.readable.find(attachment.record_id)
+
+    variant = attachment.variant(resize_to_limit: [ 800, 800 ]).processed
+
+    # 認可を通した個人向けレスポンスなので共有キャッシュには載せない。
+    expires_in 1.hour, public: false
+
+    send_data variant.download, type: variant.content_type, disposition: :inline
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,10 +24,6 @@ module ApplicationHelper
     end
   end
 
-  def thumbnail_variant(image)
-    image.variant(resize_to_limit: [ 800, 800 ])
-  end
-
   def pagy_tailwind_nav(pagy)
     return "".html_safe if pagy.pages <= 1
 

--- a/app/views/shared/_images.html.erb
+++ b/app/views/shared/_images.html.erb
@@ -4,7 +4,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
       <% record.images.each do |image| %>
         <div class="bg-gray-50 rounded p-2 text-center">
-          <%= image_tag thumbnail_variant(image), alt: image.filename.to_s, class: "rounded object-cover w-full h-auto" %>
+          <%= image_tag attachment_path(image), alt: image.filename.to_s, class: "rounded object-cover w-full h-auto" %>
         </div>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   resources :comments, only: [ :create ]
   resources :task_assignments, only: [ :update ]
 
+  resources :attachments, only: [ :show ]
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/spec/requests/attachments_spec.rb
+++ b/spec/requests/attachments_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe "Attachments", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:user)  { create(:user) }
+
+  def attach_image(record)
+    record.images.attach(valid_image)
+    record.images.first
+  end
+
+  describe "GET /attachments/:id" do
+    context "when signed in as a non-admin" do
+      before { sign_in(user) }
+
+      it "serves a task image" do
+        image = attach_image(create(:task, user: user))
+
+        get attachment_path(image)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to be_present
+      end
+
+      it "serves a notice image" do
+        image = attach_image(create(:notice, user: admin))
+
+        get attachment_path(image)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "serves an interaction image" do
+        image = attach_image(create(:interaction, user: user))
+
+        get attachment_path(image)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "marks the response as privately cacheable" do
+        image = attach_image(create(:task, user: user))
+
+        get attachment_path(image)
+
+        expect(response.headers["Cache-Control"]).to include("private", "max-age=3600")
+      end
+
+      it "does not serve an image of a restricted task" do
+        image = attach_image(create(:task, user: admin, restricted: true))
+
+        get attachment_path(image)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "does not serve an attachment on an unlisted record type" do
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: Rails.root.join("spec/fixtures/files/test.jpg").open,
+          filename: "test.jpg",
+          content_type: "image/jpeg"
+        )
+        attachment = ActiveStorage::Attachment.create!(name: "images", record: create(:customer), blob: blob)
+
+        get attachment_path(attachment)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when signed in as an admin" do
+      before { sign_in(admin) }
+
+      it "serves an image of a restricted task" do
+        image = attach_image(create(:task, user: admin, restricted: true))
+
+        get attachment_path(image)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to be_present
+      end
+    end
+
+    context "when signed in as a demo user" do
+      before { create(:user, demo: true, email_address: User::DEMO_LOGIN_EMAIL) }
+
+      it "does not serve a production record's image" do
+        image = attach_image(create(:task, user: user))
+
+        post demo_login_path
+
+        get attachment_path(image)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

添付画像の配信を ActiveStorage の既定ルートから `AttachmentsController#show` に移し、`readable` スコープによる認可を通した上でバイト列を返すようにした。署名付き URL を一切発行しないため、URL を入手しても認可を迂回できない。

---

## 変更内容

- `AttachmentsController` を追加。`ATTACHABLES`（Interaction / Task / Notice）で `record_type` をホワイトリスト検証し、`klass.readable.find(attachment.record_id)` で認可、`resize_to_limit: [800, 800]` の variant を `send_data ..., disposition: :inline` で返す。認可済みの個人向けレスポンスのため `expires_in 1.hour, public: false` を付与
- `config/routes.rb` に `resources :attachments, only: [ :show ]` を追加
- `shared/_images.html.erb` の `image_tag` を `attachment_path(image)` に差し替え
- 不要になった `ApplicationHelper#thumbnail_variant` を削除
- `spec/requests/attachments_spec.rb` を追加

---

## 確認済み

- [x] 非 admin が管理者限定タスクの画像を取得できない（404）
- [x] admin は管理者限定タスクの画像を取得できる（200）
- [x] 非 admin が Task / Notice / Interaction の画像を取得できる（200）
- [x] ホワイトリストにない record_type の添付は取得できない（404）
- [x] デモユーザーが本番レコードの画像を取得できない（404）
- [x] レスポンスに `Cache-Control: private, max-age=3600` が付く
- [x] `grep -rn "rails_blob\|rails_representation" app/views/` が空
- [x] `bundle exec rspec` 614 examples, 0 failures
- [x] `bundle exec rubocop` no offenses

---

Closes #192 