### PR TITLE
Set up production deployment with Kamal on Lightsail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy
+
+# CI (RSpec / RuboCop / Brakeman / bundler-audit) が main で成功したときだけ動かす。
+# テストが落ちた変更が本番に出ないようにするため、push トリガーではなく
+# workflow_run で CI の完了を待っている。
+on:
+  workflow_run:
+    workflows: [ "CI" ]
+    types: [ completed ]
+    branches: [ main ]
+  workflow_dispatch:
+
+# デプロイ同士が並走して kamal のロックが競合しないようにする。
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    # 手動実行 (workflow_dispatch) のときは workflow_run のコンテキストが無いので
+    # conclusion のチェックをスキップする。
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # workflow_run はデフォルトブランチの HEAD を見てしまうため、
+          # CI が実際に検証したコミットを明示的に取得する。
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      # Lightsail は x86_64 のため amd64 でビルドする。
+      # GitHub Actions の runner は amd64 ネイティブなので、
+      # Apple Silicon のローカルビルド (QEMU 経由で 20〜40 分) を回避できる。
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # config/deploy.yml の builder.cache.type: gha を使うために、
+      # Actions のキャッシュ用トークンを docker buildx へ公開する。
+      - name: Expose GitHub Actions runtime for buildx cache
+        uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf 'Host *\n  StrictHostKeyChecking accept-new\n' > ~/.ssh/config
+
+      - name: Deploy with Kamal
+        env:
+          KAMAL_REGISTRY_PASSWORD: ${{ secrets.KAMAL_REGISTRY_PASSWORD }}
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+        run: bundle exec kamal deploy
+
+      # デプロイに失敗した場合、kamal のロックが残って次回以降が実行できなくなるため解放する。
+      - name: Release Kamal lock on failure
+        if: failure()
+        env:
+          KAMAL_REGISTRY_PASSWORD: ${{ secrets.KAMAL_REGISTRY_PASSWORD }}
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+        run: bundle exec kamal lock release || true

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -2,19 +2,7 @@
 # and accessories/*/env/secret in config/deploy.yml. All secrets should be pulled from either
 # password manager, ENV, or a file. DO NOT ENTER RAW CREDENTIALS HERE! This file needs to be safe for git.
 
-# Example of extracting secrets from 1password (or another compatible pw manager)
-# SECRETS=$(kamal secrets fetch --adapter 1password --account your-account --from Vault/Item KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
-# KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
-# RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
-
-# Example of extracting secrets from Rails credentials
-# KAMAL_REGISTRY_PASSWORD=$(rails credentials:fetch kamal.registry_password)
-
-# Use a GITHUB_TOKEN if private repositories are needed for the image
-# GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
-
-# Grab the registry password from ENV
-# KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
-
-# Improve security by using a password manager. Never check config/master.key into git!
-RAILS_MASTER_KEY=$(cat config/master.key)
+RAILS_MASTER_KEY=$(cat config/master.key 2>/dev/null || echo $RAILS_MASTER_KEY)
+KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+DATABASE_URL=postgres://wfm_single:${POSTGRES_PASSWORD}@wfm-single-db:5432/wfm_single_production

--- a/README.md
+++ b/README.md
@@ -1,11 +1,247 @@
 # wfm-single
-- 業務改善アプリ　
-- 業務に関する情報を集約し、「業務版WWW」を目指す
 
-## 概要
-- 顧客応対・作業依頼・全体周知といった業務イベントを起点に情報を集約・管理
+店舗・小規模チーム向けの業務情報集約アプリ。
+顧客応対・タスク・全体周知という 3 種類の業務イベントを、相互に関連付けたまま管理する。
 
