### PR TITLE
Unify the readable scope contract across models

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -24,6 +24,7 @@ class CustomersController < ApplicationController
   end
 
   def show
+    # Interaction は公開範囲を持たず demo 境界だけなので、readable な親から辿る限り境界は保たれる。
     @interactions = @customer.interactions.order(occurred_at: :desc)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    # Interaction は公開範囲を持たず demo 境界だけなので、readable な親から辿る限り境界は保たれる。
     @interactions = @user.interactions.order(occurred_at: :desc)
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,7 +4,15 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :commentable, polymorphic: true
 
-  scope :readable, -> { demo(Current.demo?) }
+  # 閲覧スコープを持たないのは書き忘れではない。
+  # 閲覧スコープは「id で直接引く経路を持つモデル」だけが持つ約束にしている。
+  # Comment を id で引く経路は存在せず（comments#create が引くのは commentable の方）、
+  # 取得は常に親の閲覧スコープを通した commentable.comments 経由になるため、
+  # 閲覧境界（demo 境界と公開範囲）は親が保証する。
+  #
+  # commentable は polymorphic のため、TaskAssignment のように joins + merge で
+  # 親の境界を合成することもできない。demo 境界だけのスコープを置くと、
+  # 名前が保証しない範囲まで保証しているように読まれる。
 
   validates :content, presence: true, length: { maximum: 200 }
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -20,8 +20,6 @@ class Customer < ApplicationRecord
     Current.user.present?
   end
 
-  private
-
   # auth_object は「どの一覧画面から検索しているか」を表す。
   # 他モデルの関連を辿った検索では渡らないため、メールアドレス等は開放されない。
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -44,17 +44,17 @@ class Interaction < ApplicationRecord
     user == Current.user
   end
 
-  private
-
-  def set_customer_from_parent
-    self.customer ||= parent&.customer
-  end
-
   def self.ransackable_attributes(auth_object = nil)
     %w[channel completed occurred_at]
   end
 
   def self.ransackable_associations(auth_object = nil)
     %w[customer user]
+  end
+
+  private
+
+  def set_customer_from_parent
+    self.customer ||= parent&.customer
   end
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -40,8 +40,6 @@ class Notice < ApplicationRecord
     user == Current.user
   end
 
-  private
-
   scope :status, ->(value) {
     now = Time.current
     case value

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -34,8 +34,6 @@ class Task < ApplicationRecord
     user == Current.user
   end
 
-  private
-
   scope :due_within, ->(period) {
     from = Time.current.beginning_of_day
     case period

--- a/app/models/task_assignment.rb
+++ b/app/models/task_assignment.rb
@@ -21,6 +21,14 @@ class TaskAssignment < ApplicationRecord
     user == Current.user
   end
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w[status user_id]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[user]
+  end
+
   private
 
   # 管理者限定タスクは admin しか閲覧できないため、
@@ -29,13 +37,5 @@ class TaskAssignment < ApplicationRecord
     return if user.blank? || user.admin?
 
     errors.add(:user, "は管理者限定タスクの担当者にできません")
-  end
-
-  def self.ransackable_attributes(auth_object = nil)
-    %w[status user_id]
-  end
-
-  def self.ransackable_associations(auth_object = nil)
-    %w[user]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,17 @@ class User < ApplicationRecord
     Current.user&.admin?
   end
 
+  # auth_object は「どの一覧画面から検索しているか」を表す。
+  # 他モデルの関連を辿った検索では渡らないため、メールアドレス等は開放されない。
+  def self.ransackable_attributes(auth_object = nil)
+    base = %w[name]
+    auth_object == :user_list ? base + %w[email_address admin] : base
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
   private
 
   # 権限は新規登録時にのみ選択できる。降格・昇格の両方を止める。
@@ -40,16 +51,5 @@ class User < ApplicationRecord
     return unless admin_changed?
 
     errors.add(:admin, "は登録後に変更できません")
-  end
-
-  # auth_object は「どの一覧画面から検索しているか」を表す。
-  # 他モデルの関連を辿った検索では渡らないため、メールアドレス等は開放されない。
-  def self.ransackable_attributes(auth_object = nil)
-    base = %w[name]
-    auth_object == :user_list ? base + %w[email_address admin] : base
-  end
-
-  def self.ransackable_associations(auth_object = nil)
-    []
   end
 end

--- a/app/views/notices/_related_interactions.html.erb
+++ b/app/views/notices/_related_interactions.html.erb
@@ -1,6 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連応対履歴</h2>
 
+  <%# Interaction は公開範囲を持たず demo 境界だけなので、readable な親から辿る限り境界は保たれる %>
   <% interactions = notice.interactions %>
 
   <% if interactions.any? %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="border-t border-gray-200 bg-white">
   <div class="max-w-7xl mx-auto px-4 py-6 text-center text-xs text-gray-400">
-    &copy; <%= Date.current.year %> 店舗業務管理システム
+    &copy; <%= Date.current.year %> Sync
   </div>
 </footer>

--- a/app/views/tasks/_related_interactions.html.erb
+++ b/app/views/tasks/_related_interactions.html.erb
@@ -1,6 +1,7 @@
 <div class="mb-6 border-t-4 border-gray-300 pt-6 text-xs sm:text-sm">
   <h2 class="text-base sm:text-lg font-semibold mb-3">関連応対履歴</h2>
 
+  <%# Interaction は公開範囲を持たず demo 境界だけなので、readable な親から辿る限り境界は保たれる %>
   <% interactions = task.interactions %>
 
   <% if interactions.any? %>


### PR DESCRIPTION
## 概要

readable スコープを「id で直接引く経路を持つモデルだけが持つ」規約に統一し、実際には効いていなかった private の位置を実態に合わせた。あわせてフッターのサービス名を Sync に変更した。

---

## 変更内容
- `app/models/comment.rb`: 呼び出し箇所の無い `scope :readable` を削除し、閲覧スコープを持たない理由（id で引く経路が無く、取得は常に親経由になること、commentable が polymorphic で親の境界を merge 合成できないこと）をコメントとして追加
- `app/models/task.rb` / `app/models/notice.rb` / `app/models/customer.rb`: private 配下に private インスタンスメソッドが無いため `private` を削除
- `app/models/user.rb` / `app/models/interaction.rb` / `app/models/task_assignment.rb`: `def self.ransackable_attributes` および `def self.ransackable_associations` を `private` の上へ移動。private 配下には `admin_must_not_change` / `set_customer_from_parent` / `assignee_must_be_admin` のみが残る
- `app/views/shared/_footer.html.erb`: 著作権表記のサービス名を Sync に変更

---

## 確認済
- [x] `bundle exec rspec` が 614 examples, 0 failures
- [x] `bundle exec rubocop` が offense なし
- [x] app/models 配下の private の下に scope および def self. が残っていない

---

Closes #194 