-## 設計方針
-- 情報の性質ごとにテーブルを分離
-- 業務イベント間の関係性を保ったまま、関連情報を参照可能とする
-- シンプルで拡張可能な構成を優先
+**デモ環境: https://sync-wfm.com**
+トップページの「デモを試す」ボタンから、登録なしでログインできる。
+
+---
+
+## 何を解決するアプリか
+
+現場の情報は「顧客から電話が来た」「その対応で誰かに作業を頼んだ」「全員に周知した」という
+つながりを持っているのに、実際には応対メモ・タスク管理ツール・掲示板がそれぞれ分断されている。
+結果として「この作業依頼は何が発端だったのか」が後から辿れなくなる。
+
+このアプリは 3 つの業務イベントをテーブルとして分離しつつ、
+中間テーブルで相互に接続することで、**発端から結果までの流れを双方向に辿れる**ようにしている。
+
+```
+応対履歴 (Interaction) ──┬── タスク (Task)
+                          │        │
+                          └── お知らせ (Notice)
+```
+
+例えば「商品Xの不具合報告」という応対履歴から、そこで発行された「再発防止策の検討」タスクと
+「クレーム多発の注意喚起」お知らせの両方へ辿れる。逆にタスク側からも発端の応対履歴が見える。
+
+さらに応対履歴・タスク・お知らせはそれぞれ**自己参照の親子関係**を持てるため、
+「一次対応 → 二次対応」のような時系列の連なりも表現できる。
+
+---
+
+## 主な機能
+
+- **応対履歴 / タスク / お知らせ の CRUD** と、相互の関連付け
+- **顧客管理**と、顧客を軸にした応対履歴の集約
+- **認証**（Rails 8 標準の認証ジェネレータ + `has_secure_password`）とパスワードリセット
+- **権限制御** — 一般ユーザー / 管理者、レコード単位の「関係者限定」「管理者限定」
+- **検索・絞り込み**（Ransack）と**ページネーション**（Pagy）
+- **画像添付**（Active Storage + ruby-vips によるサムネイル生成）と、認可を通した配信
+- **コメント**によるレコード単位の議論
+- **デモモード** — `demo: true` のレコードだけが見える隔離された体験用データセット
+
+### デモモードの設計
+
+ポートフォリオとして誰でも触れる状態にする一方で、見学者の操作が
+本来のデータを壊さないようにする必要があった。
+
+そこで全モデルに `demo` フラグを持たせ、`DemoScoped` concern で
+「デモユーザーはデモデータだけ、通常ユーザーは通常データだけ」を見るように
+デフォルトの可視範囲を切り替えている。`bin/rails demo:reset` で
+デモデータだけを削除・再投入できるため、定期的に初期状態へ戻せる。
+
+この分離が実際に効いているかは `spec/requests/demo_isolation_spec.rb` で検証している。
+
+---
+
+## 技術構成
+
+| 領域 | 採用技術 |
+| --- | --- |
+| 言語 / フレームワーク | Ruby 4.0 / Rails 8.1 |
+| データベース | PostgreSQL 17 |
+| フロントエンド | Hotwire (Turbo / Stimulus)、Import Maps、Tailwind CSS 4 |
+| アセット | Propshaft |
+| 非同期処理 / キャッシュ | Solid Queue / Solid Cache / Solid Cable |
+| ファイル保存 | Active Storage + ruby-vips |
+| テスト | RSpec、FactoryBot、Capybara |
+| 静的解析 | RuboCop (rails-omakase)、Brakeman、bundler-audit |
+| CI / CD | GitHub Actions |
+| コンテナ / デプロイ | Docker、Kamal 2 |
+| インフラ | Amazon Lightsail、Cloudflare（ドメイン登録・DNS） |
+
+---
+
+## インフラ構成
+
+```mermaid
+flowchart LR
+    U[ユーザー] -->|HTTPS| CF[Cloudflare<br/>ドメイン + DNS]
+    CF --> KP
+
+    subgraph LS["Lightsail (Ubuntu 24.04)"]
+        KP[kamal-proxy] --> APP[Rails 8.1 + Thruster]
+        APP --> DB[(PostgreSQL 17)]
+    end
+
+    GH[GitHub Actions] -->|build & push| GHCR[(GHCR)]
+    GHCR -->|kamal deploy| LS
+```
+
+`main` への push で CI が成功すると、GitHub Actions が amd64 イメージをビルドして GHCR に push し、
+Kamal がゼロダウンタイムでコンテナを差し替える。構築手順の全文は [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)。
+
+---
+
+## DB構造
+
+```mermaid
+erDiagram
+    USERS {
+        string name
+        string email_address
+        boolean admin
+    }
+    CUSTOMERS {
+        string name
+        string email
+        string phone
+    }
+    INTERACTIONS {
+        string channel
+        text request_content
+        text response_result
+        boolean completed
+        bigint parent_id
+        bigint root_id
+    }
+    TASKS {
+        string title
+        text description
+        datetime due_at
+        boolean restricted
+        bigint parent_id
+        bigint root_id
+    }
+    NOTICES {
+        string title
+        text content
+        string level
+        boolean restricted
+        bigint parent_id
+        bigint root_id
+    }
+    TASK_ASSIGNMENTS {
+        string status
+    }
+    COMMENTS {
+        text content
+        string commentable_type
+    }
+
+    USERS ||--o{ INTERACTIONS : creates
+    USERS ||--o{ TASKS : creates
+    USERS ||--o{ NOTICES : creates
+    USERS ||--o{ COMMENTS : writes
+    USERS ||--o{ TASK_ASSIGNMENTS : assigned
+    CUSTOMERS ||--o{ INTERACTIONS : has
+
+    INTERACTIONS }o--o{ TASKS : interaction_tasks
+    INTERACTIONS }o--o{ NOTICES : interaction_notices
+    NOTICES }o--o{ TASKS : notice_tasks
+
+    TASKS ||--o{ TASK_ASSIGNMENTS : has
+    INTERACTIONS ||--o{ COMMENTS : "commentable"
+    TASKS ||--o{ COMMENTS : "commentable"
+    NOTICES ||--o{ COMMENTS : "commentable"
+
+    INTERACTIONS ||--o{ INTERACTIONS : "parent / root"
+    TASKS ||--o{ TASKS : "parent / root"
+    NOTICES ||--o{ NOTICES : "parent / root"
+```
+
+`interaction_tasks` / `interaction_notices` / `notice_tasks` は中間テーブルで、
+3つの業務イベントを相互に関連付けている。`comments` は `commentable_type` による
+ポリモーフィック関連で、3つのイベントどれにでも紐付く。
+
+---
+
+## ローカル環境の構築
+
+### 必要なもの
+
+- Ruby 4.0.1（`.ruby-version` 参照）
+- PostgreSQL 17
+- libvips（画像処理）
+
+```bash
+# macOS の場合
+brew install postgresql@17 vips
+```
+
+### セットアップ
+
+```bash
+git clone https://github.com/minamoto64/wfm-single.git
+cd wfm-single
+
+bundle install
+bin/rails db:prepare
+bin/rails db:seed        # 通常データ
+bin/rails demo:reset     # デモデータ
+
+bin/dev                  # http://localhost:3000
+```
+
+初期ユーザーのパスワードは開発環境では `password`。
+本番では `SEED_ADMIN_PASSWORD` などの環境変数が必須になる（`db/seeds.rb` 参照）。
+
+### テストと静的解析
+
+```bash
+bundle exec rspec        # 48 ファイルのテスト
+bin/rubocop              # スタイル
+bin/brakeman --no-pager  # セキュリティ静的解析
+bin/bundler-audit        # 依存 gem の脆弱性
+```
+
+---
+
+## 設計上の工夫
+
+### 可視範囲を concern に切り出す
+
+「誰がどのレコードを見られるか」の判定は、コントローラに散らばると
+抜け漏れが起きやすい。以下の 3 つの concern に責務を分けている。
+
+- `DemoScoped` — デモデータと通常データの隔離
+- `Restrictable` — 「関係者限定」「管理者限定」の可視性
+- `Rootable` — 自己参照の親子関係における root の解決
+
+これらを合成した `readable` スコープを各モデルに持たせ、
+コントローラは `Model.readable` から引くだけにしている。
+権限まわりのリクエストスペック（`restricted_visibility_spec.rb` 等）で
+境界が守られていることを検証している。
+
+### 画像を認可経由で配信する
+
+Active Storage の署名付き URL は、URL を知っていれば誰でも取得できてしまう。
+「関係者限定」のレコードに添付された画像がそれでは漏れるため、
+`AttachmentsController` を挟んで、レコードの可視性判定を通過した場合のみ
+配信するようにしている。
+
+### フォームオブジェクト
+
+タスクの登録は「タスク本体 + 担当者の割り当て + 関連レコードの紐付け」を
+1 つの画面で扱うため、`TaskForm` にまとめてコントローラを薄く保っている。
+
+---
+
+## 今後の課題
+
+- デモデータの定期リセットを Solid Queue の recurring job で自動化する
+- Active Storage の保存先を S3 に移し、ディスク使用量をインスタンスから切り離す
+- インフラを Terraform で定義する
+- N+1 の継続監視（開発環境では Bullet を導入済み）

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,119 +1,67 @@
-# Name of your application. Used to uniquely configure containers.
-service: wfm_single
+service: wfm-single
+image: minamoto64/wfm-single
 
-# Name of the container image (use your-user/app-name on external registries).
-image: wfm_single
-
-# Deploy to these servers.
 servers:
   web:
-    - 192.168.0.1
-  # job:
-  #   hosts:
-  #     - 192.168.0.1
-  #   cmd: bin/jobs
+    - 54.178.174.111
 
-# Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
-# If used with Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
-#
-# Using an SSL proxy like this requires turning on config.assume_ssl and config.force_ssl in production.rb!
-#
-# Don't use this when deploying to multiple web servers (then you have to terminate SSL at your load balancer).
-#
-# proxy:
-#   ssl: true
-#   host: app.example.com
+ssh:
+  user: ubuntu
 
-# Where you keep your container images.
+proxy:
+  ssl: true
+  host: sync-wfm.com
+  app_port: 80
+  healthcheck:
+    path: /up
+    interval: 3
+    timeout: 30
+
 registry:
-  # Alternatives: hub.docker.com / registry.digitalocean.com / ghcr.io / ...
-  server: localhost:5555
+  server: ghcr.io
+  username: minamoto64
+  password:
+    - KAMAL_REGISTRY_PASSWORD
 
-  # Needed for authenticated registries.
-  # username: your-user
-
-  # Always use an access token rather than real password when possible.
-  # password:
-  #   - KAMAL_REGISTRY_PASSWORD
-
-# Inject ENV variables into containers (secrets come from .kamal/secrets).
 env:
   secret:
     - RAILS_MASTER_KEY
+    - DATABASE_URL
   clear:
-    # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
-    # When you start using multiple servers, you should split out job processing to a dedicated machine.
     SOLID_QUEUE_IN_PUMA: true
+    JOB_CONCURRENCY: 1
+    RAILS_MAX_THREADS: 5
+    RAILS_LOG_LEVEL: info
+    APP_HOST: sync-wfm.com
 
-    # Set number of processes dedicated to Solid Queue (default: 1)
-    # JOB_CONCURRENCY: 3
+accessories:
+  db:
+    image: postgres:17
+    host: 54.178.174.111
+    port: "127.0.0.1:5432:5432"
+    env:
+      clear:
+        POSTGRES_USER: wfm_single
+        POSTGRES_DB: wfm_single_production
+      secret:
+        - POSTGRES_PASSWORD
+    directories:
+      - data:/var/lib/postgresql/data
 
-    # Set number of cores available to the application on each server (default: 1).
-    # WEB_CONCURRENCY: 2
+volumes:
+  - "wfm_single_storage:/rails/storage"
 
-    # Match this to any external database server to configure Active Record correctly
-    # Use wfm_single-db for a db accessory server on same machine via local kamal docker network.
-    # DB_HOST: 192.168.0.2
+asset_path: /rails/public/assets
 
-    # Log everything from Rails
-    # RAILS_LOG_LEVEL: debug
+builder:
+  arch: amd64
+  cache:
+    type: gha
 
-# Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
-# "bin/kamal logs -r job" will tail logs from the first server in the job section.
 aliases:
   console: app exec --interactive --reuse "bin/rails console"
   shell: app exec --interactive --reuse "bash"
   logs: app logs -f
   dbc: app exec --interactive --reuse "bin/rails dbconsole --include-password"
-
-# Use a persistent storage volume for sqlite database files and local Active Storage files.
-# Recommended to change this to a mounted volume path that is backed up off server.
-volumes:
-  - "wfm_single_storage:/rails/storage"
-
-# Bridge fingerprinted assets, like JS and CSS, between versions to avoid
-# hitting 404 on in-flight requests. Combines all files from new and old
-# version inside the asset_path.
-asset_path: /rails/public/assets
-
-# Configure the image builder.
-builder:
-  arch: amd64
-
-  # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
-  # remote: ssh://docker@docker-builder-server
-  #
-  # # Pass arguments and secrets to the Docker build process
-  # args:
-  #   RUBY_VERSION: 4.0.1
-  # secrets:
-  #   - GITHUB_TOKEN
-  #   - RAILS_MASTER_KEY
-
-# Use a different ssh user than root
-# ssh:
-#   user: app
-
-# Use accessory services (secrets come from .kamal/secrets).
-# accessories:
-#   db:
-#     image: mysql:8.0
-#     host: 192.168.0.2
-#     # Change to 3306 to expose port to the world instead of just local network.
-#     port: "127.0.0.1:3306:3306"
-#     env:
-#       clear:
-#         MYSQL_ROOT_HOST: '%'
-#       secret:
-#         - MYSQL_ROOT_PASSWORD
-#     files:
-#       - config/mysql/production.cnf:/etc/mysql/my.cnf
-#       - db/production.sql:/docker-entrypoint-initdb.d/setup.sql
-#     directories:
-#       - data:/var/lib/mysql
-#   redis:
-#     image: valkey/valkey:8
-#     host: 192.168.0.2
-#     port: 6379
-#     directories:
-#       - data:/data
+  demo-reset: app exec "bin/rails demo:reset"
+  db-dump: accessory exec db "pg_dump -U wfm_single -d wfm_single_production" --reuse

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,14 +24,16 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  # kamal-proxy が TLS を終端し、アプリコンテナへは平文 HTTP で転送される。
+  # これを付けないと Rails がリクエストを HTTP と誤認し、force_ssl と組み合わせて
+  # リダイレクトループになる。
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # kamal-proxy のヘルスチェックは HTTP で /up を叩くため、ここだけリダイレクトから除外する。
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
@@ -58,7 +60,11 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  # APP_HOST は config/deploy.yml の env.clear で注入している。
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST", "localhost"),
+    protocol: "https"
+  }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,127 @@
+# デプロイ手順
+
+Amazon Lightsail 1台に Kamal 2 で本番環境を構築する手順。
+
+```
+Cloudflare (ドメイン + DNS) ──► Lightsail 静的IP
+                                     │
+                        ┌────────────┴────────────┐
+                        │ Lightsail (Ubuntu 24.04)│
+                        │  kamal-proxy  :80/:443  │
+                        │  wfm-single   Rails 8.1 │
+                        │  wfm-single-db Postgres │
+                        └─────────────────────────┘
+```
+
+ビルドは GitHub Actions（amd64）で行い GHCR に push、Kamal がデプロイする。
+
+費用: Lightsail $12/月バンドル（3ヶ月無料）、ドメイン年$9〜10。
+
+Route 53 は無料プランアカウントだとドメイン新規登録ができないため、
+ドメイン登録・DNS は Cloudflare を使っている。
+
+## 1. Lightsail インスタンス作成
+
+Ubuntu 24.04 / $12バンドル（2GB RAM）で作成。起動スクリプトに以下を貼る。
+
+```bash
+#!/bin/bash
+set -eux
+apt-get update -y
+apt-get install -y docker.io curl
+systemctl enable --now docker
+usermod -aG docker ubuntu
+
+fallocate -l 2G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile none swap sw 0 0' >> /etc/fstab
+```
+
+## 2. 静的IPとファイアウォール
+
+静的IPを作成してアタッチ。ファイアウォールで SSH(22) / HTTP(80) / HTTPS(443) を開放。
+80番は Let's Encrypt の証明書取得に必須。
+
+## 3. ドメイン設定（Cloudflare）
+
+Cloudflareでドメインを取得し、DNSにAレコードを追加。
+
+| Type | Name | Content | Proxy status |
+| --- | --- | --- | --- |
+| A | `@` | Lightsailの静的IP | DNS only |
+| A | `www` | Lightsailの静的IP | DNS only |
+
+Proxy statusは必ずDNS only（グレー）にする。オレンジのままだとLet's Encryptの証明書取得が失敗する。
+
+反映確認:
+
+```bash
+dig +short example.com
+```
+
+## 4. SSH鍵の準備
+
+サーバー用に鍵を作り、公開鍵をサーバーの `~/.ssh/authorized_keys` に追加する。
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/wfm_single_deploy -N ""
+```
+
+## 5. GHCRトークンを作る
+
+GitHub → Settings → Developer settings → Personal access tokens (classic) →
+`write:packages` / `read:packages` スコープで発行。
+
+## 6. config/deploy.yml を書き換える
+
+`servers.web` / `accessories.db.host` にLightsailの静的IP、`proxy.host` / `env.clear.APP_HOST` にドメインを設定。
+
+## 7. GitHub Secretsを登録
+
+| 名前 | 値 |
+| --- | --- |
+| `SSH_PRIVATE_KEY` | 手順4の秘密鍵 |
+| `RAILS_MASTER_KEY` | `config/master.key` の中身 |
+| `KAMAL_REGISTRY_PASSWORD` | 手順5のPAT |
+| `POSTGRES_PASSWORD` | `openssl rand -hex 24` で生成 |
+
+## 8. サーバー初期化（ローカルから1回）
+
+```bash
+export KAMAL_REGISTRY_PASSWORD=<手順5のPAT>
+export POSTGRES_PASSWORD=<手順7と同じ値>
+
+bundle exec kamal server bootstrap
+bundle exec kamal accessory boot db
+```
+
+## 9. 初回デプロイ
+
+mainへのpushでCI成功後、GitHub Actionsが自動でビルド・デプロイする。
+
+```bash
+bundle exec kamal demo-reset
+```
+
+デモデータを投入する。
+
+## 動作確認
+
+```bash
+curl -I https://example.com/up   # → 200
+curl -I http://example.com       # → 301
+```
+
+## 運用コマンド
+
+```bash
+bundle exec kamal logs -f          # ログ
+bundle exec kamal console          # rails console
+bundle exec kamal demo-reset       # デモデータ初期化
+bundle exec kamal db-dump > backup.sql  # 論理バックアップ
+bundle exec kamal lock release     # デプロイロック解除
+```
+
+RDSを使っていないため自動バックアップは無い。`kamal db-dump` で手動バックアップする。


### PR DESCRIPTION
## 概要

Amazon Lightsail の 1 台構成へデプロイするための設定一式を追加する。
kamal-proxy が TLS を終端し、Rails と PostgreSQL を同一ホスト上のコンテナとして稼働させる。
CI が成功したときのみ GitHub Actions からデプロイが走る。

---

## 変更内容

- **本番設定** — `assume_ssl` と `force_ssl` を有効化し、`/up` をリダイレクト対象から除外。メーラーの URL を `APP_HOST` から生成するよう変更
- **Kamal 設定** — デプロイ先を Lightsail の静的 IP に、レジストリを GHCR に設定。`proxy.ssl` と `/up` のヘルスチェック、PostgreSQL 17 のアクセサリ（`127.0.0.1` のみ待ち受け・データを永続化）、`demo-reset` と `db-dump` のエイリアスを追加
- **シークレット** — `.kamal/secrets` を実際に使う `RAILS_MASTER_KEY` / `KAMAL_REGISTRY_PASSWORD` / `POSTGRES_PASSWORD` / `DATABASE_URL` の定義に置き換え
- **CD** — CI ワークフローの成功を条件に、amd64 イメージをビルドして GHCR へ push し Kamal でデプロイするワークフローを追加
- **ドキュメント** — 構築手順を `docs/DEPLOYMENT.md` に追加し、README をデモ環境・機能・技術構成・インフラ構成・設計上の工夫を含む内容に刷新

---

## 確認済

- [x] HTTPS でデモ環境にアクセスできる
- [x] `/up` のヘルスチェックが HTTP のままリダイレクトされずに応答する
- [x] CI 成功時のみデプロイワークフローが起動する

---

Closes #196 